### PR TITLE
Fix unit tests

### DIFF
--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -328,7 +328,11 @@ where
     }
 
     pub fn mem(&self, state_hash: &BlockHash) -> bool {
-        for node in self.branches.traverse_level_order(&self.branches.root_node_id().unwrap()).unwrap() {
+        for node in self
+            .branches
+            .traverse_level_order(self.branches.root_node_id().unwrap())
+            .unwrap()
+        {
             if &node.data().block.state_hash == state_hash {
                 return true;
             }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -316,7 +316,7 @@ where
     pub fn len(&self) -> usize {
         let mut size = 0;
         if let Some(root) = self.branches.root_node_id() {
-            for _ in &self.branches.children_ids(root) {
+            for _ in self.branches.traverse_level_order_ids(root).unwrap() {
                 size += 1;
             }
         }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -62,6 +62,7 @@ impl Branch<Ledger> {
             leaves,
         }
     }
+
     // only the genesis block should work here
     pub fn new_rooted(root_precomputed: &PrecomputedBlock) -> Self {
         let new_ledger = Ledger::from_diff(LedgerDiff::from_precomputed_block(root_precomputed));
@@ -310,6 +311,20 @@ where
         }
 
         longest_chain
+    }
+
+    pub fn len(&self) -> usize {
+        let mut size = 0;
+        if let Some(root) = self.branches.root_node_id() {
+            for _ in &self.branches.children_ids(root) {
+                size += 1;
+            }
+        }
+        size
+    }
+
+    pub fn height(&self) -> usize {
+        self.branches.height()
     }
 }
 

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -326,6 +326,15 @@ where
     pub fn height(&self) -> usize {
         self.branches.height()
     }
+
+    pub fn mem(&self, state_hash: &BlockHash) -> bool {
+        for node in self.branches.traverse_level_order(&self.branches.root_node_id().unwrap()).unwrap() {
+            if &node.data().block.state_hash == state_hash {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 impl<T> Leaf<T> {

--- a/src/state/ledger/diff/account.rs
+++ b/src/state/ledger/diff/account.rs
@@ -71,8 +71,8 @@ impl AccountDiff {
 
     pub fn public_key(&self) -> PublicKey {
         match self {
-            AccountDiff::Payment(payment_diff) => payment_diff.public_key.clone().into(),
-            AccountDiff::Delegation(delegation_diff) => delegation_diff.delegator.clone().into(),
+            AccountDiff::Payment(payment_diff) => payment_diff.public_key.clone(),
+            AccountDiff::Delegation(delegation_diff) => delegation_diff.delegator.clone(),
         }
     }
 

--- a/src/state/ledger/diff/account.rs
+++ b/src/state/ledger/diff/account.rs
@@ -69,7 +69,7 @@ impl AccountDiff {
         })
     }
 
-    pub fn public_key(&self) -> PublicKeyV1 {
+    pub fn public_key(&self) -> PublicKey {
         match self {
             AccountDiff::Payment(payment_diff) => payment_diff.public_key.clone().into(),
             AccountDiff::Delegation(delegation_diff) => delegation_diff.delegator.clone().into(),

--- a/src/state/ledger/diff/mod.rs
+++ b/src/state/ledger/diff/mod.rs
@@ -62,7 +62,11 @@ impl std::fmt::Debug for LedgerDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "=== LedgerDiff ===")?;
         let mut account_diffs = self.account_diffs.clone();
-        account_diffs.sort_by(|x, y| x.public_key().to_address().cmp(&y.public_key().to_address()));
+        account_diffs.sort_by(|x, y| {
+            x.public_key()
+                .to_address()
+                .cmp(&y.public_key().to_address())
+        });
         for account_diff in account_diffs.iter() {
             writeln!(f, "{account_diff:?}")?;
         }

--- a/src/state/ledger/diff/mod.rs
+++ b/src/state/ledger/diff/mod.rs
@@ -61,7 +61,9 @@ impl LedgerDiff {
 impl std::fmt::Debug for LedgerDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "=== LedgerDiff ===")?;
-        for account_diff in self.account_diffs.iter() {
+        let mut account_diffs = self.account_diffs.clone();
+        account_diffs.sort_by(|x, y| x.public_key().to_address().cmp(&y.public_key().to_address()));
+        for account_diff in account_diffs.iter() {
             writeln!(f, "{account_diff:?}")?;
         }
         Ok(())

--- a/src/state/ledger/mod.rs
+++ b/src/state/ledger/mod.rs
@@ -87,7 +87,7 @@ impl Ledger {
 
         let mut success = Ok(());
         diff.account_diffs.into_iter().for_each(|diff| {
-            if let Some(account_before) = self.accounts.remove(&diff.public_key().into()) {
+            if let Some(account_before) = self.accounts.remove(&diff.public_key()) {
                 let account_after = match &diff {
                     diff::account::AccountDiff::Payment(payment_diff) => {
                         match &payment_diff.update_type {
@@ -108,8 +108,7 @@ impl Ledger {
                     // TODO got this in another branch
                     diff::account::AccountDiff::Delegation(_) => todo!(),
                 };
-                self.accounts
-                    .insert(diff.public_key().into(), account_after);
+                self.accounts.insert(diff.public_key(), account_after);
             } else {
                 success = Err(anyhow::Error::new(Error::default()));
             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -53,13 +53,33 @@ impl IndexerState {
         })
     }
 
+    /// Adds the block to the witness tree and the precomputed block to the db
+    /// 
+    /// Errors if the block is already present in the witness tree
     pub fn add_block(
         &mut self,
         precomputed_block: &PrecomputedBlock,
     ) -> anyhow::Result<ExtensionType> {
+        // add precomputed block to the db
         self.block_store
             .as_mut()
             .map(|block_store| block_store.add_block(precomputed_block));
+
+        // check that the block doesn't already exist in the witness tree
+        {
+            let state_hash = &BlockHash(precomputed_block.state_hash.clone());
+            let err = Err(anyhow::Error::msg(format!("Block {:?} is already present in the witness tree", state_hash.0)));
+            if let Some(root_branch) = &self.root_branch {
+                if root_branch.mem(state_hash) {
+                    return err;
+                }
+            }
+            for dangling_branch in &self.dangling_branches {
+                if dangling_branch.mem(state_hash) {
+                    return err;
+                }
+            }
+        }
         // forward extension on root branch
         // TODO put heights of root and the highest leaf in Branch
         if let Some(root_branch) = self.root_branch.as_mut() {

--- a/tests/block/block_parser.rs
+++ b/tests/block/block_parser.rs
@@ -1,17 +1,39 @@
 use std::path::PathBuf;
 
 use mina_indexer::block::parser::BlockParser;
+use tokio::time::Instant;
 
 #[tokio::test]
-async fn parses_representative_sample() {
-    let sample_dir = PathBuf::from("./tests/data/beautified_logs");
-    let mut block_parser = BlockParser::new(&sample_dir).unwrap();
+async fn representative_bench() {
+    let start = Instant::now();
+    let sample_dir0 = PathBuf::from("./tests/data/beautified_logs");
+    let mut block_parser0 = BlockParser::new(&sample_dir0).unwrap();
     let mut logs_processed = 0;
-    while let Some(precomputed_block) = block_parser.next().await.expect("IO Error on block_parser")
+    while let Some(precomputed_block) = block_parser0
+        .next()
+        .await
+        .expect("IO Error on block_parser")
     {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }
-
     assert_eq!(logs_processed, 23);
+    println!("./tests/data/beautified_logs");
+    println!("Parse {logs_processed} logs: {:?}\n", start.elapsed());
+
+    let start = Instant::now();
+    logs_processed = 0;
+    let sample_dir1 = PathBuf::from("./tests/data/beautified_sequential_blocks");
+    let mut block_parser1 = BlockParser::new(&sample_dir1).unwrap();
+    while let Some(precomputed_block) = block_parser1
+        .next()
+        .await
+        .expect("IO Error on block_parser")
+    {
+        logs_processed += 1;
+        dbg!(precomputed_block.state_hash);
+    }
+    assert_eq!(logs_processed, 24);
+    println!("./tests/data/beautified_sequential_blocks");
+    println!("Parse {logs_processed} logs: {:?}\n", start.elapsed());
 }

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -16,7 +16,8 @@ async fn extension() {
 
     let mut n = 0;
     if let Some(precomputed_block) = block_parser.next().await.unwrap() {
-        let mut state = IndexerState::new(BlockHash(precomputed_block.state_hash), None, None).unwrap();
+        let mut state =
+            IndexerState::new(BlockHash(precomputed_block.state_hash), None, None).unwrap();
         n += 1;
         while let Some(precomputed_block) = block_parser.next().await.unwrap() {
             state.add_block(&precomputed_block).unwrap();
@@ -83,7 +84,8 @@ async fn extension() {
             {
                 let node = dangling_branch.branches.get(&node_id).unwrap();
                 for child_id in node.children() {
-                    let parent_block = &dangling_branch.branches.get(&node_id).unwrap().data().block;
+                    let parent_block =
+                        &dangling_branch.branches.get(&node_id).unwrap().data().block;
                     let child_block = &dangling_branch.branches.get(child_id).unwrap().data().block;
                     assert_eq!(child_block.height, 1 + parent_block.height);
                     assert_eq!(

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -2,55 +2,87 @@ use std::path::PathBuf;
 
 use mina_indexer::{
     block::{parser::BlockParser, BlockHash},
-    state::IndexerState,
+    state::{ExtensionType, IndexerState},
 };
+use tokio::fs::remove_dir_all;
 
-/// Adds the same block
+/// Adds the same block twice, second time fails
 #[tokio::test]
 async fn test() {
+    let block_store_dir = PathBuf::from("./test_block_store");
     let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
     let mut block_parser = BlockParser::new(&log_dir).unwrap();
 
-    // block0 = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let block0 = block_parser
+    // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
+    let root_block = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
     assert_eq!(
-        block0.state_hash,
+        root_block.state_hash,
         "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
     );
 
-    // block1 = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let block1 = block0.clone();
-    let mut state = IndexerState::new(BlockHash(block0.state_hash), None, None).unwrap();
-
-    // println!("=== Root Branch ===");
-    let mut tree = String::new();
-    state
-        .root_branch
-        .clone()
-        .unwrap()
-        .branches
-        .write_formatted(&mut tree)
+    // block0 = mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
+    let block0 = block_parser
+        .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
+        .await
         .unwrap();
+    assert_eq!(
+        block0.state_hash,
+        "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
+    );
 
-    println!("Root:     {}", state.root_branch.clone().unwrap().len());
+    // block1 = mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
+    let block1 = block0.clone();
+    assert_eq!(
+        block1.state_hash,
+        "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
+    );
+
+    // initialize state
+    let mut state = IndexerState::new(
+        BlockHash(root_block.state_hash),
+        None,
+        Some(&block_store_dir),
+    )
+    .unwrap();
+
+    // add block for the first time
+    let extension_type = state.add_block(&block0).unwrap();
+    assert_eq!(extension_type, ExtensionType::DanglingNew);
+
+    println!("=== Before state ===");
+    println!("{state:?}");
+
+    println!("Root:     {}", state.root_branch.as_ref().unwrap().len());
     println!("Dangling: {}", state.dangling_branches.len());
 
+    // 1 block in the root branch
+    // 1 blovk in the 0th dangling branch
     assert_eq!(state.root_branch.clone().unwrap().len(), 1);
-    assert_eq!(state.dangling_branches.len(), 0);
+    assert_eq!(state.dangling_branches.len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().len(), 1);
 
     // throws err
-    match state.add_block(&block1) {
-        Ok(ext) => println!("Extension type: {ext:?}"),
-        Err(err) => println!("{err:?}"),
-    }
+    assert!(match state.add_block(&block1) {
+        Ok(ext) => {
+            println!("Extension type: {ext:?}");
+            false
+        }
+        Err(err) => {
+            println!("{err:?}");
+            true
+        }
+    });
 
-    // the block is not added to root or dangling
+    // the block is not added to the state
     println!("Root:     {}", state.root_branch.clone().unwrap().len());
     println!("Dangling: {}", state.dangling_branches.len());
 
     assert_eq!(state.root_branch.unwrap().len(), 1);
-    assert_eq!(state.dangling_branches.len(), 0);
+    assert_eq!(state.dangling_branches.len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().len(), 1);
+
+    remove_dir_all(block_store_dir).await.unwrap();
 }

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use mina_indexer::{block::{parser::BlockParser, BlockHash}, state::IndexerState};
+use mina_indexer::{
+    block::{parser::BlockParser, BlockHash},
+    state::IndexerState,
+};
 
 /// Adds the same block
 #[tokio::test]

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -72,7 +72,15 @@ async fn extensions() {
         .as_ref()
         .unwrap()
         .leaves
-        .get(state.root_branch.as_ref().unwrap().branches.root_node_id().unwrap())
+        .get(
+            state
+                .root_branch
+                .as_ref()
+                .unwrap()
+                .branches
+                .root_node_id()
+                .unwrap(),
+        )
         .unwrap()
         .clone();
 

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -8,10 +8,21 @@ use mina_indexer::{
 /// Creates multiple dangling branches
 #[tokio::test]
 async fn extensions() {
-    // ----- Dangling branches -----
-    //    Before   |    After
-    // -----------------------------
-    //      0      =>   0   1  (two separate branches)
+    // -----------------------
+    //       Root branch
+    // -----------------------
+    //   Before   |   After
+    // -----------+-----------
+    //      0     =>    0
+    // -----------------------
+
+    // -----------------------
+    //    Dangling branches
+    // ------- indicies ------
+    //      .     |     0
+    // -----------+-----------
+    //      .     =>    1
+    // -----------------------
 
     let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
     let mut block_parser = BlockParser::new(&log_dir).unwrap();
@@ -43,43 +54,33 @@ async fn extensions() {
     // root0_block will the be the root of the 0th dangling_branch
     let mut state = IndexerState::new(BlockHash(root0_block.state_hash), None, None).unwrap();
 
-    // 1 dangling branch
+    // Root branch
+    // - len = 1
+    // - leaf = 1
     // - height = 1
-    // - 1 leaf
-    assert_eq!(state.dangling_branches.len(), 1);
-    state
-        .dangling_branches
-        .iter()
-        .for_each(|tree| assert_eq!(tree.branches.height(), 1));
-    state
-        .dangling_branches
-        .iter()
-        .for_each(|tree| assert_eq!(tree.leaves.len(), 1));
+    assert_eq!(state.root_branch.clone().unwrap().len(), 1);
+    assert_eq!(state.root_branch.clone().unwrap().height(), 1);
+    assert_eq!(state.root_branch.clone().unwrap().leaves.len(), 1);
+
+    // no dangling branches
+    assert_eq!(state.dangling_branches.len(), 0);
 
     // before extension quantities
-    let root0 = state.dangling_branches.get(0).unwrap().root.clone();
+    let root0 = state.root_branch.clone().unwrap().root;
     let root_leaf0 = state
-        .dangling_branches
-        .get(0)
+        .root_branch
+        .as_ref()
         .unwrap()
         .leaves
-        .get(
-            state
-                .dangling_branches
-                .get(0)
-                .unwrap()
-                .branches
-                .root_node_id()
-                .unwrap(),
-        )
+        .get(state.root_branch.as_ref().unwrap().branches.root_node_id().unwrap())
         .unwrap()
-        .block
         .clone();
 
-    // root == leaf
-    assert_eq!(root0, root_leaf0);
     println!("=== Before Branch 0 ===");
-    println!("{:?}", state.dangling_branches.get(0).unwrap().branches);
+    println!("{:?}", state.root_branch.as_ref().unwrap().branches);
+
+    // root == leaf
+    assert_eq!(root0, root_leaf0.block);
 
     // ---------
     // add block
@@ -89,45 +90,46 @@ async fn extensions() {
     let extension_type = state.add_block(&root1_block).unwrap();
     assert_eq!(extension_type, ExtensionType::DanglingNew);
 
-    // 2 dangling branches
-    // - each height = 1
-    // - each has 1 leaf
-    assert_eq!(state.dangling_branches.len(), 2);
-    state
-        .dangling_branches
-        .iter()
-        .for_each(|tree| assert_eq!(tree.branches.height(), 1));
-    state
-        .dangling_branches
-        .iter()
-        .for_each(|tree| assert_eq!(tree.leaves.len(), 1));
+    // Root branch
+    // - len = 1
+    // - height = 1
+    // - leaves = 1
+    assert_eq!(state.root_branch.as_ref().unwrap().len(), 1);
+    assert_eq!(state.root_branch.as_ref().unwrap().height(), 1);
+    assert_eq!(state.root_branch.as_ref().unwrap().leaves.len(), 1);
+
+    // 1 dangling branch
+    // - len = 1
+    // - height = 1
+    // - leaves = 1
+    assert_eq!(state.dangling_branches.len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().height(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().leaves.len(), 1);
 
     // after extension quantities
-    let root1 = &state.dangling_branches.get(1).unwrap().root;
-    let branches1 = &state.dangling_branches.get(1).unwrap().branches;
+    let root1 = &state.root_branch.as_ref().unwrap().root;
+    let branches1 = &state.root_branch.as_ref().unwrap().branches;
     let branch_root1 = &branches1
         .get(&branches1.root_node_id().unwrap())
         .unwrap()
-        .data()
-        .block;
-    let root_leaf1 = &state
-        .dangling_branches
-        .get(1)
+        .data();
+    let root_leaf1 = state
+        .root_branch
+        .as_ref()
         .unwrap()
         .leaves
         .get(branches1.root_node_id().unwrap())
-        .unwrap()
-        .block
-        .clone();
+        .unwrap();
 
     // root == leaf
-    assert_eq!(root1, root_leaf1);
+    assert_eq!(root1, &root_leaf1.block);
 
-    println!("\n=== After Branch 0 ===");
-    println!("{:?}", &state.dangling_branches.get(0).unwrap());
-    println!("\n=== After Branch 1 ===");
-    println!("{:?}", &state.dangling_branches.get(1).unwrap());
+    println!("\n=== After Root Branch ===");
+    println!("{:?}", state.root_branch);
+    println!("\n=== After Dangling Branch 0 ===");
+    println!("{:?}", state.dangling_branches.get(0).unwrap());
 
     // branch root should match the tree's root
-    assert_eq!(root1, branch_root1);
+    assert_eq!(root1, &branch_root1.block);
 }

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -56,10 +56,7 @@ async fn extension() {
         .get_precomputed_block("3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk")
         .await
         .unwrap();
-    assert_eq!(
-        state.add_block(&child1).unwrap(),
-        ExtensionType::RootSimple
-    );
+    assert_eq!(state.add_block(&child1).unwrap(), ExtensionType::RootSimple);
     assert_eq!(
         child1.state_hash,
         "3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk".to_owned()
@@ -90,10 +87,7 @@ async fn extension() {
         .get_precomputed_block("3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN")
         .await
         .unwrap();
-    assert_eq!(
-        state.add_block(&child2).unwrap(),
-        ExtensionType::RootSimple
-    );
+    assert_eq!(state.add_block(&child2).unwrap(), ExtensionType::RootSimple);
     assert_eq!(
         child2.state_hash,
         "3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN".to_owned()
@@ -153,7 +147,13 @@ async fn extension() {
     assert_eq!(after_child2_block, leaves1.get(after_child2).unwrap().block);
 
     println!("=== After Root Branch Leaves ===");
-    println!("{:?}", leaves1.iter().map(|(_, leaf)| &leaf.block).collect::<Vec<&Block>>());
+    println!(
+        "{:?}",
+        leaves1
+            .iter()
+            .map(|(_, leaf)| &leaf.block)
+            .collect::<Vec<&Block>>()
+    );
 
     // root doesn't change
     assert_eq!(&before_root, after_root);

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -3,15 +3,19 @@ use std::path::PathBuf;
 use id_tree::NodeId;
 use mina_indexer::{
     block::{parser::BlockParser, Block, BlockHash},
-    state::{branch::Leaf, ledger::diff::LedgerDiff, ExtensionType, IndexerState},
+    state::{ExtensionType, IndexerState},
 };
 
 /// Extends a branch with a new leaf
 #[tokio::test]
 async fn extension() {
-    // 0      0
-    // | =>  / \
-    // 1    1   2
+    // --------------------------------
+    //           Root branch
+    // --------------------------------
+    //      =>  root  =>     root
+    // root =>   |    =>    /    \
+    //      => child0 => child0 child1
+    // --------------------------------
 
     let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
     let mut block_parser = BlockParser::new(&log_dir).unwrap();
@@ -32,11 +36,16 @@ async fn extension() {
 
     let mut state = IndexerState::new(BlockHash(root_block.state_hash), None, None).unwrap();
 
-    // blocks added to 0th dangling branch
-    assert_eq!(state.dangling_branches.len(), 1);
+    // root branch
+    // - len = 1
+    // - height = 1
+    // - leaves = 1
+    assert_eq!(state.root_branch.as_ref().unwrap().len(), 1);
+    assert_eq!(state.root_branch.as_ref().unwrap().height(), 1);
+    assert_eq!(state.root_branch.as_ref().unwrap().leaves.len(), 1);
 
-    // only one leaf
-    assert_eq!(state.dangling_branches.get(0).unwrap().leaves.len(), 1);
+    // no dangling branches
+    assert_eq!(state.dangling_branches.len(), 0);
 
     // -----------
     // add child 1
@@ -49,28 +58,28 @@ async fn extension() {
         .unwrap();
     assert_eq!(
         state.add_block(&child1).unwrap(),
-        ExtensionType::DanglingSimpleForward
+        ExtensionType::RootSimple
     );
     assert_eq!(
         child1.state_hash,
         "3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk".to_owned()
     );
 
-    println!(
-        "Before tree:\n{:?}",
-        state.dangling_branches.get(0).unwrap().branches
-    );
+    println!("=== Before Root Branch ===");
+    println!("{:?}", state.root_branch.as_ref().unwrap().branches);
 
-    let before_root = state.dangling_branches.get(0).unwrap().root.clone();
+    let before_root = state.root_branch.as_ref().unwrap().root.clone();
 
-    // blocks added to 0th dangling branch
-    assert_eq!(state.dangling_branches.len(), 1);
+    // root branch
+    // - len = 2
+    // - height = 2
+    // - leaves = 1
+    assert_eq!(state.root_branch.as_ref().unwrap().len(), 2);
+    assert_eq!(state.root_branch.as_ref().unwrap().height(), 2);
+    assert_eq!(state.root_branch.as_ref().unwrap().leaves.len(), 1);
 
-    // two blocks in the dangling branch
-    assert_eq!(state.dangling_branches.get(0).unwrap().branches.height(), 2);
-
-    // only one leaf
-    assert_eq!(state.dangling_branches.get(0).unwrap().leaves.len(), 1);
+    // no dangling branches
+    assert_eq!(state.dangling_branches.len(), 0);
 
     // -----------
     // add child 2
@@ -83,34 +92,36 @@ async fn extension() {
         .unwrap();
     assert_eq!(
         state.add_block(&child2).unwrap(),
-        ExtensionType::DanglingSimpleForward
+        ExtensionType::RootSimple
     );
     assert_eq!(
         child2.state_hash,
         "3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN".to_owned()
     );
 
-    // blocks are added to 0th dangling branch
-    assert_eq!(state.dangling_branches.len(), 1);
+    // root branch
+    // - len = 3
+    // - height = 2
+    // - leaves = 2
+    assert_eq!(state.root_branch.as_ref().unwrap().len(), 3);
+    assert_eq!(state.root_branch.as_ref().unwrap().height(), 2);
+    assert_eq!(state.root_branch.as_ref().unwrap().leaves.len(), 2);
 
-    // three blocks but height = 2
-    assert_eq!(state.dangling_branches.get(0).unwrap().branches.height(), 2);
-
-    // two leaves
-    assert_eq!(state.dangling_branches.get(0).unwrap().leaves.len(), 2);
+    // no dangling branches
+    assert_eq!(state.dangling_branches.len(), 0);
 
     // after extension quantities
-    let after_root = &state.dangling_branches.get(0).unwrap().root;
-    let branches1 = &state.dangling_branches.get(0).unwrap().branches;
-    let leaves1 = &state.dangling_branches.get(0).unwrap().leaves;
+    let after_root = &state.root_branch.as_ref().unwrap().root;
+    let branches1 = &state.root_branch.as_ref().unwrap().branches;
+    let leaves1 = &state.root_branch.as_ref().unwrap().leaves;
     let after_root_id = branches1.root_node_id().unwrap();
 
     // branch root should match the tree's root
     assert_eq!(
         after_root,
         &state
-            .dangling_branches
-            .get(0)
+            .root_branch
+            .as_ref()
             .unwrap()
             .branches
             .get(after_root_id)
@@ -119,10 +130,8 @@ async fn extension() {
             .block
     );
 
-    println!(
-        "After tree:\n{:?}",
-        state.dangling_branches.get(0).unwrap().branches
-    );
+    println!("=== After Root Branch ===");
+    println!("{:?}", state.root_branch.as_ref().unwrap().branches);
 
     // after root has one child
     let after_children = branches1
@@ -143,12 +152,10 @@ async fn extension() {
     // child2 is a leaf
     assert_eq!(after_child2_block, leaves1.get(after_child2).unwrap().block);
 
-    println!(
-        "After leaves: {:?}",
-        leaves1.values().collect::<Vec<&Leaf<LedgerDiff>>>()
-    );
+    println!("=== After Root Branch Leaves ===");
+    println!("{:?}", leaves1.iter().map(|(_, leaf)| &leaf.block).collect::<Vec<&Block>>());
 
-    // root shouldn't change
+    // root doesn't change
     assert_eq!(&before_root, after_root);
 
     // after root isn't a leaf

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -8,7 +8,7 @@ use mina_indexer::{
 /// Extends multiple dangling branches
 #[tokio::test]
 async fn extensions() {
-    // ----- Dangling branches -----
+    // ----- Dangling branches -----------------
     //     Before    |         After
     // ----------- indices ---------------------
     //   0      1    |    0            1
@@ -20,54 +20,64 @@ async fn extensions() {
     let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
     let mut block_parser = BlockParser::new(&log_dir).unwrap();
 
-    // root0_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root0_block = block_parser
+    // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
+    let root_block = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
     assert_eq!(
-        root0_block.state_hash,
+        root_block.state_hash,
         "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
     );
 
-    // child0_block = mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
+    // root0_block = mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
+    let root0_block = block_parser
+        .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
+        .await
+        .unwrap();
+    assert_eq!(
+        root0_block.state_hash,
+        "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
+    );
+
+    // child0_block = mainnet-105492-3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ.json
     let child0_block = block_parser
-        .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
+        .get_precomputed_block("3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ")
         .await
         .unwrap();
     assert_eq!(
         child0_block.state_hash,
-        "3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC".to_owned()
+        "3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ".to_owned()
     );
 
-    // root1_block = mainnet-105493-3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db.json
+    // root1_block = mainnet-105495-3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9.json
     let root1_block = block_parser
-        .get_precomputed_block("3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db")
+        .get_precomputed_block("3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9")
         .await
         .unwrap();
     assert_eq!(
         root1_block.state_hash,
-        "3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db".to_owned()
+        "3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9".to_owned()
     );
 
-    // child10_block = mainnet-105494-3NKXsaznJ6WdyA4PHfXxn25RzVanzQsNMZrxjidbhoBug8R4LZDy.json
+    // child10_block = mainnet-105496-3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL.json
     let child10_block = block_parser
-        .get_precomputed_block("3NKXsaznJ6WdyA4PHfXxn25RzVanzQsNMZrxjidbhoBug8R4LZDy")
+        .get_precomputed_block("3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL")
         .await
         .expect("WTF");
     assert_eq!(
         child10_block.state_hash,
-        "3NKXsaznJ6WdyA4PHfXxn25RzVanzQsNMZrxjidbhoBug8R4LZDy".to_owned()
+        "3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL".to_owned()
     );
 
-    // child11_block = mainnet-105494-3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww.json
+    // child11_block = mainnet-105496-3NKE1aiFviFWrYMN5feKm3L7C4Zqp3czkwAtcXj1tdbaGDZ47L1k.json
     let child11_block = block_parser
-        .get_precomputed_block("3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww")
+        .get_precomputed_block("3NKE1aiFviFWrYMN5feKm3L7C4Zqp3czkwAtcXj1tdbaGDZ47L1k")
         .await
         .unwrap();
     assert_eq!(
         child11_block.state_hash,
-        "3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww".to_owned()
+        "3NKE1aiFviFWrYMN5feKm3L7C4Zqp3czkwAtcXj1tdbaGDZ47L1k".to_owned()
     );
 
     // ----------------
@@ -75,7 +85,14 @@ async fn extensions() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new(BlockHash(root0_block.state_hash), None, None).unwrap();
+    let mut state = IndexerState::new(BlockHash(root_block.state_hash), None, None).unwrap();
+
+    // ----------
+    // add root 0
+    // ----------
+
+    let extension_type = state.add_block(&root0_block).unwrap();
+    assert_eq!(extension_type, ExtensionType::DanglingNew);
 
     // ------------
     // add child 10
@@ -100,7 +117,7 @@ async fn extensions() {
     state
         .dangling_branches
         .iter()
-        .for_each(|tree| assert_eq!(tree.branches.height(), 1));
+        .for_each(|tree| assert_eq!(tree.height(), 1));
     state
         .dangling_branches
         .iter()
@@ -135,7 +152,7 @@ async fn extensions() {
     state
         .dangling_branches
         .iter()
-        .for_each(|tree| assert_eq!(tree.branches.height(), 2));
+        .for_each(|tree| assert_eq!(tree.height(), 2));
     state
         .dangling_branches
         .iter()
@@ -154,8 +171,7 @@ async fn extensions() {
     let branch_root1 = &branches1
         .get(&branches1.root_node_id().unwrap())
         .unwrap()
-        .data()
-        .block;
+        .data();
     let leaves1: Vec<&Block> = state
         .dangling_branches
         .get(1)
@@ -177,5 +193,5 @@ async fn extensions() {
     );
 
     // branch root should match the tree's root
-    assert_eq!(root1, branch_root1);
+    assert_eq!(root1, &branch_root1.block);
 }

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -26,17 +26,30 @@ async fn extension() {
         "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
     );
 
+    // dangling_root_block = mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
+    let dangling_root_block = block_parser
+        .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
+        .await
+        .unwrap();
+    assert_eq!(
+        dangling_root_block.state_hash,
+        "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
+    );
+
     // ----------------
     // initialize state
     // ----------------
 
-    let mut state =
-        IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
+    let mut state = IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
 
-    // root_block is added as the root of the 0th dangling branch
-    assert!(state.root_branch.is_none());
+    // add dangling_root_block
+    let extension = state.add_block(&dangling_root_block).unwrap();
+    assert_eq!(extension, ExtensionType::DanglingNew);
+
+    // danlging_root_block is added as the root of the 0th dangling branch
+    assert_eq!(state.root_branch.clone().unwrap().height(), 1);
     assert_eq!(state.dangling_branches.len(), 1);
-    assert_eq!(state.dangling_branches.get(0).unwrap().branches.height(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().height(), 1);
 
     // before extension quantities
     let before_root = state.dangling_branches.get(0).unwrap().root.clone();
@@ -51,23 +64,21 @@ async fn extension() {
                 .root_node_id()
                 .unwrap(),
         )
-        .unwrap()
-        .block;
+        .unwrap();
 
     // before_root is the only leaf
     assert_eq!(before_leaves.len(), 1);
-    assert_eq!(&before_root, before_leaf);
-    assert_eq!(before_root, Block::from_precomputed(&root_block, 0));
+    assert_eq!(before_root, before_leaf.block);
+    assert_eq!(before_root, Block::from_precomputed(&dangling_root_block, 0));
 
-    // extend the branch with a child of the root
-    // child_block = mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
-    let child_block = block_parser
-        .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
+    // dangling_child_block = mainnet-105492-3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ.json
+    let dangling_child_block = block_parser
+        .get_precomputed_block("3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ")
         .await
         .unwrap();
     assert_eq!(
-        child_block.state_hash,
-        "3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC".to_owned()
+        dangling_child_block.state_hash,
+        "3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ".to_owned()
     );
 
     // before root has no children
@@ -89,28 +100,22 @@ async fn extension() {
         .next()
         .is_none());
 
-    println!(
-        "Before tree:\n{:?}",
-        state.dangling_branches.get(0).unwrap().branches
-    );
+    println!("Before state:\n{state:?}");
 
     // ---------------
     // add child block
     // ---------------
-    assert_eq!(
-        state.add_block(&child_block).unwrap(),
-        ExtensionType::DanglingSimpleForward
-    );
+    let extension = state.add_block(&dangling_child_block).unwrap();
 
     // after extension quantities
     let after_root = &state.dangling_branches.get(0).unwrap().root;
-    let branches1 = &state.dangling_branches.get(0).unwrap().branches;
-    let leaves1 = &state.dangling_branches.get(0).unwrap().leaves;
-    let after_root_id = branches1.root_node_id().unwrap();
+    let branches1 = &state.dangling_branches.get(0).unwrap();
+    let leaves1 = &branches1.leaves;
+    let after_root_id = branches1.branches.root_node_id().unwrap();
     let after_root_leaf = {
-        let child_ids: Vec<&NodeId> = branches1.children_ids(&after_root_id).unwrap().collect();
+        let child_ids: Vec<&NodeId> = branches1.branches.children_ids(&after_root_id).unwrap().collect();
         assert_eq!(child_ids.len(), 1);
-        branches1.get(child_ids.get(0).unwrap()).unwrap().data()
+        branches1.branches.get(child_ids.get(0).unwrap()).unwrap().data()
     };
 
     // branch root should still match the root of the dangling branch
@@ -135,18 +140,17 @@ async fn extension() {
             .block
     );
 
-    println!("After tree:\n{branches1:?}");
+    println!("After state:\n{state:?}");
 
-    assert_eq!(
-        after_root_leaf.block,
-        Block::from_precomputed(&child_block, 1)
-    );
+    assert_eq!(extension, ExtensionType::DanglingSimpleForward);
+
+    assert_eq!(Block::from_precomputed(&dangling_child_block, 1), after_root_leaf.block);
 
     // root shouldn't change
     assert_eq!(&before_root, after_root);
 
     // after tree has 2 blocks
-    assert_eq!(state.dangling_branches.get(0).unwrap().branches.height(), 2);
+    assert_eq!(state.dangling_branches.get(0).unwrap().height(), 2);
 
     // after root isn't a leaf
     assert!(!leaves1.contains_key(after_root_id));

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -40,7 +40,8 @@ async fn extension() {
     // initialize state
     // ----------------
 
-    let mut state = IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
+    let mut state =
+        IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
 
     // add dangling_root_block
     let extension = state.add_block(&dangling_root_block).unwrap();
@@ -69,7 +70,10 @@ async fn extension() {
     // before_root is the only leaf
     assert_eq!(before_leaves.len(), 1);
     assert_eq!(before_root, before_leaf.block);
-    assert_eq!(before_root, Block::from_precomputed(&dangling_root_block, 0));
+    assert_eq!(
+        before_root,
+        Block::from_precomputed(&dangling_root_block, 0)
+    );
 
     // dangling_child_block = mainnet-105492-3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ.json
     let dangling_child_block = block_parser
@@ -113,9 +117,17 @@ async fn extension() {
     let leaves1 = &branches1.leaves;
     let after_root_id = branches1.branches.root_node_id().unwrap();
     let after_root_leaf = {
-        let child_ids: Vec<&NodeId> = branches1.branches.children_ids(&after_root_id).unwrap().collect();
+        let child_ids: Vec<&NodeId> = branches1
+            .branches
+            .children_ids(&after_root_id)
+            .unwrap()
+            .collect();
         assert_eq!(child_ids.len(), 1);
-        branches1.branches.get(child_ids.get(0).unwrap()).unwrap().data()
+        branches1
+            .branches
+            .get(child_ids.get(0).unwrap())
+            .unwrap()
+            .data()
     };
 
     // branch root should still match the root of the dangling branch
@@ -144,7 +156,10 @@ async fn extension() {
 
     assert_eq!(extension, ExtensionType::DanglingSimpleForward);
 
-    assert_eq!(Block::from_precomputed(&dangling_child_block, 1), after_root_leaf.block);
+    assert_eq!(
+        Block::from_precomputed(&dangling_child_block, 1),
+        after_root_leaf.block
+    );
 
     // root shouldn't change
     assert_eq!(&before_root, after_root);

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -56,7 +56,8 @@ async fn extension() {
     // ----------------
 
     // root_block is the root of the root branch
-    let mut state = IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
+    let mut state =
+        IndexerState::new(BlockHash(root_block.state_hash.clone()), None, None).unwrap();
 
     // old_dangling_root_block is originally the root of the 0th dangling branch
     let extension_type = state.add_block(&old_dangling_root_block).unwrap();

--- a/tests/state/ledger/apply_diff.rs
+++ b/tests/state/ledger/apply_diff.rs
@@ -22,49 +22,49 @@ async fn account_diffs() {
             "B62qrRvo5wngd5WA1dgXkQpCdQMRDndusmjfWXWT1LgsSFFdBS9RCsV",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qrdhG66vK71Jbdz6Xs7cnDxQ8f6jZUFvefkp3pje4EejYUTvotGP",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qqLa7eh6FNPH4hCw2oB7qhA5HuKtMyqnNRnD7KyGR3McaATPjahL",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qq66ZuaVGxVvNwR752jPoZfN4uyZWrKkLeBS8FxdG9S76dhscRLy",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qrusueb8gq1RbZWyZG9EN1eCKjbByTQ39fgiGigkvg7nJR3VdGwX",
             1000000000000,
             None,
-            None,
+            None
         ),
         (
             "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB",
             1000000000000,
             None,
-            None,
+            None
         ),
     ])
     .unwrap();
@@ -78,50 +78,50 @@ async fn account_diffs() {
         (
             "B62qrusueb8gq1RbZWyZG9EN1eCKjbByTQ39fgiGigkvg7nJR3VdGwX",
             1000000000000,
-            Some(0),
             None,
+            None
         ),
         (
             "B62qrRvo5wngd5WA1dgXkQpCdQMRDndusmjfWXWT1LgsSFFdBS9RCsV",
             843190000000,
             Some(2),
-            None,
+            None
         ),
         (
             "B62qrdhG66vK71Jbdz6Xs7cnDxQ8f6jZUFvefkp3pje4EejYUTvotGP",
             2439634213000,
             Some(7),
-            None,
+            None
         ),
         (
             "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB",
             1000000000000,
-            Some(0),
             None,
+            None
         ),
         (
             "B62qqLa7eh6FNPH4hCw2oB7qhA5HuKtMyqnNRnD7KyGR3McaATPjahL",
             1000377787000,
             Some(1),
-            None,
+            None
         ),
         (
             "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
             999997998000,
             Some(4),
-            None,
+            None
         ),
         (
             "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
             1000000002000,
             Some(2),
-            None,
+            None
         ),
         (
             "B62qq66ZuaVGxVvNwR752jPoZfN4uyZWrKkLeBS8FxdG9S76dhscRLy",
             1156800000000,
             Some(1),
-            None,
+            None
         ),
     ])
     .unwrap();

--- a/tests/state/ledger/apply_diff.rs
+++ b/tests/state/ledger/apply_diff.rs
@@ -22,49 +22,49 @@ async fn account_diffs() {
             "B62qrRvo5wngd5WA1dgXkQpCdQMRDndusmjfWXWT1LgsSFFdBS9RCsV",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qrdhG66vK71Jbdz6Xs7cnDxQ8f6jZUFvefkp3pje4EejYUTvotGP",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qqLa7eh6FNPH4hCw2oB7qhA5HuKtMyqnNRnD7KyGR3McaATPjahL",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qq66ZuaVGxVvNwR752jPoZfN4uyZWrKkLeBS8FxdG9S76dhscRLy",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qrusueb8gq1RbZWyZG9EN1eCKjbByTQ39fgiGigkvg7nJR3VdGwX",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB",
             1000000000000,
             None,
-            None
+            None,
         ),
     ])
     .unwrap();
@@ -79,49 +79,49 @@ async fn account_diffs() {
             "B62qrusueb8gq1RbZWyZG9EN1eCKjbByTQ39fgiGigkvg7nJR3VdGwX",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qrRvo5wngd5WA1dgXkQpCdQMRDndusmjfWXWT1LgsSFFdBS9RCsV",
             843190000000,
             Some(2),
-            None
+            None,
         ),
         (
             "B62qrdhG66vK71Jbdz6Xs7cnDxQ8f6jZUFvefkp3pje4EejYUTvotGP",
             2439634213000,
             Some(7),
-            None
+            None,
         ),
         (
             "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB",
             1000000000000,
             None,
-            None
+            None,
         ),
         (
             "B62qqLa7eh6FNPH4hCw2oB7qhA5HuKtMyqnNRnD7KyGR3McaATPjahL",
             1000377787000,
             Some(1),
-            None
+            None,
         ),
         (
             "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
             999997998000,
             Some(4),
-            None
+            None,
         ),
         (
             "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
             1000000002000,
             Some(2),
-            None
+            None,
         ),
         (
             "B62qq66ZuaVGxVvNwR752jPoZfN4uyZWrKkLeBS8FxdG9S76dhscRLy",
             1156800000000,
             Some(1),
-            None
+            None,
         ),
     ])
     .unwrap();

--- a/tests/state/mod.rs
+++ b/tests/state/mod.rs
@@ -1,3 +1,3 @@
-// mod dangling_branches;
+mod dangling_branches;
 mod ledger;
 mod root_branch;

--- a/tests/state/root_branch/simple_proper.rs
+++ b/tests/state/root_branch/simple_proper.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use id_tree::NodeId;
 use mina_indexer::{
     block::{parser::BlockParser, Block},
-    state::{branch::Branch, ledger::LedgerMock},
+    state::{branch::Branch, ledger::Ledger},
 };
 
 // extend a branch with a new leaf
@@ -25,7 +25,7 @@ async fn extension() {
         "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
     );
     // we declare this to be the root tree
-    let root_tree = Branch::new(&root_block, LedgerMock {}).unwrap();
+    let root_tree = Branch::new(&root_block, Ledger::new()).unwrap();
 
     // before extension quantities
     let before_root = root_tree.root;
@@ -35,14 +35,13 @@ async fn extension() {
     let before_root_leaf = before_branches.get(&before_root_id).unwrap().data();
     let before_leaf_block = &before_leaves
         .get(&before_root_id)
-        .expect("before: root = leaf")
-        .block;
+        .expect("before: root = leaf");
 
     // before root is also a leaf
-    assert_eq!(&before_root_leaf.block, before_leaf_block);
+    assert_eq!(&before_root_leaf, before_leaf_block);
 
     // extend the branch with a child of the root
-    let mut tree2 = Branch::new(&root_block, LedgerMock {}).unwrap();
+    let mut tree2 = Branch::new(&root_block, Ledger::new()).unwrap();
     let child_block = block_parser
         .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
         .await
@@ -64,7 +63,7 @@ async fn extension() {
 
     // branch root should match the tree's root
     assert_eq!(before_root, before_root_leaf.block);
-    assert_eq!(&after_root, &after_root_leaf.block);
+    assert_eq!(after_root, after_root_leaf.block);
 
     let mut w = String::new();
     before_branches.write_formatted(&mut w).unwrap();
@@ -97,10 +96,9 @@ async fn extension() {
             .expect("There should be a leaf block")
             .block
     );
-    println!(
-        "After leaf: {:?}",
-        after_leaves.get(after_child).unwrap().block.clone()
-    );
+
+    let a_leaves = after_leaves.get(after_child).unwrap().clone();
+    println!("After leaf: {a_leaves:?}");
 
     // root shouldn't change
     assert_eq!(before_root, after_root);
@@ -113,10 +111,7 @@ async fn extension() {
 
     // before root is also a leaf
     assert!(before_leaves.contains_key(before_root_id));
-    assert_eq!(
-        before_leaves.get(&before_root_id).unwrap().block,
-        before_root
-    );
+    assert_eq!(before_root, before_leaves.get(&before_root_id).unwrap().block);
 
     // after root isn't a leaf
     assert!(!after_leaves.contains_key(after_root_id));

--- a/tests/state/root_branch/simple_proper.rs
+++ b/tests/state/root_branch/simple_proper.rs
@@ -111,7 +111,10 @@ async fn extension() {
 
     // before root is also a leaf
     assert!(before_leaves.contains_key(before_root_id));
-    assert_eq!(before_root, before_leaves.get(&before_root_id).unwrap().block);
+    assert_eq!(
+        before_root,
+        before_leaves.get(&before_root_id).unwrap().block
+    );
 
     // after root isn't a leaf
     assert!(!after_leaves.contains_key(after_root_id));


### PR DESCRIPTION
- fixes all unit tests
- adds a check to `IndexerState::add_block` to verify the block is not in the db before adding to the witness tree
- makes a few small modifications elsewhere to get tests to pass