### PR TITLE
Server logging fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,12 +1886,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ nix build '.?submodules=1'
 Start the Mina Indexer with `mina-indexer-server`
 * `--startup-dir` the directory to initialize the indexer's state from
 * `--watch-dir` the directory to watch to keep the indexer up to date
-* `--store-dir` the directory to store the indexer's internal RocksDB database in
+* `--database-dir` the directory to store the indexer's internal RocksDB database in
 * `--log-dir` the directory to output the indexer's logs to
 
 ```sh
-mina-indexer-server --startup-dir PATH --watch-dir PATH --store_dir PATH --log-dir PATH
+mina-indexer-server --startup-dir PATH --watch-dir PATH --database_dir PATH --log-dir PATH
 ```
 
 Query data from the Mina Indexer with `mina-indexer-client`

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -107,14 +107,14 @@ async fn main() -> Result<(), anyhow::Error> {
         genesis_ledger,
     } = parse_command_line_arguments().await?;
 
-    if log_stdout {
-        let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
-        tracing_subscriber::fmt().with_writer(non_blocking).init();
-    } else {
-        let log_writer = std::fs::File::create(log_file)?;
-        let (non_blocking, _guard) = tracing_appender::non_blocking(log_writer);
-        tracing_subscriber::fmt().with_writer(non_blocking).init();
-    }
+    let (non_blocking, _guard) = match log_stdout {
+        true => tracing_appender::non_blocking(std::io::stdout()),
+        false => {
+            let log_writer = std::fs::File::create(log_file)?;
+            tracing_appender::non_blocking(log_writer)
+        }
+    };
+    tracing_subscriber::fmt().with_writer(non_blocking).init();
 
     info!("initializing IndexerState");
     let mut indexer_state =

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -117,8 +117,11 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().with_writer(non_blocking).init();
 
     info!("initializing IndexerState");
-    let mut indexer_state =
-        mina_indexer::state::IndexerState::new(root_hash, genesis_ledger.ledger, Some(&database_dir))?;
+    let mut indexer_state = mina_indexer::state::IndexerState::new(
+        root_hash,
+        genesis_ledger.ledger,
+        Some(&database_dir),
+    )?;
 
     info!(
         "fast forwarding IndexerState using precomputed blocks in {}",

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -29,10 +29,10 @@ struct ServerArgs {
     #[arg(short, long)]
     watch_dir: PathBuf,
     #[arg(short, long)]
-    store_dir: PathBuf,
+    database_dir: PathBuf,
     #[arg(short, long)]
     log_dir: PathBuf,
-    #[arg(short, long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     log_stdout: bool,
 }
 
@@ -40,7 +40,7 @@ pub struct IndexerConfiguration {
     root_hash: BlockHash,
     startup_dir: PathBuf,
     watch_dir: PathBuf,
-    store_dir: PathBuf,
+    database_dir: PathBuf,
     log_file: PathBuf,
     genesis_ledger: GenesisRoot,
     log_stdout: bool,
@@ -53,7 +53,7 @@ pub async fn parse_command_line_arguments() -> anyhow::Result<IndexerConfigurati
     let root_hash = BlockHash(args.root_hash);
     let startup_dir = args.startup_dir;
     let watch_dir = args.watch_dir;
-    let store_dir = args.store_dir;
+    let database_dir = args.database_dir;
     let log_dir = args.log_dir;
     let log_stdout = args.log_stdout;
     info!("parsing GenesisLedger file");
@@ -84,7 +84,7 @@ pub async fn parse_command_line_arguments() -> anyhow::Result<IndexerConfigurati
                 root_hash,
                 startup_dir,
                 watch_dir,
-                store_dir,
+                database_dir,
                 log_file,
                 log_stdout,
                 genesis_ledger,
@@ -101,7 +101,7 @@ async fn main() -> Result<(), anyhow::Error> {
         root_hash,
         startup_dir,
         watch_dir,
-        store_dir,
+        database_dir,
         log_file,
         log_stdout,
         genesis_ledger,
@@ -118,7 +118,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("initializing IndexerState");
     let mut indexer_state =
-        mina_indexer::state::IndexerState::new(root_hash, genesis_ledger.ledger, Some(&store_dir))?;
+        mina_indexer::state::IndexerState::new(root_hash, genesis_ledger.ledger, Some(&database_dir))?;
 
     info!(
         "fast forwarding IndexerState using precomputed blocks in {}",
@@ -157,7 +157,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 info!("receiving connection");
                 let best_chain = indexer_state.best_chain.clone();
 
-                let primary_path = store_dir.clone();
+                let primary_path = database_dir.clone();
                 let mut secondary_path = primary_path.clone();
                 secondary_path.push(Uuid::new_v4().to_string());
 


### PR DESCRIPTION
Fixes server logging setting up `tracing_appender` incorrectly

* use match statement instead of if to assign non blocking writer and worker guard
* rename `--store-dir` to `--database-dir` to avoid name collision on short flag `-s` with `--startup-dir`

<hr>

Asana Tasks Referenced:

* https://app.asana.com/0/1203669416123378/1204789093923684/f