### PR TITLE
Remove best chain field from state

### DIFF
--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -11,7 +11,7 @@ use mina_indexer::{
     },
     state::ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
 };
-use tracing::{debug, error, event, info, instrument, Level};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -171,7 +171,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 tokio::spawn(async move {
                     debug!("handling connection");
                     if let Err(e) = handle_conn(conn, block_store_readonly, best_chain, ledger).await {
-                        event!(Level::ERROR, "Error handling connection {}", e);
+                        error!("Error handling connection {e}");
                     }
                     debug!("removing readonly instance");
                     tokio::fs::remove_dir_all(&secondary_path).await.ok();

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -9,10 +9,7 @@ use mina_indexer::{
         parser::BlockParser, precomputed::PrecomputedBlock, receiver::BlockReceiver,
         store::BlockStoreConn, BlockHash,
     },
-    state::{
-        branch::Leaf,
-        ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
-    },
+    state::ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
 };
 use tracing::{debug, error, event, info, instrument, Level};
 use uuid::Uuid;
@@ -118,7 +115,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("initializing IndexerState");
     let mut indexer_state = mina_indexer::state::IndexerState::new(
-        root_hash,
+        root_hash.clone(),
         genesis_ledger.ledger,
         Some(&database_dir),
     )?;
@@ -158,7 +155,7 @@ async fn main() -> Result<(), anyhow::Error> {
             conn_fut = listener.accept() => {
                 let conn = conn_fut?;
                 info!("receiving connection");
-                let best_chain = indexer_state.best_chain.clone();
+                let best_chain = indexer_state.root_branch.longest_chain();
 
                 let primary_path = database_dir.clone();
                 let mut secondary_path = primary_path.clone();
@@ -166,9 +163,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
                 debug!("spawning secondary readonly RocksDB instance");
                 let block_store_readonly = BlockStoreConn::new_read_only(&primary_path, &secondary_path)?;
+
+                let mut leaves = indexer_state.root_branch.leaves.values().cloned();
+                let leaf = leaves.find(|leaf| &leaf.block.state_hash == best_chain.first().unwrap_or(&root_hash)).unwrap();
+                let ledger = leaf.get_ledger().clone();
+
                 tokio::spawn(async move {
                     debug!("handling connection");
-                    if let Err(e) = handle_conn(conn, block_store_readonly, best_chain).await {
+                    if let Err(e) = handle_conn(conn, block_store_readonly, best_chain, ledger).await {
                         event!(Level::ERROR, "Error handling connection {}", e);
                     }
                     debug!("removing readonly instance");
@@ -183,7 +185,8 @@ async fn main() -> Result<(), anyhow::Error> {
 async fn handle_conn(
     conn: LocalSocketStream,
     db: BlockStoreConn,
-    best_chain: Vec<Leaf<Ledger>>,
+    best_chain: Vec<BlockHash>,
+    ledger: Ledger,
 ) -> Result<(), anyhow::Error> {
     let (reader, mut writer) = conn.into_split();
     let mut reader = BufReader::new(reader);
@@ -201,7 +204,6 @@ async fn handle_conn(
             let best_chain: Vec<PrecomputedBlock> = best_chain[..best_chain.len() - 1]
                 .iter()
                 .cloned()
-                .map(|leaf| leaf.block.state_hash)
                 .map(|state_hash| db.get_block(&state_hash.0).unwrap().unwrap())
                 .collect();
             let bytes = bcs::to_bytes(&best_chain)?;
@@ -213,14 +215,12 @@ async fn handle_conn(
             let public_key = PublicKey::from_address(&String::from_utf8(
                 data_buffer[..data_buffer.len() - 1].to_vec(),
             )?)?;
-            if let Some(block) = best_chain.first() {
-                debug!("using ledger {:?}", block.get_ledger());
-                let account = block.get_ledger().accounts.get(&public_key);
-                if let Some(account) = account {
-                    info!("writing account {:?} to client", account);
-                    let bytes = bcs::to_bytes(account)?;
-                    writer.write_all(&bytes).await?;
-                }
+            debug!("using ledger {ledger:?}");
+            let account = ledger.accounts.get(&public_key);
+            if let Some(account) = account {
+                info!("writing account {:?} to client", account);
+                let bytes = bcs::to_bytes(account)?;
+                writer.write_all(&bytes).await?;
             }
         }
         bad_request => {

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -286,7 +286,7 @@ where
         new_root_id
     }
 
-    pub fn longest_chain(&self) -> Vec<Leaf<T>> {
+    pub fn longest_chain(&self) -> Vec<BlockHash> {
         let mut longest_chain = Vec::new();
         let mut highest_leaf = None;
         for (node_id, leaf) in self.leaves.iter() {
@@ -302,11 +302,19 @@ where
 
         if let Some((node_id, _height)) = highest_leaf {
             // push the leaf itself
-            longest_chain.push(self.branches.get(node_id).unwrap().data().clone());
+            longest_chain.push(
+                self.branches
+                    .get(node_id)
+                    .unwrap()
+                    .data()
+                    .block
+                    .state_hash
+                    .clone(),
+            );
 
             // push the leaf's ancestors
             for node in self.branches.ancestors(node_id).expect("node_id is valid") {
-                longest_chain.push(node.data().clone());
+                longest_chain.push(node.data().block.state_hash.clone());
             }
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -278,17 +278,15 @@ impl IndexerState {
     }
 
     pub fn best_ledger(&self) -> Option<&Ledger> {
-        let mut res = None;
         if let Some(head_state_hash) = self.root_branch.longest_chain().first() {
             // find the corresponding leaf ledger
             for leaf in self.root_branch.leaves.values() {
                 if &leaf.block.state_hash == head_state_hash {
-                    res = Some(leaf.get_ledger());
-                    break;
+                    return Some(leaf.get_ledger());
                 }
             }
         }
-        res
+        None
     }
 }
 

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -145,14 +145,8 @@ async fn extension() {
         let longest_chain = state.root_branch.longest_chain();
         let display_chain = longest_chain
             .iter()
-            .map(|x| {
-                (
-                    x.block.height,
-                    x.block.blockchain_length.unwrap_or(0),
-                    &x.block.state_hash.0[0..12],
-                )
-            })
-            .collect::<Vec<(u32, u32, &str)>>();
+            .map(|x| &x.0[0..12])
+            .collect::<Vec<&str>>();
 
         println!("=== Longest dangling chain ===");
         println!("{display_chain:?}");


### PR DESCRIPTION
Flamegraph exposed a lot of time being spent updating the `IndexerState::best_chain` field. Turns out, this was also causing a lot of unnecessary allocations too and the field is unnecessary!

This PR drastically improves performance

- removes the `best_chain` field from `IndexerState`
- replaces all uses of `best_chain` with a call to `root_branch.longest_chain()`
- modifies the server and tests accordingly