### PR TITLE
Blockchain length unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,21 @@ nix build '.?submodules=1'
 ```
 
 Start the Mina Indexer with `mina-indexer-server`
+* `--genesis-ledger` the genesis ledger `.json` file to use to initialize the indexer
+* `--root-hash` the state hash of the genesis block, can be found in the genesis ledger
 * `--startup-dir` the directory to initialize the indexer's state from
 * `--watch-dir` the directory to watch to keep the indexer up to date
 * `--database-dir` the directory to store the indexer's internal RocksDB database in
 * `--log-dir` the directory to output the indexer's logs to
+* `--log-stdout` write logs to standard out instead of to a file (overrides `--log-dir`)
 
 ```sh
-mina-indexer-server --startup-dir PATH --watch-dir PATH --database_dir PATH --log-dir PATH
+mina-indexer-server --root-hash STATE_HASH \
+    --genesis-ledger PATH \
+    --startup-dir PATH \
+    --watch-dir PATH \
+    --database-dir PATH \
+    --log-dir PATH 
 ```
 
 Query data from the Mina Indexer with `mina-indexer-client`

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -124,10 +124,10 @@ impl IndexerState {
                     .fold(None, |acc, x| acc.max(Some(x))),
                 dangling_branch.root.blockchain_length,
             ) {
-                (Some(max_length), Some(min_length)) => {
+                (Some(max_length), min_length) => {
                     // check incoming block is within the height bounds
                     if let Some(length) = precomputed_block.blockchain_length {
-                        if max_length + 1 >= length && length + 1 >= min_length {
+                        if max_length + 1 >= length && length + 1 >= min_length.unwrap_or(0) {
                             // simple reverse
                             if precomputed_block.state_hash == dangling_branch.root.parent_hash.0 {
                                 dangling_branch.new_root(precomputed_block);


### PR DESCRIPTION
Fixes a bug where precomputed blocks lacking a `blockchain_length` in the filename cause an unreachable code error

* change comparison of `min_length` to use `.unwrap_or(0)` in case the field doesn't exist
* update the readme to fix some flags missing (`--root-hash` `--genesis-ledger` `--log-stdout`)

<hr>

Asana tasks referenced

* https://app.asana.com/0/1203669416123378/1204782760949370/f