### PR TITLE
Transition Frontier Pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,12 +1886,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -12,7 +12,7 @@ use mina_indexer::{
     state::{
         branch::Leaf,
         ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
-    },
+    }, MAINNET_TRANSITION_FRONTIER_K,
 };
 use tracing::{debug, error, event, info, instrument, Level};
 use uuid::Uuid;
@@ -118,7 +118,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("initializing IndexerState");
     let mut indexer_state =
-        mina_indexer::state::IndexerState::new(root_hash, genesis_ledger.ledger, Some(&store_dir))?;
+        mina_indexer::state::IndexerState::new(
+            root_hash, genesis_ledger.ledger, 
+            Some(&store_dir), Some(MAINNET_TRANSITION_FRONTIER_K)
+        )?;
 
     info!(
         "fast forwarding IndexerState using precomputed blocks in {}",

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -119,7 +119,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut indexer_state =
         mina_indexer::state::IndexerState::new(
             root_hash.clone(), genesis_ledger.ledger, 
-            Some(&database_dir), Some(MAINNET_TRANSITION_FRONTIER_K)
+            Some(&database_dir), Some(MAINNET_TRANSITION_FRONTIER_K), Some(100)
         )?;
 
     info!(

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -9,9 +9,8 @@ use mina_indexer::{
         parser::BlockParser, precomputed::PrecomputedBlock, receiver::BlockReceiver,
         store::BlockStoreConn, BlockHash,
     },
-    state::{
-        ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
-    }, MAINNET_TRANSITION_FRONTIER_K,
+    state::ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
+    MAINNET_TRANSITION_FRONTIER_K,
 };
 use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
@@ -116,11 +115,13 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().with_writer(non_blocking).init();
 
     info!("initializing IndexerState");
-    let mut indexer_state =
-        mina_indexer::state::IndexerState::new(
-            root_hash.clone(), genesis_ledger.ledger, 
-            Some(&database_dir), Some(MAINNET_TRANSITION_FRONTIER_K), Some(100)
-        )?;
+    let mut indexer_state = mina_indexer::state::IndexerState::new(
+        root_hash.clone(),
+        genesis_ledger.ledger,
+        Some(&database_dir),
+        Some(MAINNET_TRANSITION_FRONTIER_K),
+        Some(100),
+    )?;
 
     info!(
         "fast forwarding IndexerState using precomputed blocks in {}",

--- a/src/bin/mina-indexer-server.rs
+++ b/src/bin/mina-indexer-server.rs
@@ -10,7 +10,6 @@ use mina_indexer::{
         store::BlockStoreConn, BlockHash,
     },
     state::{
-        branch::Leaf,
         ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
     }, MAINNET_TRANSITION_FRONTIER_K,
 };
@@ -119,8 +118,8 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("initializing IndexerState");
     let mut indexer_state =
         mina_indexer::state::IndexerState::new(
-            root_hash, genesis_ledger.ledger, 
-            Some(&store_dir), Some(MAINNET_TRANSITION_FRONTIER_K)
+            root_hash.clone(), genesis_ledger.ledger, 
+            Some(&database_dir), Some(MAINNET_TRANSITION_FRONTIER_K)
         )?;
 
     info!(

--- a/src/block/store.rs
+++ b/src/block/store.rs
@@ -8,30 +8,6 @@ use thiserror::Error;
 
 use super::precomputed::PrecomputedBlock;
 
-#[derive(Debug, Clone)]
-pub struct BlockStore(pub PathBuf);
-
-impl r2d2::ManageConnection for BlockStore {
-    type Connection = BlockStoreConn;
-
-    type Error = BlockStoreError;
-
-    fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let mut secondary = self.0.clone();
-        secondary.push("secondary");
-        BlockStoreConn::new_read_only(&self.0, &secondary)
-    }
-
-    fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        conn.test_conn()?;
-        Ok(())
-    }
-
-    fn has_broken(&self, _conn: &mut Self::Connection) -> bool {
-        false
-    }
-}
-
 #[derive(Debug)]
 pub struct BlockStoreConn {
     db_path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod block;
 pub mod state;
 
 pub const SOCKET_NAME: &str = "@mina-indexer.sock";
+pub const MAINNET_TRANSITION_FRONTIER_K: u32 = 290;

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use id_tree::{InsertBehavior::*, Node, NodeId, Tree};
+use id_tree::{InsertBehavior::{*, self}, Node, NodeId, Tree};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
@@ -154,6 +154,83 @@ where
             return Some(new_node_id);
         }
         None
+    }
+
+    pub fn prune_transition_frontier(&mut self, k: u32) {
+        let mut prune_point_id = None;
+        for (node_id, _leaf) in self.leaves.iter() {
+            let mut witness_length = 0;
+            let mut transition_frontier_id = None;
+            for ancestor_id in self.branches
+                .ancestor_ids(&node_id)
+                .expect("node_id from leaves, is valid") 
+            {
+                witness_length += 1;
+                if witness_length >= k {
+                    transition_frontier_id = Some(ancestor_id.clone());
+                    break;
+                }
+            }
+            if let Some(node_id) = transition_frontier_id {
+                prune_point_id = Some(node_id);
+                break;
+            }
+        }
+
+        if let Some(node_id) = prune_point_id {
+            let mut new_tree = Tree::new();
+            let mut new_leaves = HashMap::new();
+            let mut merge_id_map = HashMap::new();
+            
+            let new_root_data = self.branches
+                .get(&node_id)
+                .expect("node_id valid, comes from iterator")
+                .data()
+                .clone();
+            let new_root_id = new_tree.insert(
+                Node::new(new_root_data.clone()), 
+                InsertBehavior::AsRoot).expect("insert as root always succeeds"
+            );
+            merge_id_map.insert(node_id.clone(), new_root_id);
+            for old_node_id in self.branches
+                .traverse_level_order_ids(&node_id)
+                .expect("node_id guaranteed by iterator") 
+            {
+                let under_node_id = merge_id_map
+                    .get(&old_node_id)
+                    .expect("guaranteed by call structure");
+                let children_ids = self.branches
+                    .children_ids(&old_node_id)
+                    .expect("old_node_id valid");
+                let mut merge_id_map_inserts = Vec::new();
+                for child_id in children_ids {
+                    let child_node_data = self.branches
+                        .get(child_id)
+                        .expect("child_id valid")
+                        .data()
+                        .clone();
+                    let new_child_id = new_tree
+                        .insert(Node::new(child_node_data.clone()), UnderNode(under_node_id))
+                        .expect("under_node_id guaranteed by call structure");
+                    if self.branches
+                        .children_ids(child_id)
+                        .expect("child_id is valid")
+                        .collect::<Vec<&NodeId>>()
+                        .is_empty()
+                    {
+                        new_leaves.insert(new_child_id.clone(), child_node_data.clone());
+                    }
+                    merge_id_map_inserts.push((child_id, new_child_id));
+                }
+                for (child_id, new_child_id) in merge_id_map_inserts {
+                    merge_id_map.insert(child_id.clone(), new_child_id);
+                }
+            }
+
+            self.branches = new_tree;
+            self.leaves = new_leaves;
+            self.root = new_root_data.block;
+        }
     }
 
     pub fn merge_on(&mut self, junction_id: &NodeId, incoming: &mut Branch<LedgerDiff>) {

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use id_tree::{InsertBehavior::{*, self}, Node, NodeId, Tree};
+use id_tree::{
+    InsertBehavior::{self, *},
+    Node, NodeId, Tree,
+};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
@@ -161,9 +164,10 @@ where
         for (node_id, _leaf) in self.leaves.iter() {
             let mut witness_length = 0;
             let mut transition_frontier_id = None;
-            for ancestor_id in self.branches
+            for ancestor_id in self
+                .branches
                 .ancestor_ids(&node_id)
-                .expect("node_id from leaves, is valid") 
+                .expect("node_id from leaves, is valid")
             {
                 witness_length += 1;
                 if witness_length >= k {
@@ -181,30 +185,33 @@ where
             let mut new_tree = Tree::new();
             let mut new_leaves = HashMap::new();
             let mut merge_id_map = HashMap::new();
-            
-            let new_root_data = self.branches
+
+            let new_root_data = self
+                .branches
                 .get(&node_id)
                 .expect("node_id valid, comes from iterator")
                 .data()
                 .clone();
-            let new_root_id = new_tree.insert(
-                Node::new(new_root_data.clone()), 
-                InsertBehavior::AsRoot).expect("insert as root always succeeds"
-            );
+            let new_root_id = new_tree
+                .insert(Node::new(new_root_data.clone()), InsertBehavior::AsRoot)
+                .expect("insert as root always succeeds");
             merge_id_map.insert(node_id.clone(), new_root_id);
-            for old_node_id in self.branches
+            for old_node_id in self
+                .branches
                 .traverse_level_order_ids(&node_id)
-                .expect("node_id guaranteed by iterator") 
+                .expect("node_id guaranteed by iterator")
             {
                 let under_node_id = merge_id_map
                     .get(&old_node_id)
                     .expect("guaranteed by call structure");
-                let children_ids = self.branches
+                let children_ids = self
+                    .branches
                     .children_ids(&old_node_id)
                     .expect("old_node_id valid");
                 let mut merge_id_map_inserts = Vec::new();
                 for child_id in children_ids {
-                    let child_node_data = self.branches
+                    let child_node_data = self
+                        .branches
                         .get(child_id)
                         .expect("child_id valid")
                         .data()
@@ -212,7 +219,8 @@ where
                     let new_child_id = new_tree
                         .insert(Node::new(child_node_data.clone()), UnderNode(under_node_id))
                         .expect("under_node_id guaranteed by call structure");
-                    if self.branches
+                    if self
+                        .branches
                         .children_ids(child_id)
                         .expect("child_id is valid")
                         .collect::<Vec<&NodeId>>()

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -83,17 +83,12 @@ impl IndexerState {
         if let Some(block_store) = self.block_store.as_ref() {
             match block_store.get_block(state_hash) {
                 Err(err) => return Err(err),
-                Ok(None) => (),
-                Ok(_) => {
-                    error!( "Block with state hash '{state_hash:?}' is already present in the block store");
-                    // return Err(anyhow::Error::msg(format!(
-                    // "Block with state hash '{state_hash:?}' is already present in the block store"
-                    // )))
-                }
+                // add precomputed block to the db
+                Ok(None) => block_store.add_block(precomputed_block)?,
+                // log duplicate block to error
+                Ok(_) => error!( "Block with state hash '{state_hash:?}' is already present in the block store"),
+                    
             }
-
-            // add precomputed block to the db
-            block_store.add_block(precomputed_block)?;
         }
 
         self.blocks_processed += 1;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,4 @@
+use log::info;
 use tracing::error;
 
 use crate::block::{precomputed::PrecomputedBlock, store::BlockStoreConn, BlockHash};
@@ -71,9 +72,11 @@ impl IndexerState {
         if let Some(k) = self.transition_frontier_length {
             if let Some(interval) = self.prune_interval {
                 if self.blocks_processed % interval == 0 {
+                    info!("pruning transition frontier at k={}", k);
                     self.root_branch.prune_transition_frontier(k);
                 }
             } else {
+                info!("pruning transition frontier at k={}", k);
                 self.root_branch.prune_transition_frontier(k);
             }
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,5 @@
+use tracing::error;
+
 use crate::block::{precomputed::PrecomputedBlock, store::BlockStoreConn, BlockHash};
 
 use self::{
@@ -83,9 +85,10 @@ impl IndexerState {
                 Err(err) => return Err(err),
                 Ok(None) => (),
                 Ok(_) => {
-                    return Err(anyhow::Error::msg(format!(
-                    "Block with state hash '{state_hash:?}' is already present in the block store"
-                )))
+                    error!( "Block with state hash '{state_hash:?}' is already present in the block store");
+                    // return Err(anyhow::Error::msg(format!(
+                    // "Block with state hash '{state_hash:?}' is already present in the block store"
+                    // )))
                 }
             }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -57,7 +57,7 @@ impl IndexerState {
             block_store,
             transition_frontier_length,
             prune_interval,
-            blocks_processed: 0
+            blocks_processed: 0,
         })
     }
 
@@ -89,11 +89,10 @@ impl IndexerState {
                 // add precomputed block to the db
                 Ok(None) => block_store.add_block(precomputed_block)?,
                 // log duplicate block to error
-                Ok(_) =>{
+                Ok(_) => {
                     error!( "Block with state hash '{state_hash:?}' is already present in the block store");
                     return Ok(ExtensionType::BlockNotAdded);
-                },
-                    
+                }
             }
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -86,7 +86,10 @@ impl IndexerState {
                 // add precomputed block to the db
                 Ok(None) => block_store.add_block(precomputed_block)?,
                 // log duplicate block to error
-                Ok(_) => error!( "Block with state hash '{state_hash:?}' is already present in the block store"),
+                Ok(_) =>{
+                    error!( "Block with state hash '{state_hash:?}' is already present in the block store");
+                    return Ok(ExtensionType::BlockNotAdded);
+                },
                     
             }
         }

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -23,6 +23,7 @@ async fn extension() {
                 accounts: Vec::new(),
             },
             None,
+            None
         )
         .unwrap();
         n += 1;

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -22,7 +22,9 @@ async fn extension() {
                 name: "testing".to_string(),
                 accounts: Vec::new(),
             },
-            None,None, None
+            None,
+            None,
+            None,
         )
         .unwrap();
         n += 1;

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -22,8 +22,7 @@ async fn extension() {
                 name: "testing".to_string(),
                 accounts: Vec::new(),
             },
-            None,
-            None
+            None,None, None
         )
         .unwrap();
         n += 1;

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -47,8 +47,7 @@ async fn test() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        Some(&block_store_dir),
-        None
+        Some(&block_store_dir), None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -48,6 +48,7 @@ async fn test() {
             accounts: Vec::new(),
         },
         Some(&block_store_dir),
+        None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -47,7 +47,9 @@ async fn test() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        Some(&block_store_dir), None, None
+        Some(&block_store_dir),
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -72,7 +72,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -72,7 +72,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -72,7 +72,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
+        None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -83,7 +83,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -83,7 +83,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -83,7 +83,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
+        None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -75,7 +75,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -75,7 +75,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
+        None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -75,7 +75,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -58,7 +58,7 @@ async fn extensions() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
+        None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -58,7 +58,9 @@ async fn extensions() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -58,7 +58,7 @@ async fn extensions() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -40,8 +40,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
-        None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -41,6 +41,7 @@ async fn extension() {
             accounts: Vec::new(),
         },
         None,
+        None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -40,7 +40,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -91,8 +91,7 @@ async fn extensions() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
-        None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -91,7 +91,9 @@ async fn extensions() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -92,6 +92,7 @@ async fn extensions() {
             accounts: Vec::new(),
         },
         None,
+        None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -47,6 +47,7 @@ async fn extension() {
             accounts: Vec::new(),
         },
         None,
+        None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -46,7 +46,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -46,8 +46,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
-        None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -62,7 +62,9 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None, None, None
+        None,
+        None,
+        None,
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -63,6 +63,7 @@ async fn extension() {
             accounts: Vec::new(),
         },
         None,
+        None
     )
     .unwrap();
 

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -62,8 +62,7 @@ async fn extension() {
             name: "testing".to_string(),
             accounts: Vec::new(),
         },
-        None,
-        None
+        None, None, None
     )
     .unwrap();
 

--- a/tests/state/root_branch/mod.rs
+++ b/tests/state/root_branch/mod.rs
@@ -7,6 +7,12 @@ mod simple_proper;
 
 #[tokio::test]
 async fn prune_transition_frontier() {
+    // 0
+    // |    1
+    // 1 => |
+    // |    2
+    // 2
+
     let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
     let mut block_parser = BlockParser::new(&log_dir).unwrap();
 

--- a/tests/state/root_branch/mod.rs
+++ b/tests/state/root_branch/mod.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use mina_indexer::{state::{branch::Branch, ledger::Ledger}, block::{parser::BlockParser, Block}};
+use mina_indexer::{
+    block::{parser::BlockParser, Block},
+    state::{branch::Branch, ledger::Ledger},
+};
 
 mod simple_improper;
 mod simple_proper;

--- a/tests/state/root_branch/mod.rs
+++ b/tests/state/root_branch/mod.rs
@@ -1,2 +1,54 @@
+use std::path::PathBuf;
+
+use mina_indexer::{state::{branch::Branch, ledger::Ledger}, block::{parser::BlockParser, Block}};
+
 mod simple_improper;
 mod simple_proper;
+
+#[tokio::test]
+async fn prune_transition_frontier() {
+    let log_dir = PathBuf::from("./tests/data/beautified_sequential_blocks");
+    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+
+    // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
+    let root_block = block_parser
+        .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
+        .await
+        .unwrap();
+    assert_eq!(
+        root_block.state_hash,
+        "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
+    );
+
+    let mut root_tree = Branch::new(&root_block, Ledger::new()).unwrap();
+
+    let middle_block = block_parser
+        .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
+        .await
+        .unwrap();
+    assert_eq!(
+        middle_block.state_hash,
+        "3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC".to_owned()
+    );
+    root_tree
+        .simple_extension(&middle_block)
+        .expect("new leaf should be inserted");
+
+    let child_block = block_parser
+        .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
+        .await
+        .unwrap();
+    assert_eq!(
+        child_block.state_hash,
+        "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
+    );
+    root_tree
+        .simple_extension(&child_block)
+        .expect("new leaf should be inserted");
+
+    root_tree.prune_transition_frontier(1);
+
+    let pruned_root_block = root_tree.root;
+
+    assert_eq!(Block::from_precomputed(&middle_block, 1), pruned_root_block);
+}


### PR DESCRIPTION
Adds support for pruning the root branch to a transition frontier of `k` blocks at a regular interval (number of blocks added)

* creates `Branch::prune_transition_frontier` which leverages Isaac's code in `Branch::merge_on` to prune the state tree when a branch has an ancestor list longer than `k`
* adds `prune_interval` field to `IndexerState` and calls `Branch::prune_transition_frontier` on the Root Branch for every `prune_interval` blocks added, or every block if no interval  is specified
* adds `info!` calls to `IndexerState::add_block` to log pruning
* changes the behavior of `IndexerState::add_block` to log duplicate blocks, and return `BlockNotAdded` instead of crashing

<hr>

Asana Tasks Referenced
* https://app.asana.com/0/1203669416123378/1204782760949366/f
* https://app.asana.com/0/1203669416123378/1204758919833975/f 