### PR TITLE
fix BlockReceiver tests (at last)

### DIFF
--- a/tests/block/receiver.rs
+++ b/tests/block/receiver.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use mina_indexer::block::receiver::BlockReceiver;
 use tokio::{
-    fs::{create_dir, metadata, remove_dir, remove_file, File},
+    fs::{create_dir, remove_dir, remove_file, File},
     io::AsyncWriteExt,
     process::Command,
 };
@@ -18,7 +18,7 @@ async fn detects_new_block_written() {
     let mut test_block_path = test_dir_path.clone();
     test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
 
-    if metadata(test_block_path.clone()).await.is_ok() {
+    if tokio::fs::metadata(&test_block_path).await.is_ok() {
         remove_file(test_block_path.clone()).await.unwrap();
         remove_dir(TEST_DIR).await.unwrap();
     }
@@ -42,16 +42,19 @@ async fn detects_new_block_copied() {
     const TEST_DIR: &'static str = "./receiver_copy_test";
     const TEST_BLOCK_PATH: &'static str = "./tests/data/beautified_logs/mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json";
 
-    create_dir(TEST_DIR).await.unwrap_or(());
-
     let test_dir_path = PathBuf::from(TEST_DIR);
+    let mut test_block_path = test_dir_path.clone();
+    test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
+
+    if tokio::fs::metadata(&test_block_path).await.is_ok() {
+        remove_file(test_block_path.clone()).await.unwrap();
+        remove_dir(TEST_DIR).await.unwrap();
+    }
+    create_dir(TEST_DIR).await.unwrap_or(());
 
     let mut block_receiver = BlockReceiver::new().await.unwrap();
 
     block_receiver.load_directory(&test_dir_path).await.unwrap();
-
-    let mut test_block_path = test_dir_path;
-    test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
 
     let mut command = Command::new("cp")
         .arg(TEST_BLOCK_PATH)


### PR DESCRIPTION
Fixes the `BlockReceiver` tests hanging on repeated runs of the test suite

* adds file directory checking and deletion before the test runs for:
** `detects_new_block_written`
** `detects_new_block_copied`

<hr>

Asana tasks referenced
* https://app.asana.com/0/1203669416123378/1204820393125448/f