### PR TITLE
Remove leaves from `Branch`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -236,16 +236,13 @@ pub async fn run(args: ServerArgs) -> Result<(), anyhow::Error> {
                     root_hash: indexer_state.root_branch.root.state_hash.0.clone(),
                     root_height: indexer_state.root_branch.height(),
                     root_length: indexer_state.root_branch.len(),
-                    num_leaves: indexer_state.root_branch.leaves.len(),
+                    num_leaves: indexer_state.root_branch.leaves().len(),
                     num_dangling: indexer_state.dangling_branches.len(),
                     max_dangling_height,
                     max_dangling_length,
                     db_stats: db_stats_str.map(|s| DbStats::from_str(&format!("{mem}\n{s}")).unwrap()),
                 };
-
-                let mut leaves = indexer_state.root_branch.leaves.values().cloned();
-                let leaf = leaves.find(|leaf| &leaf.block.state_hash == best_chain.first().unwrap_or(&root_hash)).unwrap();
-                let ledger = leaf.get_ledger().clone();
+                let ledger = indexer_state.root_branch.best_tip().unwrap().get_ledger().clone();
 
                 tokio::spawn(async move {
                     debug!("Handling connection");

--- a/tests/block/receiver.rs
+++ b/tests/block/receiver.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use mina_indexer::block::receiver::BlockReceiver;
 use tokio::{
@@ -14,27 +14,29 @@ async fn detects_new_block_written() {
         "../data/beautified_logs/mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json"
     );
 
-    let test_dir_path = PathBuf::from(TEST_DIR);
-    let mut test_block_path = test_dir_path.clone();
-    test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
+    let timeout = Duration::new(5, 0);
+    let mut success = false;
 
-    if metadata(&TEST_DIR).await.is_ok() {
-        remove_dir_all(TEST_DIR).await.unwrap();
-    }
-    create_dir(TEST_DIR).await.unwrap();
+    tokio::time::timeout(timeout, async {
+        let test_dir_path = PathBuf::from(TEST_DIR);
+        let mut test_block_path = test_dir_path.clone();
+        test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
 
-    let mut block_receiver = BlockReceiver::new().await.unwrap();
+        pretest(TEST_DIR).await;
 
-    block_receiver.load_directory(&test_dir_path).await.unwrap();
+        let mut block_receiver = BlockReceiver::new().await.unwrap();
+        block_receiver.load_directory(&test_dir_path).await.unwrap();
 
-    let mut file = File::create(test_block_path.clone()).await.unwrap();
-    file.write_all(TEST_BLOCK.as_bytes()).await.unwrap();
+        let mut file = File::create(test_block_path.clone()).await.unwrap();
+        file.write_all(TEST_BLOCK.as_bytes()).await.unwrap();
 
-    let _recvd = block_receiver.recv().await.unwrap().unwrap();
+        block_receiver.recv().await.unwrap().unwrap();
+        success = true;
+    })
+    .await
+    .unwrap();
 
-    if metadata(TEST_DIR).await.is_ok() {
-        remove_dir_all(TEST_DIR).await.unwrap();
-    }
+    posttest(TEST_DIR, success).await;
 }
 
 #[tokio::test]
@@ -42,29 +44,48 @@ async fn detects_new_block_copied() {
     const TEST_DIR: &'static str = "./receiver_copy_test";
     const TEST_BLOCK_PATH: &'static str = "./tests/data/beautified_logs/mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json";
 
-    let test_dir_path = PathBuf::from(TEST_DIR);
-    let mut test_block_path = test_dir_path.clone();
-    test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
+    let timeout = Duration::new(5, 0);
+    let mut success = false;
 
-    if metadata(&TEST_DIR).await.is_ok() {
-        remove_dir_all(TEST_DIR).await.unwrap();
+    tokio::time::timeout(timeout, async {
+        let test_dir_path = PathBuf::from(TEST_DIR);
+        let mut test_block_path = test_dir_path.clone();
+        test_block_path.push("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
+
+        pretest(TEST_DIR).await;
+
+        let mut block_receiver = BlockReceiver::new().await.unwrap();
+        block_receiver.load_directory(&test_dir_path).await.unwrap();
+
+        let mut command = Command::new("cp")
+            .arg(TEST_BLOCK_PATH)
+            .arg(&test_block_path)
+            .spawn()
+            .unwrap();
+        command.wait().await.unwrap();
+
+        block_receiver.recv().await.unwrap().unwrap();
+        success = true;
+    })
+    .await
+    .unwrap();
+
+    posttest(TEST_DIR, success).await;
+}
+
+async fn pretest(path: &str) {
+    if metadata(path).await.is_ok() {
+        remove_dir_all(path).await.unwrap();
     }
-    create_dir(TEST_DIR).await.unwrap_or(());
+    create_dir(path).await.unwrap_or(());
+}
 
-    let mut block_receiver = BlockReceiver::new().await.unwrap();
+async fn posttest(path: &str, success: bool) {
+    if metadata(path).await.is_ok() {
+        remove_dir_all(path).await.unwrap();
+    }
 
-    block_receiver.load_directory(&test_dir_path).await.unwrap();
-
-    let mut command = Command::new("cp")
-        .arg(TEST_BLOCK_PATH)
-        .arg(&test_block_path)
-        .spawn()
-        .unwrap();
-    command.wait().await.unwrap();
-
-    let _recvd = block_receiver.recv().await.unwrap().unwrap();
-
-    if metadata(TEST_DIR).await.is_ok() {
-        remove_dir_all(TEST_DIR).await.unwrap();
+    if !success {
+        panic!("Timed out");
     }
 }

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -1,7 +1,4 @@
-use mina_indexer::{
-    block::{parser::BlockParser, Block},
-    state::IndexerState,
-};
+use mina_indexer::{block::parser::BlockParser, state::IndexerState};
 use std::path::PathBuf;
 
 /// Parses all blocks in ./tests/data/sequential_blocks
@@ -48,7 +45,7 @@ async fn extension() {
             .iter()
             .enumerate()
             .for_each(|(_, tree)| {
-                assert_eq!(tree.leaves.len(), 1);
+                assert_eq!(tree.leaves().len(), 1);
             });
 
         // root branch
@@ -72,7 +69,7 @@ async fn extension() {
         // check all children.height = 1 + parent.height
         // check all children.parent_hash = parent.state_hash
         // check all children.parent_hash = parent.state_hash
-        for (idx, dangling_branch) in state.dangling_branches.iter().enumerate() {
+        for dangling_branch in state.dangling_branches.iter() {
             for node_id in dangling_branch
                 .branches
                 .traverse_level_order_ids(dangling_branch.branches.root_node_id().unwrap())
@@ -99,36 +96,6 @@ async fn extension() {
                             .parent_hash
                     );
                 }
-
-                // Branch leaves faithfully correspond to the underlying tree's leaf blocks
-                let leaves: Vec<&Block> = state
-                    .dangling_branches
-                    .get(idx)
-                    .unwrap()
-                    .leaves
-                    .iter()
-                    .map(|(_, node_block)| &node_block.block)
-                    .collect();
-                let tree_leaves: Vec<&Block> = state
-                    .dangling_branches
-                    .get(idx)
-                    .unwrap()
-                    .leaves
-                    .iter()
-                    .map(|(leaf_id, _)| {
-                        // tree node corresponding to leaf_id
-                        &state
-                            .dangling_branches
-                            .get(idx)
-                            .unwrap()
-                            .branches
-                            .get(leaf_id)
-                            .unwrap()
-                            .data()
-                            .block
-                    })
-                    .collect();
-                assert_eq!(leaves, tree_leaves);
             }
         }
 

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -106,7 +106,7 @@ async fn extension() {
     state
         .dangling_branches
         .iter()
-        .for_each(|tree| assert_eq!(tree.leaves.len(), 1));
+        .for_each(|tree| assert_eq!(tree.leaves().len(), 1));
 
     // ----------------
     // add middle block
@@ -139,7 +139,7 @@ async fn extension() {
     // - height = 3
     assert_eq!(state.root_branch.clone().len(), 3);
     assert_eq!(state.root_branch.clone().height(), 3);
-    assert_eq!(state.root_branch.clone().leaves.len(), 1);
+    assert_eq!(state.root_branch.clone().leaves().len(), 1);
 
     // after extension quantities
     let root = &state.root_branch.clone().root;
@@ -149,7 +149,7 @@ async fn extension() {
         .unwrap()
         .data();
     let root_branch = state.root_branch;
-    let leaves: Vec<&Block> = root_branch.leaves.iter().map(|(_, x)| &x.block).collect();
+    let leaves: Vec<&Block> = root_branch.leaves().iter().map(|x| &x.block).collect();
 
     assert_eq!(leaves.get(0).unwrap().state_hash.0, leaf_block.state_hash);
 

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -98,7 +98,7 @@ async fn merge() {
     // - leaves = 1
     assert_eq!(state.root_branch.clone().len(), 1);
     assert_eq!(state.root_branch.clone().height(), 1);
-    assert_eq!(state.root_branch.clone().leaves.len(), 1);
+    assert_eq!(state.root_branch.clone().leaves().len(), 1);
 
     // 2 dangling branches
     // - len = 1
@@ -116,7 +116,7 @@ async fn merge() {
     state
         .dangling_branches
         .iter()
-        .for_each(|tree| assert_eq!(tree.leaves.len(), 1));
+        .for_each(|tree| assert_eq!(tree.leaves().len(), 1));
 
     println!("=== Before state ===");
     println!("{state:?}");
@@ -137,7 +137,7 @@ async fn merge() {
     // - leaves = 2
     assert_eq!(state.root_branch.clone().len(), 4);
     assert_eq!(state.root_branch.clone().height(), 3);
-    assert_eq!(state.root_branch.clone().leaves.len(), 2);
+    assert_eq!(state.root_branch.clone().leaves().len(), 2);
 
     // no dangling branches
     assert_eq!(state.dangling_branches.len(), 0);
@@ -152,7 +152,7 @@ async fn merge() {
     let leaf0 = Block::from_precomputed(&leaf0_block, 2);
     let leaf1 = Block::from_precomputed(&leaf1_block, 2);
     let root_branch = state.root_branch.clone();
-    let leaves0: HashSet<&Block> = root_branch.leaves.iter().map(|(_, x)| &x.block).collect();
+    let leaves0: HashSet<&Block> = root_branch.leaves().iter().map(|x| &x.block).collect();
 
     assert_eq!(
         leaves0.iter().collect::<HashSet<&&Block>>(),

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -84,7 +84,7 @@ async fn extension() {
     assert_eq!(state.dangling_branches.len(), 2);
     state.dangling_branches.iter().for_each(|tree| {
         assert_eq!(tree.len(), 1);
-        assert_eq!(tree.leaves.len(), 1);
+        assert_eq!(tree.leaves().len(), 1);
     });
 
     for (idx, branch) in state.dangling_branches.iter().enumerate() {
@@ -111,7 +111,7 @@ async fn extension() {
 
     // root branch
     assert_eq!(state.root_branch.clone().len(), 3);
-    assert_eq!(state.root_branch.clone().leaves.len(), 1);
+    assert_eq!(state.root_branch.clone().leaves().len(), 1);
 
     // 1 dangling branch
     // - height = 1
@@ -123,7 +123,7 @@ async fn extension() {
         .enumerate()
         .for_each(|(_, tree)| assert_eq!(tree.height(), 1));
     state.dangling_branches.iter().for_each(|tree| {
-        assert_eq!(tree.leaves.len(), 1);
+        assert_eq!(tree.leaves().len(), 1);
     });
 
     // after extension quantities
@@ -135,9 +135,9 @@ async fn extension() {
         .data();
     let leaves: Vec<Block> = state
         .root_branch
-        .leaves
+        .leaves()
         .iter()
-        .map(|(_, x)| x.block.clone())
+        .map(|x| x.block.clone())
         .collect();
     let leaf = Block::from_precomputed(&leaf_block, 2);
 

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -59,19 +59,14 @@ async fn extensions() {
     // - height = 1
     assert_eq!(state.root_branch.clone().len(), 1);
     assert_eq!(state.root_branch.clone().height(), 1);
-    assert_eq!(state.root_branch.clone().leaves.len(), 1);
+    assert_eq!(state.root_branch.clone().leaves().len(), 1);
 
     // no dangling branches
     assert_eq!(state.dangling_branches.len(), 0);
 
     // before extension quantities
     let root0 = state.root_branch.clone().root;
-    let root_leaf0 = state
-        .root_branch
-        .leaves
-        .get(state.root_branch.branches.root_node_id().unwrap())
-        .unwrap()
-        .clone();
+    let root_leaf0 = state.root_branch.leaves().get(0).unwrap().clone();
 
     println!("=== Before Branch 0 ===");
     println!("{:?}", state.root_branch.branches);
@@ -93,7 +88,7 @@ async fn extensions() {
     // - leaves = 1
     assert_eq!(state.root_branch.len(), 1);
     assert_eq!(state.root_branch.height(), 1);
-    assert_eq!(state.root_branch.leaves.len(), 1);
+    assert_eq!(state.root_branch.leaves().len(), 1);
 
     // 1 dangling branch
     // - len = 1
@@ -102,7 +97,7 @@ async fn extensions() {
     assert_eq!(state.dangling_branches.len(), 1);
     assert_eq!(state.dangling_branches.get(0).unwrap().len(), 1);
     assert_eq!(state.dangling_branches.get(0).unwrap().height(), 1);
-    assert_eq!(state.dangling_branches.get(0).unwrap().leaves.len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().leaves().len(), 1);
 
     // after extension quantities
     let root1 = &state.root_branch.root;
@@ -111,11 +106,8 @@ async fn extensions() {
         .get(&branches1.root_node_id().unwrap())
         .unwrap()
         .data();
-    let root_leaf1 = state
-        .root_branch
-        .leaves
-        .get(branches1.root_node_id().unwrap())
-        .unwrap();
+    let leaves1 = state.root_branch.leaves();
+    let root_leaf1 = leaves1.get(0).unwrap();
 
     // root == leaf
     assert_eq!(root1, &root_leaf1.block);

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -41,7 +41,7 @@ async fn extension() {
     // - leaves = 1
     assert_eq!(state.root_branch.len(), 1);
     assert_eq!(state.root_branch.height(), 1);
-    assert_eq!(state.root_branch.leaves.len(), 1);
+    assert_eq!(state.root_branch.leaves().len(), 1);
 
     // no dangling branches
     assert_eq!(state.dangling_branches.len(), 0);
@@ -72,7 +72,7 @@ async fn extension() {
     // - leaves = 1
     assert_eq!(state.root_branch.len(), 2);
     assert_eq!(state.root_branch.height(), 2);
-    assert_eq!(state.root_branch.leaves.len(), 1);
+    assert_eq!(state.root_branch.leaves().len(), 1);
 
     // no dangling branches
     assert_eq!(state.dangling_branches.len(), 0);
@@ -98,7 +98,7 @@ async fn extension() {
     // - leaves = 2
     assert_eq!(state.root_branch.len(), 3);
     assert_eq!(state.root_branch.height(), 2);
-    assert_eq!(state.root_branch.leaves.len(), 2);
+    assert_eq!(state.root_branch.leaves().len(), 2);
 
     // no dangling branches
     assert_eq!(state.dangling_branches.len(), 0);
@@ -106,7 +106,7 @@ async fn extension() {
     // after extension quantities
     let after_root = &state.root_branch.root;
     let branches1 = &state.root_branch.branches;
-    let leaves1 = &state.root_branch.leaves;
+    let leaves1 = state.root_branch.leaves();
     let after_root_id = branches1.root_node_id().unwrap();
 
     // branch root should match the tree's root
@@ -132,23 +132,29 @@ async fn extension() {
     assert_eq!(after_children.len(), 2);
     println!("After children:\n  {:?}", after_children);
 
-    let after_child1 = after_children.get(0).unwrap();
-    let after_child2 = after_children.get(1).unwrap();
     let after_child1_block = Block::from_precomputed(&child1, 1);
     let after_child2_block = Block::from_precomputed(&child2, 1);
 
     // child1 is a leaf
-    assert_eq!(after_child1_block, leaves1.get(after_child1).unwrap().block);
+    assert!(leaves1
+        .iter()
+        .map(|x| x.block.clone())
+        .collect::<Vec<Block>>()
+        .contains(&after_child1_block));
 
     // child2 is a leaf
-    assert_eq!(after_child2_block, leaves1.get(after_child2).unwrap().block);
+    assert!(leaves1
+        .iter()
+        .map(|x| x.block.clone())
+        .collect::<Vec<Block>>()
+        .contains(&after_child2_block));
 
     println!("=== After Root Branch Leaves ===");
     println!(
         "{:?}",
         leaves1
             .iter()
-            .map(|(_, leaf)| &leaf.block)
+            .map(|leaf| &leaf.block)
             .collect::<Vec<&Block>>()
     );
 
@@ -156,5 +162,9 @@ async fn extension() {
     assert_eq!(&before_root, after_root);
 
     // after root isn't a leaf
-    assert!(!leaves1.contains_key(after_root_id));
+    assert!(!leaves1
+        .iter()
+        .map(|x| x.block.clone())
+        .collect::<Vec<Block>>()
+        .contains(after_root));
 }

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -120,7 +120,7 @@ async fn extensions() {
     state
         .dangling_branches
         .iter()
-        .for_each(|tree| assert_eq!(tree.leaves.len(), 1));
+        .for_each(|tree| assert_eq!(tree.leaves().len(), 1));
 
     // -----------
     // add child 0
@@ -158,9 +158,9 @@ async fn extensions() {
         .enumerate()
         .for_each(|(idx, tree)| {
             if idx == 0 {
-                assert_eq!(tree.leaves.len(), 1)
+                assert_eq!(tree.leaves().len(), 1)
             } else if idx == 1 {
-                assert_eq!(tree.leaves.len(), 2)
+                assert_eq!(tree.leaves().len(), 2)
             }
         });
 
@@ -175,9 +175,9 @@ async fn extensions() {
         .dangling_branches
         .get(1)
         .unwrap()
-        .leaves
+        .leaves()
         .iter()
-        .map(|(_, x)| &x.block)
+        .map(|x| &x.block)
         .collect();
 
     // root1 is not a leaf

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -52,18 +52,8 @@ async fn extension() {
 
     // before extension quantities
     let before_root = state.dangling_branches.get(0).unwrap().root.clone();
-    let before_leaves = state.dangling_branches.get(0).unwrap().leaves.clone();
-    let before_leaf = &before_leaves
-        .get(
-            state
-                .dangling_branches
-                .get(0)
-                .unwrap()
-                .branches
-                .root_node_id()
-                .unwrap(),
-        )
-        .unwrap();
+    let before_leaves = state.dangling_branches.get(0).unwrap().leaves().clone();
+    let before_leaf = before_leaves.get(0).unwrap();
 
     // before_root is the only leaf
     assert_eq!(before_leaves.len(), 1);
@@ -112,7 +102,7 @@ async fn extension() {
     // after extension quantities
     let after_root = &state.dangling_branches.get(0).unwrap().root;
     let branches1 = &state.dangling_branches.get(0).unwrap();
-    let leaves1 = &branches1.leaves;
+    let leaves1 = branches1.leaves();
     let after_root_id = branches1.branches.root_node_id().unwrap();
     let after_root_leaf = {
         let child_ids: Vec<&NodeId> = branches1
@@ -166,5 +156,6 @@ async fn extension() {
     assert_eq!(state.dangling_branches.get(0).unwrap().height(), 2);
 
     // after root isn't a leaf
-    assert!(!leaves1.contains_key(after_root_id));
+    assert_eq!(leaves1.len(), 1);
+    assert_ne!(after_root, &leaves1.get(0).unwrap().block);
 }

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -63,22 +63,24 @@ async fn extension() {
     assert_eq!(extension_type, ExtensionType::DanglingNew);
 
     // before extension quantities
-    let before_branch = state.dangling_branches.get(0).unwrap();
-    let before_root = before_branch.root.clone();
-    let before_leaves = before_branch.leaves.clone();
-    let before_root_leaf = before_branch
-        .leaves
-        .get(before_branch.branches.root_node_id().unwrap())
+    let before_root = state.dangling_branches.get(0).unwrap().root.clone();
+    let before_leaves = state.dangling_branches.get(0).unwrap().leaves().clone();
+    let before_root_leaf = state
+        .dangling_branches
+        .get(0)
+        .unwrap()
+        .leaves()
+        .get(0)
         .unwrap()
         .clone();
 
     assert_eq!(before_leaves.len(), 1);
-    assert_eq!(before_branch.len(), 1);
-    assert_eq!(before_branch.height(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().len(), 1);
+    assert_eq!(state.dangling_branches.get(0).unwrap().height(), 1);
     assert_eq!(before_root, before_root_leaf.block);
 
     println!("=== Before state ===");
-    println!("{:?}", &state);
+    println!("{state:?}");
 
     // extend the branch with new_dangling_root_block (the parent)
     let extension_type = state.add_block(&new_dangling_root_block).unwrap();
@@ -92,7 +94,7 @@ async fn extension() {
     let after_branch = state.dangling_branches.get(0).unwrap();
     let after_root = &after_branch.root;
     let branches1 = &after_branch.branches;
-    let leaves1 = &after_branch.leaves;
+    let leaves1 = &after_branch.leaves();
     let after_root_id = branches1.root_node_id().unwrap();
     let after_root_block = branches1.get(&after_root_id).unwrap().data().clone();
 
@@ -108,12 +110,12 @@ async fn extension() {
         .collect::<Vec<&NodeId>>();
     assert_eq!(after_children.len(), 1);
 
-    let after_child = after_children.get(0).unwrap();
     let after_child_block = Block::from_precomputed(&old_dangling_root_block, 1);
     assert_eq!(
         after_child_block,
-        leaves1
-            .get(after_child)
+        after_branch
+            .leaves()
+            .get(0)
             .expect("There should be a leaf block")
             .block
     );
@@ -123,7 +125,7 @@ async fn extension() {
     assert_eq!(after_root, &after_root_block.block);
 
     // leaf checks
-    let leaves: Vec<&Block> = leaves1.iter().map(|(_, x)| &x.block).collect();
+    let leaves: Vec<&Block> = leaves1.iter().map(|x| &x.block).collect();
     let leaf = leaves.get(0).unwrap();
 
     // height differs, hashes agree


### PR DESCRIPTION
- removes the `leaves` field from the `Branch` struct in favor post order traversals
- adds a timeout to the block receiver test because it was still occasionally hanging
- updates other tests to reflect the `Branch` change