### PR TITLE
Filter canonical blocks on initial ingestion

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -60,7 +60,12 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
     let conn = match LocalSocketStream::connect(SOCKET_NAME).await {
         Ok(conn) => conn,
         Err(e) => {
-            println!("Make sure the server has started!");
+            println!(
+                "Make sure the server has been started and initial block ingestion has completed."
+            );
+            println!(
+                "Initial block ingestion takes several minutes if ingesting all mainnet blocks."
+            );
             println!("Error: {e}");
             process::exit(111);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@ pub mod server;
 pub mod state;
 pub mod store;
 
-pub const SOCKET_NAME: &str = "@mina-indexer.sock";
+pub const BLOCK_REPORTING_FREQ: u32 = 5000;
 pub const MAINNET_CANONICAL_THRESHOLD: u32 = 10;
 pub const MAINNET_GENESIS_HASH: &str = "3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ";
 pub const MAINNET_TRANSITION_FRONTIER_K: u32 = 290;
+pub const PRUNE_INTERVAL_DEFAULT: u32 = 10;
+pub const SOCKET_NAME: &str = "@mina-indexer.sock";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod state;
 pub mod store;
 
 pub const SOCKET_NAME: &str = "@mina-indexer.sock";
-pub const MAINNET_TRANSITION_FRONTIER_K: u32 = 290;
+pub const MAINNET_CANONICAL_THRESHOLD: u32 = 10;
 pub const MAINNET_GENESIS_HASH: &str = "3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ";
+pub const MAINNET_TRANSITION_FRONTIER_K: u32 = 290;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         IndexerMode, IndexerState,
     },
     store::IndexerStore,
-    MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, SOCKET_NAME,
+    MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT, SOCKET_NAME,
 };
 use clap::Parser;
 use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -61,7 +61,7 @@ pub struct ServerArgs {
     #[arg(short, long, default_value_t = false)]
     ignore_db: bool,
     /// Interval for pruning the root branch
-    #[arg(short, long, default_value_t = 2)]
+    #[arg(short, long, default_value_t = PRUNE_INTERVAL_DEFAULT)]
     prune_interval: u32,
 }
 

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -45,17 +45,26 @@ impl Branch {
         }
     }
 
-    pub fn new_testing(precomputed_block: &PrecomputedBlock) -> Self {
-        let root_block = Block::from_precomputed(precomputed_block, 0);
+    pub fn new_non_genesis(root_hash: BlockHash, blockchain_length: Option<u32>) -> Self {
+        let root = Block {
+            state_hash: root_hash.clone(),
+            parent_hash: root_hash,
+            height: 0,
+            blockchain_length,
+        };
         let mut branches = Tree::new();
-        branches
-            .insert(Node::new(root_block.clone()), AsRoot)
-            .unwrap();
 
-        Self {
-            root: root_block,
-            branches,
-        }
+        branches.insert(Node::new(root), AsRoot).unwrap();
+
+        Self { root, branches }
+    }
+
+    pub fn new_testing(precomputed_block: &PrecomputedBlock) -> Self {
+        let root = Block::from_precomputed(precomputed_block, 0);
+        let mut branches = Tree::new();
+        branches.insert(Node::new(root.clone()), AsRoot).unwrap();
+
+        Self { root, branches }
     }
 
     // only the genesis block should work here

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -54,7 +54,7 @@ impl Branch {
         };
         let mut branches = Tree::new();
 
-        branches.insert(Node::new(root), AsRoot).unwrap();
+        branches.insert(Node::new(root.clone()), AsRoot).unwrap();
 
         Self { root, branches }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -120,8 +120,14 @@ impl IndexerState {
         transition_frontier_length: Option<u32>,
         prune_interval: Option<u32>,
     ) -> anyhow::Result<Self> {
-        let root_branch = Branch::new_non_genesis(root_hash, blockchain_length);
-        let indexer_store = rocksdb_path.map(|path| IndexerStore::new(path).unwrap());
+        let root_branch = Branch::new_non_genesis(root_hash.clone(), blockchain_length);
+        let indexer_store = rocksdb_path.map(|path| {
+            let store = IndexerStore::new(path).unwrap();
+            store
+                .add_ledger(&root_hash, ledger)
+                .expect("ledger add succeeds");
+            store
+        });
         Ok(Self {
             mode,
             phase: IndexerPhase::InitializingFromDB,

--- a/tests/block/block_parser.rs
+++ b/tests/block/block_parser.rs
@@ -7,7 +7,7 @@ use tokio::time::Instant;
 async fn representative_bench() {
     let start = Instant::now();
     let sample_dir0 = PathBuf::from("./tests/data/beautified_logs");
-    let mut block_parser0 = BlockParser::new(&sample_dir0).unwrap();
+    let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
     while let Some(precomputed_block) = block_parser0
         .next()
@@ -24,7 +24,7 @@ async fn representative_bench() {
     let start = Instant::now();
     logs_processed = 0;
     let sample_dir1 = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser1 = BlockParser::new(&sample_dir1).unwrap();
+    let mut block_parser1 = BlockParser::new_testing(&sample_dir1).unwrap();
     while let Some(precomputed_block) = block_parser1
         .next()
         .await

--- a/tests/block/store/add_and_get_blocks.rs
+++ b/tests/block/store/add_and_get_blocks.rs
@@ -13,6 +13,7 @@ async fn rocksdb() {
 
     let db = IndexerStore::new(store_dir).unwrap();
     let mut bp = BlockParser::new(log_dir).unwrap();
+
     let mut blocks = HashMap::new();
 
     let mut n = 0;

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[tokio::test]
 async fn extension() {
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     let mut n = 0;
     if let Some(precomputed_block) = block_parser.next().await.unwrap() {

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -10,7 +10,7 @@ use tokio::fs::remove_dir_all;
 async fn test() {
     let block_store_dir = PathBuf::from("./test_block_store");
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -28,7 +28,7 @@ async fn extension() {
     // -----------------------------
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -30,7 +30,7 @@ async fn merge() {
     // --------------------------
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -21,7 +21,7 @@ async fn extension() {
     //       |             =>   leaf   |
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -24,7 +24,7 @@ async fn extensions() {
     // -----------------------
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root0_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root0_block = block_parser

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -17,7 +17,7 @@ async fn extension() {
     // --------------------------------
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // ----------------
     // initialize state

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -17,7 +17,7 @@ async fn extensions() {
     //               => child0  child10  child11
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -13,7 +13,7 @@ async fn extension() {
     //      1
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -16,7 +16,7 @@ async fn extension() {
     //            =>   old
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser

--- a/tests/state/ledger/apply_diff.rs
+++ b/tests/state/ledger/apply_diff.rs
@@ -8,7 +8,7 @@ use mina_indexer::{
 #[tokio::test]
 async fn account_diffs() {
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
     let block = block_parser

--- a/tests/state/ledger/diff_from_precomputed.rs
+++ b/tests/state/ledger/diff_from_precomputed.rs
@@ -14,7 +14,7 @@ use mina_indexer::{
 #[tokio::test]
 async fn account_diffs() {
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
     let block = block_parser

--- a/tests/state/root_branch/prune.rs
+++ b/tests/state/root_branch/prune.rs
@@ -20,7 +20,7 @@ async fn transition_frontier() {
     // 5
 
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
     let root_block = block_parser

--- a/tests/state/root_branch/simple_proper.rs
+++ b/tests/state/root_branch/simple_proper.rs
@@ -13,7 +13,7 @@ async fn extension() {
     // 0 => |
     //      1
     let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new(&log_dir).unwrap();
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // root_block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
     let root_block = block_parser


### PR DESCRIPTION
This PR rethinks our initial ingestion of blocks. Instead of parsing and adding _all_ blocks in the startup dir to the witness tree, we instead _discover the longest canonical chain within these blocks_. Then we only parse and add _canonical_ blocks until we reach the highest canonical block in this directory, at which point we parse and add all successive blocks.

- implements the canonical chain discovery algorithm
- separates canonical and successive block paths in `BlockParser`
- adds `mode` and `phase` to `IndexerState`
  - `mode` dictates whether non-canonical blocks are stored in the db
  - `phase` allows us to change strategies depending on if we are initializing or watching
    - we may want to experiment with a longer `prune_interval` while initializing and a shorter one while watching
    - we may also want to experiment with aggregating ledger diffs and applying them in batches while initializing
- introduces `IndexerState::new_non_genesis()` to aid with our snapshotting efforts
- fixes some CLI flag defaults

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204837873015977