### PR TITLE
Adding slot field global_slot_number to PC block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,6 +1602,7 @@ dependencies = [
  "mina-serialization-types",
  "mina-signer",
  "r2d2",
+ "regex",
  "rocksdb",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ test = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1.4"
 anyhow = {version = "1.0.69"}
 async_executors = { version = "0.6.0", features = ["tokio_tp"] }
 async-trait = "0.1.64"

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -17,6 +17,8 @@ use std::{
 use tokio::io::AsyncReadExt;
 use tracing::{debug, info};
 
+use super::extract_global_slot_number;
+
 pub enum SearchRecursion {
     None,
     Recursive,
@@ -278,10 +280,13 @@ impl BlockParser {
 
             log_file.read_to_end(&mut log_file_contents).await?;
 
+            let global_slot_number = extract_global_slot_number(&String::from_utf8_lossy(&log_file_contents));
+
             let precomputed_block = PrecomputedBlock::from_log_contents(BlockLogContents {
                 state_hash,
                 blockchain_length,
                 contents: log_file_contents,
+                global_slot_number,
             })?;
 
             Ok(Some(precomputed_block))
@@ -336,10 +341,13 @@ impl BlockParser {
 
             log_file.read_to_end(&mut log_file_contents).await?;
 
+            let global_slot_number = extract_global_slot_number(&String::from_utf8_lossy(&log_file_contents));
+
             let precomputed_block = PrecomputedBlock::from_log_contents(BlockLogContents {
                 state_hash,
                 blockchain_length,
                 contents: log_file_contents,
+                global_slot_number,
             })?;
 
             Ok(precomputed_block)

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -17,7 +17,7 @@ use std::{
 use tokio::io::AsyncReadExt;
 use tracing::{debug, info};
 
-use super::extract_global_slot_number;
+use super::extract_global_slot_since_genesis;
 
 pub enum SearchRecursion {
     None,
@@ -280,13 +280,13 @@ impl BlockParser {
 
             log_file.read_to_end(&mut log_file_contents).await?;
 
-            let global_slot_number = extract_global_slot_number(&String::from_utf8_lossy(&log_file_contents));
+            let global_slot_since_genesis = extract_global_slot_since_genesis(&PathBuf::from(path));
 
             let precomputed_block = PrecomputedBlock::from_log_contents(BlockLogContents {
                 state_hash,
                 blockchain_length,
                 contents: log_file_contents,
-                global_slot_number,
+                global_slot_since_genesis,
             })?;
 
             Ok(Some(precomputed_block))
@@ -341,13 +341,13 @@ impl BlockParser {
 
             log_file.read_to_end(&mut log_file_contents).await?;
 
-            let global_slot_number = extract_global_slot_number(&String::from_utf8_lossy(&log_file_contents));
+            let global_slot_since_genesis = extract_global_slot_since_genesis(&PathBuf::from(filename));
 
             let precomputed_block = PrecomputedBlock::from_log_contents(BlockLogContents {
                 state_hash,
                 blockchain_length,
                 contents: log_file_contents,
-                global_slot_number,
+                global_slot_since_genesis,
             })?;
 
             Ok(precomputed_block)

--- a/src/block/precomputed.rs
+++ b/src/block/precomputed.rs
@@ -1,11 +1,13 @@
 use mina_serialization_types::{
-    json::DeltaTransitionChainProofJson,
+    json::{DeltaTransitionChainProofJson},
     protocol_state::{ProtocolState, ProtocolStateJson},
+    consensus_state::{ConsensusState, ConsensusStateJson},
     protocol_state_proof::ProtocolStateProofBase64Json,
     staged_ledger_diff::{
         self, SignedCommandPayloadBody, StagedLedgerDiff, StagedLedgerDiffJson, StakeDelegation,
     },
-    v1::{DeltaTransitionChainProof, ProtocolStateProofV1, PublicKeyV1},
+    v1::{DeltaTransitionChainProof, ProtocolStateProofV1, PublicKeyV1, GlobalSlotNumberV1},
+    common::U32Json,
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,13 +15,14 @@ pub struct BlockLogContents {
     pub(crate) state_hash: String,
     pub(crate) blockchain_length: Option<u32>,
     pub(crate) contents: Vec<u8>,
-    pub(crate) global_slot_number: Option<u32>,
+    pub(crate) global_slot_since_genesis: GlobalSlotNumberV1,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BlockLog {
     scheduled_time: String,
     protocol_state: ProtocolStateJson,
+    consensus_state: ConsensusStateJson,
     protocol_state_proof: ProtocolStateProofBase64Json,
     staged_ledger_diff: StagedLedgerDiffJson,
     delta_transition_chain_proof: DeltaTransitionChainProofJson,
@@ -30,22 +33,24 @@ pub struct PrecomputedBlock {
     pub state_hash: String,
     pub scheduled_time: String,
     pub protocol_state: ProtocolState,
+    pub consensus_state: ConsensusState,
     pub blockchain_length: Option<u32>,
     pub protocol_state_proof: ProtocolStateProofV1,
     pub staged_ledger_diff: StagedLedgerDiff,
     pub delta_transition_chain_proof: DeltaTransitionChainProof,
-    pub global_slot_number: Option<u32>,
+    pub global_slot_since_genesis: U32Json,
 }
 
 impl PrecomputedBlock {
     pub fn from_log_contents(log_contents: BlockLogContents) -> serde_json::Result<Self> {
         let state_hash = log_contents.state_hash;
         let blockchain_length = log_contents.blockchain_length;
-        let global_slot_number = log_contents.global_slot_number;
         let str = String::from_utf8_lossy(&log_contents.contents);
+        let global_slot_since_genesis = log_contents.global_slot_since_genesis;
         let BlockLog {
             scheduled_time,
             protocol_state,
+            consensus_state,
             protocol_state_proof,
             staged_ledger_diff,
             delta_transition_chain_proof,
@@ -55,10 +60,11 @@ impl PrecomputedBlock {
             scheduled_time,
             blockchain_length,
             protocol_state: protocol_state.into(),
+            consensus_state: consensus_state.into(),
             protocol_state_proof: protocol_state_proof.into(),
             staged_ledger_diff: staged_ledger_diff.into(),
             delta_transition_chain_proof: delta_transition_chain_proof.into(),
-            global_slot_number,
+            global_slot_since_genesis: global_slot_since_genesis.into(),
         })
     }
 }

--- a/src/block/precomputed.rs
+++ b/src/block/precomputed.rs
@@ -13,6 +13,7 @@ pub struct BlockLogContents {
     pub(crate) state_hash: String,
     pub(crate) blockchain_length: Option<u32>,
     pub(crate) contents: Vec<u8>,
+    pub(crate) global_slot_number: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -33,12 +34,14 @@ pub struct PrecomputedBlock {
     pub protocol_state_proof: ProtocolStateProofV1,
     pub staged_ledger_diff: StagedLedgerDiff,
     pub delta_transition_chain_proof: DeltaTransitionChainProof,
+    pub global_slot_number: Option<u32>,
 }
 
 impl PrecomputedBlock {
     pub fn from_log_contents(log_contents: BlockLogContents) -> serde_json::Result<Self> {
         let state_hash = log_contents.state_hash;
         let blockchain_length = log_contents.blockchain_length;
+        let global_slot_number = log_contents.global_slot_number;
         let str = String::from_utf8_lossy(&log_contents.contents);
         let BlockLog {
             scheduled_time,
@@ -55,6 +58,7 @@ impl PrecomputedBlock {
             protocol_state_proof: protocol_state_proof.into(),
             staged_ledger_diff: staged_ledger_diff.into(),
             delta_transition_chain_proof: delta_transition_chain_proof.into(),
+            global_slot_number,
         })
     }
 }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -32,6 +32,7 @@ impl Branch {
             parent_hash: root_hash,
             height: 0,
             blockchain_length: Some(1),
+            global_slot_number: Some(1),
         };
         let mut branches = Tree::new();
 
@@ -45,12 +46,13 @@ impl Branch {
         }
     }
 
-    pub fn new_non_genesis(root_hash: BlockHash, blockchain_length: Option<u32>) -> Self {
+    pub fn new_non_genesis(root_hash: BlockHash, blockchain_length: Option<u32>, global_slot_number: Option<u32>) -> Self {
         let root = Block {
             state_hash: root_hash.clone(),
             parent_hash: root_hash,
             height: 0,
             blockchain_length,
+            global_slot_number,
         };
         let mut branches = Tree::new();
 

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -32,7 +32,6 @@ impl Branch {
             parent_hash: root_hash,
             height: 0,
             blockchain_length: Some(1),
-            global_slot_number: Some(1),
         };
         let mut branches = Tree::new();
 
@@ -46,13 +45,15 @@ impl Branch {
         }
     }
 
-    pub fn new_non_genesis(root_hash: BlockHash, blockchain_length: Option<u32>, global_slot_number: Option<u32>) -> Self {
+    pub fn new_non_genesis(
+        root_hash: BlockHash,
+        blockchain_length: Option<u32>,
+    ) -> Self {
         let root = Block {
             state_hash: root_hash.clone(),
             parent_hash: root_hash,
             height: 0,
             blockchain_length,
-            global_slot_number,
         };
         let mut branches = Tree::new();
 

--- a/src/state/ledger/command.rs
+++ b/src/state/ledger/command.rs
@@ -32,7 +32,6 @@ pub enum Command {
 }
 
 impl Command {
-    // i say i say now this is a thiccy
     pub fn from_precomputed_block(precomputed_block: &PrecomputedBlock) -> Vec<Self> {
         precomputed_block
             .staged_ledger_diff

--- a/src/state/ledger/mod.rs
+++ b/src/state/ledger/mod.rs
@@ -113,7 +113,7 @@ impl Ledger {
                 };
                 self.accounts.insert(diff.public_key(), account_after);
             } else {
-                success = Err(anyhow::Error::new(Error::default()));
+                success = Err(anyhow::Error::new(Error));
             }
         });
         success

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -112,6 +112,7 @@ impl IndexerState {
         })
     }
 
+    // 8 arguments here
     #[allow(clippy::too_many_arguments)]
     pub fn new_non_genesis(
         mode: IndexerMode,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -112,6 +112,7 @@ impl IndexerState {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_non_genesis(
         mode: IndexerMode,
         root_hash: BlockHash,
@@ -122,7 +123,8 @@ impl IndexerState {
         prune_interval: Option<u32>,
         global_slot_number: Option<u32>,
     ) -> anyhow::Result<Self> {
-        let root_branch = Branch::new_non_genesis(root_hash.clone(), blockchain_length, global_slot_number);
+        let root_branch =
+            Branch::new_non_genesis(root_hash.clone(), blockchain_length, global_slot_number);
         let indexer_store = rocksdb_path.map(|path| {
             let store = IndexerStore::new(path).unwrap();
             store

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -112,8 +112,6 @@ impl IndexerState {
         })
     }
 
-    // 8 arguments here
-    #[allow(clippy::too_many_arguments)]
     pub fn new_non_genesis(
         mode: IndexerMode,
         root_hash: BlockHash,
@@ -122,10 +120,9 @@ impl IndexerState {
         rocksdb_path: Option<&Path>,
         transition_frontier_length: Option<u32>,
         prune_interval: Option<u32>,
-        global_slot_number: Option<u32>,
     ) -> anyhow::Result<Self> {
         let root_branch =
-            Branch::new_non_genesis(root_hash.clone(), blockchain_length, global_slot_number);
+            Branch::new_non_genesis(root_hash.clone(), blockchain_length);
         let indexer_store = rocksdb_path.map(|path| {
             let store = IndexerStore::new(path).unwrap();
             store

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -120,8 +120,9 @@ impl IndexerState {
         rocksdb_path: Option<&Path>,
         transition_frontier_length: Option<u32>,
         prune_interval: Option<u32>,
+        global_slot_number: Option<u32>,
     ) -> anyhow::Result<Self> {
-        let root_branch = Branch::new_non_genesis(root_hash.clone(), blockchain_length);
+        let root_branch = Branch::new_non_genesis(root_hash.clone(), blockchain_length, global_slot_number);
         let indexer_store = rocksdb_path.map(|path| {
             let store = IndexerStore::new(path).unwrap();
             store


### PR DESCRIPTION
Adding slot field `global_slot_number` to precomputed block (corresponding struct and impl), which corresponds to global_slot_since_genesis. This adds support for staking ledgers (current and next) at epoch boundaries and therefore unblocking that issue. 