### PR TITLE
Short circuit canonical block diffs during bootstrap

### DIFF
--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -26,6 +26,8 @@ pub enum SearchRecursion {
 ///
 /// Traverses canoncial paths first, then successive
 pub struct BlockParser {
+    pub num_canonical: u32,
+    pub total_num_blocks: u32,
     pub blocks_dir: PathBuf,
     pub recursion: SearchRecursion,
     canonical_paths: IntoIter<PathBuf>,
@@ -50,6 +52,8 @@ impl BlockParser {
                 .collect();
 
             Ok(Self {
+                num_canonical: 0,
+                total_num_blocks: paths.len() as u32,
                 blocks_dir,
                 recursion: SearchRecursion::None,
                 canonical_paths: vec![].into_iter(),
@@ -127,6 +131,8 @@ impl BlockParser {
                 if check.is_none() {
                     info!("No canoncial blocks can be confidently found. Adding all blocks to the witness tree.");
                     return Ok(Self {
+                        num_canonical: 0,
+                        total_num_blocks: paths.len() as u32,
                         blocks_dir,
                         recursion,
                         canonical_paths: vec![].into_iter(),
@@ -180,7 +186,7 @@ impl BlockParser {
                 );
 
                 canonical_paths.push(curr_path.clone());
-                info!("Walking the canonical chain back to the beginning, Will report every {BLOCK_REPORTING_FREQ_NUM} blocks found.", );
+                info!("Walking the canonical chain back to the beginning, reporting every {BLOCK_REPORTING_FREQ_NUM} blocks.", );
 
                 let time = Instant::now();
                 let mut count = 1;
@@ -237,6 +243,8 @@ impl BlockParser {
             }
 
             Ok(Self {
+                num_canonical: canonical_paths.len() as u32,
+                total_num_blocks: (canonical_paths.len() + successive_paths.len()) as u32,
                 blocks_dir,
                 recursion,
                 canonical_paths: canonical_paths.into_iter(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -224,7 +224,9 @@ pub async fn run(args: ServerArgs) -> Result<(), anyhow::Error> {
             .initialize_with_contiguous_canonical(&mut block_parser)
             .await?;
     } else {
-        indexer_state.add_blocks(&mut block_parser).await?;
+        indexer_state
+            .initialize_without_contiguous_canonical(&mut block_parser)
+            .await?;
     }
 
     let mut block_receiver = BlockReceiver::new().await?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 use clap::Parser;
 use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use interprocess::local_socket::tokio::{LocalSocketListener, LocalSocketStream};
+use log::trace;
 use std::{path::PathBuf, process};
 use tokio::fs::{self, create_dir_all, metadata};
 use tracing::{debug, error, info, instrument, level_filters::LevelFilter};
@@ -24,10 +25,13 @@ use uuid::Uuid;
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct ServerArgs {
-    /// Path to genesis ledger
+    /// Path to the root ledger (if non-genesis, set --non-genesis-ledger and --root-hash)
     #[arg(short, long)]
-    genesis_ledger: PathBuf,
-    /// Hash of startup ledger
+    ledger: PathBuf,
+    /// Use a non-genesis ledger
+    #[arg(short, long, default_value_t = false)]
+    non_genesis_ledger: bool,
+    /// Hash of the base ledger
     #[arg(
         long,
         default_value = MAINNET_GENESIS_HASH
@@ -43,7 +47,7 @@ pub struct ServerArgs {
     #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/database"))]
     database_dir: PathBuf,
     /// Path to directory for logs
-    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/logs"))]
+    #[arg(long, default_value = concat!(env!("HOME"), "/.mina-indexer/logs"))]
     log_dir: PathBuf,
     /// Only store canonical blocks in the db
     #[arg(short, long, default_value_t = false)]
@@ -66,7 +70,8 @@ pub struct ServerArgs {
 }
 
 pub struct IndexerConfiguration {
-    genesis_ledger: GenesisRoot,
+    ledger: GenesisRoot,
+    non_genesis_ledger: bool,
     root_hash: BlockHash,
     startup_dir: PathBuf,
     watch_dir: PathBuf,
@@ -84,7 +89,9 @@ pub struct IndexerConfiguration {
 pub async fn handle_command_line_arguments(
     args: ServerArgs,
 ) -> anyhow::Result<IndexerConfiguration> {
-    debug!("Parsing server args");
+    trace!("Parsing server args");
+
+    let non_genesis_ledger = args.non_genesis_ledger;
     let root_hash = BlockHash(args.root_hash.to_string());
     let startup_dir = args.startup_dir;
     let watch_dir = args.watch_dir;
@@ -106,25 +113,22 @@ pub async fn handle_command_line_arguments(
     create_dir_if_non_existent(watch_dir.to_str().unwrap()).await;
     create_dir_if_non_existent(log_dir.to_str().unwrap()).await;
 
-    info!(
-        "Parsing genesis ledger file at {}",
-        args.genesis_ledger.display()
-    );
+    info!("Parsing genesis ledger file at {}", args.ledger.display());
 
-    match ledger::genesis::parse_file(&args.genesis_ledger).await {
+    match ledger::genesis::parse_file(&args.ledger).await {
         Err(err) => {
             error!(
                 reason = "Unable to parse genesis ledger",
                 error = err.to_string(),
-                path = &args.genesis_ledger.display().to_string()
+                path = &args.ledger.display().to_string()
             );
             process::exit(100)
         }
-        Ok(genesis_ledger) => {
+        Ok(ledger) => {
             info!("Genesis ledger parsed successfully!");
 
             let mut log_number = 0;
-            let mut log_fname = format!("{}/mina-indexer-0.log", log_dir.display());
+            let mut log_fname = format!("{}/mina-indexer-{}.log", log_dir.display(), log_number);
 
             while tokio::fs::metadata(&log_fname).await.is_ok() {
                 log_number += 1;
@@ -132,7 +136,8 @@ pub async fn handle_command_line_arguments(
             }
 
             Ok(IndexerConfiguration {
-                genesis_ledger,
+                ledger,
+                non_genesis_ledger,
                 root_hash,
                 startup_dir,
                 watch_dir,
@@ -158,7 +163,8 @@ pub async fn run(args: ServerArgs) -> Result<(), anyhow::Error> {
 
     info!("Starting mina-indexer server");
     let IndexerConfiguration {
-        genesis_ledger,
+        ledger,
+        non_genesis_ledger,
         root_hash,
         startup_dir,
         watch_dir,
@@ -199,25 +205,27 @@ pub async fn run(args: ServerArgs) -> Result<(), anyhow::Error> {
         IndexerState::new(
             mode,
             root_hash.clone(),
-            genesis_ledger.ledger,
+            ledger.ledger,
             Some(&database_dir),
             MAINNET_TRANSITION_FRONTIER_K,
             prune_interval,
             canonical_update_threshold,
         )?
     } else {
-        info!("Restoring from db in {}", database_dir.display());
         // if db exists in database_dir, use it's blocks to restore state before reading blocks from startup_dir (or maybe go right to watching)
         // if no db or it doesn't have blocks, use the startup_dir like usual
         IndexerState::new_from_db(&database_dir)?;
-        todo!()
+        todo!("Restoring from db in {}", database_dir.display());
     };
 
-    let init_dir = startup_dir.display().to_string();
-    info!("Ingesting precomputed blocks from {init_dir}");
-
     let mut block_parser = BlockParser::new(&startup_dir)?;
-    indexer_state.add_blocks(&mut block_parser).await?;
+    if ignore_db && !non_genesis_ledger {
+        indexer_state
+            .initialize_with_contiguous_canonical(&mut block_parser)
+            .await?;
+    } else {
+        indexer_state.add_blocks(&mut block_parser).await?;
+    }
 
     let mut block_receiver = BlockReceiver::new().await?;
     block_receiver.load_directory(&watch_dir).await?;

--- a/src/state/ledger/genesis.rs
+++ b/src/state/ledger/genesis.rs
@@ -52,6 +52,12 @@ pub fn string_to_public_key_json(s: String) -> Result<PublicKeyJson, Box<dyn Err
     Ok(pk.into())
 }
 
+impl From<GenesisRoot> for Ledger {
+    fn from(value: GenesisRoot) -> Self {
+        value.ledger.into()
+    }
+}
+
 impl From<GenesisLedger> for Ledger {
     fn from(genesis_ledger: GenesisLedger) -> Ledger {
         let mut accounts = HashMap::new();

--- a/src/state/ledger/mod.rs
+++ b/src/state/ledger/mod.rs
@@ -33,6 +33,11 @@ pub struct Ledger {
     pub accounts: HashMap<PublicKey, Account>,
 }
 
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct NonGenesisLedger {
+    pub ledger: Ledger,
+}
+
 impl Ledger {
     pub fn new() -> Self {
         Ledger {

--- a/tests/block/block_parser.rs
+++ b/tests/block/block_parser.rs
@@ -6,7 +6,7 @@ use tokio::time::Instant;
 #[tokio::test]
 async fn representative_bench() {
     let start = Instant::now();
-    let sample_dir0 = PathBuf::from("./tests/data/beautified_logs");
+    let sample_dir0 = PathBuf::from("./tests/data/block_logs");
     let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
     while let Some(precomputed_block) = block_parser0
@@ -17,7 +17,7 @@ async fn representative_bench() {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }
-    assert_eq!(logs_processed, 23);
+    assert_eq!(logs_processed, block_parser0.total_num_blocks);
     println!("./tests/data/beautified_logs");
     println!("Parse {logs_processed} logs: {:?}\n", start.elapsed());
 
@@ -33,7 +33,7 @@ async fn representative_bench() {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }
-    assert_eq!(logs_processed, 24);
+    assert_eq!(logs_processed, block_parser1.total_num_blocks);
     println!("./tests/data/sequential_blocks");
     println!("Parse {logs_processed} logs: {:?}\n", start.elapsed());
 }


### PR DESCRIPTION
This PR fixes the bootstrap ingestion performance problem
- instead of building the witness tree during bootstrapping, we simply calculate ledger diffs and apply them
- once we're done processing canonical blocks, we switch to building the witness tree