### PR TITLE
Adding slot field global_slot_since_genesis to PC block 

### DIFF
--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -17,6 +17,7 @@ pub struct Block {
     pub state_hash: BlockHash,
     pub height: u32,
     pub blockchain_length: Option<u32>,
+    pub global_slot_since_genesis: u32,
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -24,6 +25,7 @@ pub struct BlockWithoutHeight {
     pub parent_hash: BlockHash,
     pub state_hash: BlockHash,
     pub blockchain_length: Option<u32>,
+    pub global_slot_since_genesis: u32,
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -55,6 +57,17 @@ impl Block {
             parent_hash,
             state_hash,
             height,
+            global_slot_since_genesis: precomputed_block
+                .protocol_state
+                .body
+                .t
+                .t
+                .consensus_state
+                .t
+                .t
+                .global_slot_since_genesis
+                .t
+                .t,
             blockchain_length: precomputed_block.blockchain_length,
         }
     }
@@ -74,6 +87,7 @@ impl From<Block> for BlockWithoutHeight {
         Self {
             parent_hash: value.parent_hash.clone(),
             state_hash: value.state_hash.clone(),
+            global_slot_since_genesis: value.global_slot_since_genesis,
             blockchain_length: value.blockchain_length,
         }
     }
@@ -87,6 +101,17 @@ impl BlockWithoutHeight {
         Self {
             parent_hash,
             state_hash,
+            global_slot_since_genesis: precomputed_block
+                .protocol_state
+                .body
+                .t
+                .t
+                .consensus_state
+                .t
+                .t
+                .global_slot_since_genesis
+                .t
+                .t,
             blockchain_length: precomputed_block.blockchain_length,
         }
     }
@@ -116,9 +141,10 @@ impl std::fmt::Debug for Block {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Block {{ height: {}, len: {}, state: {}, parent: {} }}",
+            "Block {{ height: {}, len: {}, slot: {}, state: {}, parent: {} }}",
             self.height,
             self.blockchain_length.unwrap_or(0),
+            self.global_slot_since_genesis,
             &self.state_hash.0[0..12],
             &self.parent_hash.0[0..12]
         )
@@ -129,8 +155,9 @@ impl std::fmt::Debug for BlockWithoutHeight {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Block {{ len: {}, state: {}, parent: {} }}",
+            "Block {{ len: {}, slot: {}, state: {}, parent: {} }}",
             self.blockchain_length.unwrap_or(0),
+            self.global_slot_since_genesis,
             &self.state_hash.0[0..12],
             &self.parent_hash.0[0..12]
         )

--- a/src/block/precomputed.rs
+++ b/src/block/precomputed.rs
@@ -135,4 +135,17 @@ impl PrecomputedBlock {
 
         public_keys
     }
+
+    pub fn global_slot_since_genesis(&self) -> u32 {
+        self.protocol_state
+            .body
+            .t
+            .t
+            .consensus_state
+            .t
+            .t
+            .global_slot_since_genesis
+            .t
+            .t
+    }
 }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -32,6 +32,7 @@ impl Branch {
             parent_hash: root_hash,
             height: 0,
             blockchain_length: Some(1),
+            global_slot_since_genesis: 0,
         };
         let mut branches = Tree::new();
 
@@ -40,11 +41,16 @@ impl Branch {
         Self { root, branches }
     }
 
-    pub fn new_non_genesis(root_hash: BlockHash, blockchain_length: Option<u32>) -> Self {
+    pub fn new_non_genesis(
+        root_hash: BlockHash,
+        blockchain_length: Option<u32>,
+        global_slot_since_genesis: u32,
+    ) -> Self {
         let root_block = Block {
             state_hash: root_hash.clone(),
             parent_hash: root_hash,
             height: 0,
+            global_slot_since_genesis,
             blockchain_length,
         };
         let mut branches = Tree::new();
@@ -581,7 +587,7 @@ mod leaf_ser_de_tests {
                 Str("block"),
                 Struct {
                     name: "Block",
-                    len: 4,
+                    len: 5,
                 },
                 Str("parent_hash"),
                 NewtypeStruct { name: "BlockHash" },
@@ -594,6 +600,8 @@ mod leaf_ser_de_tests {
                 Str("blockchain_length"),
                 Some,
                 U32(175222),
+                Str("global_slot_since_genesis"),
+                U32(258335),
                 StructEnd,
                 Str("ledger"),
                 Struct {
@@ -632,7 +640,7 @@ mod leaf_ser_de_tests {
                 Str("block"),
                 Struct {
                     name: "Block",
-                    len: 4,
+                    len: 5,
                 },
                 Str("parent_hash"),
                 NewtypeStruct { name: "BlockHash" },
@@ -645,6 +653,8 @@ mod leaf_ser_de_tests {
                 Str("blockchain_length"),
                 Some,
                 U32(175222),
+                Str("global_slot_since_genesis"),
+                U32(258335),
                 StructEnd,
                 Str("ledger"),
                 Struct {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -152,19 +152,24 @@ impl IndexerState {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Creates a new indexer state from a "canonical" ledger
+    #[allow(clippy::too_many_arguments)]
     pub fn new_non_genesis(
         mode: IndexerMode,
         root_hash: BlockHash,
         ledger: Ledger,
         blockchain_length: Option<u32>,
+        global_slot_since_genesis: u32,
         rocksdb_path: Option<&Path>,
         transition_frontier_length: u32,
         prune_interval: u32,
         canonical_update_threshold: u32,
     ) -> anyhow::Result<Self> {
-        let root_branch = Branch::new_non_genesis(root_hash.clone(), blockchain_length);
+        let root_branch = Branch::new_non_genesis(
+            root_hash.clone(),
+            blockchain_length,
+            global_slot_since_genesis,
+        );
         let indexer_store = rocksdb_path.map(|path| {
             let store = IndexerStore::new(path).unwrap();
             store

--- a/tests/block/block_parser.rs
+++ b/tests/block/block_parser.rs
@@ -37,3 +37,20 @@ async fn representative_bench() {
     println!("./tests/data/sequential_blocks");
     println!("Parse {logs_processed} logs: {:?}\n", start.elapsed());
 }
+
+#[tokio::test]
+async fn get_global_slot_since_genesis() {
+    let log_dir = PathBuf::from("./tests/data/sequential_blocks");
+    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
+
+    // block = mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
+    let block = block_parser
+        .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
+        .await
+        .unwrap();
+    assert_eq!(
+        block.state_hash,
+        "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
+    );
+    assert_eq!(block.global_slot_since_genesis(), 155140);
+}


### PR DESCRIPTION
Adding field global_slot_since_genesis to precomputed block (corresponding struct and impl), which is consistent with mina-rs for global_slot_since_genesis. This adds support for staking ledgers (current and next) at epoch boundaries and therefore unblocking that issue. Also, some refactoring of tests and one new test. 