### PR TITLE
feat: index transactions

### DIFF
--- a/src/block/precomputed.rs
+++ b/src/block/precomputed.rs
@@ -5,7 +5,7 @@ use mina_serialization_types::{
     staged_ledger_diff::{
         self, SignedCommandPayloadBody, StagedLedgerDiff, StagedLedgerDiffJson, StakeDelegation,
     },
-    v1::{DeltaTransitionChainProof, ProtocolStateProofV1, PublicKeyV1},
+    v1::{DeltaTransitionChainProof, ProtocolStateProofV1, PublicKeyV1, UserCommandWithStatusV1},
 };
 use serde::{Deserialize, Serialize};
 
@@ -60,6 +60,17 @@ impl PrecomputedBlock {
             staged_ledger_diff: staged_ledger_diff.into(),
             delta_transition_chain_proof: delta_transition_chain_proof.into(),
         })
+    }
+
+    pub fn cmds(&self) -> Vec<UserCommandWithStatusV1> {
+        self.staged_ledger_diff
+            .diff
+            .clone()
+            .inner()
+            .0
+            .inner()
+            .inner()
+            .commands
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -401,6 +401,12 @@ impl IndexerState {
                 ledger.apply_diff(&diff)?;
                 indexer_store.add_block(&precomputed_block)?;
 
+                if let Some(height) = precomputed_block.blockchain_length {
+                    for cmd in precomputed_block.cmds() {
+                        indexer_store.put_tx(height, cmd)?;
+                    }
+                }
+
                 // TODO store ledger at specified cadence, e.g. at epoch boundaries
                 // for now, just store every 1000 blocks
                 if block_count % 1000 == 0 {
@@ -524,6 +530,12 @@ impl IndexerState {
         // add block to the db
         if let Some(indexer_store) = self.indexer_store.as_ref() {
             indexer_store.add_block(precomputed_block)?;
+
+            if let Some(height) = precomputed_block.blockchain_length {
+                for cmd in precomputed_block.cmds() {
+                    indexer_store.put_tx(height, cmd)?;
+                }
+            }
         }
 
         self.blocks_processed += 1;

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 /// Storage Key
-pub struct Key<T>(PhantomData<T>);
+pub struct Key<T>(PhantomData<T>, String);
 
 /// T-{Height}-{Signature} -> Transaction
 /// We use the signature as key until we have a better way to identify transactions (e.g. hash)
@@ -21,8 +21,8 @@ pub struct Key<T>(PhantomData<T>);
 pub struct Transaction;
 
 impl Key<Transaction> {
-    /// Creates a new key for a transaction
-    pub fn new<S>(h: u32, s: S) -> String
+    /// Creates a new key for a transaction as string
+    pub fn str<S>(h: u32, s: S) -> String
     where
         S: Into<String>,
     {
@@ -34,7 +34,7 @@ impl Key<Transaction> {
     where
         S: Into<String>,
     {
-        Self::new(h, s).into_bytes()
+        Self::str(h, s).into_bytes()
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 /// Storage Key
-pub struct Key<T>(PhantomData<T>, String);
+pub struct Key<T>(PhantomData<T>);
 
 /// T-{Height}-{Signature} -> Transaction
 /// We use the signature as key until we have a better way to identify transactions (e.g. hash)

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,8 +5,38 @@ use crate::{
         Canonicity,
     },
 };
+use mina_serialization_types::{staged_ledger_diff::UserCommand, v1::UserCommandWithStatusV1};
 use rocksdb::{ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded};
-use std::path::{Path, PathBuf};
+use std::{
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
+
+/// Storage Key
+pub struct Key<T>(PhantomData<T>);
+
+/// T-{Height}-{Signature} -> Transaction
+/// We use the signature as key until we have a better way to identify transactions (e.g. hash)
+/// The height is padded to 12 digits for sequential iteration
+pub struct Transaction;
+
+impl Key<Transaction> {
+    /// Creates a new key for a transaction
+    pub fn new<S>(h: u32, s: S) -> String
+    where
+        S: Into<String>,
+    {
+        format!("T-{:012}-{}", h, s.into())
+    }
+
+    /// Creates a new key for a transaction as bytes
+    pub fn bytes<S>(h: u32, s: S) -> Vec<u8>
+    where
+        S: Into<String>,
+    {
+        Self::new(h, s).into_bytes()
+    }
+}
 
 #[derive(Debug)]
 pub struct IndexerStore {
@@ -33,7 +63,8 @@ impl IndexerStore {
         cf_opts.set_max_write_buffer_number(16);
         let blocks = ColumnFamilyDescriptor::new("blocks", cf_opts.clone());
         let ledgers = ColumnFamilyDescriptor::new("ledgers", cf_opts.clone());
-        let canonicity = ColumnFamilyDescriptor::new("canonicity", cf_opts);
+        let canonicity = ColumnFamilyDescriptor::new("canonicity", cf_opts.clone());
+        let tx = ColumnFamilyDescriptor::new("tx", cf_opts);
 
         let mut database_opts = rocksdb::Options::default();
         database_opts.create_missing_column_families(true);
@@ -41,7 +72,7 @@ impl IndexerStore {
         let database = rocksdb::DBWithThreadMode::open_cf_descriptors(
             &database_opts,
             path,
-            vec![blocks, ledgers, canonicity],
+            vec![blocks, ledgers, canonicity, tx],
         )?;
         Ok(Self {
             db_path: PathBuf::from(path),
@@ -51,6 +82,23 @@ impl IndexerStore {
 
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    pub fn put_tx(&self, height: u32, tx: UserCommandWithStatusV1) -> anyhow::Result<()> {
+        let cf_handle = self.database.cf_handle("tx").expect("column family exists");
+
+        match tx.clone().inner().data.inner().inner() {
+            UserCommand::SignedCommand(cmd) => {
+                let sig = serde_json::to_string(&cmd.inner().inner().signature)?;
+
+                let key = Key::<Transaction>::bytes(height, sig);
+                let value = bcs::to_bytes(&tx)?;
+
+                self.database.put_cf(&cf_handle, key, value)?;
+
+                Ok(())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Changes

- Adds a `Key` interface
- Adds a `Transaction` interface to act as key variant
- Persists transactions when adding a block

### Notes
The Transaction storage key is structured as follows - `T-{Height}-{Signature}`
We use the signature as unique part of the key until we have a better way to identify transactions (e.g. hash).
The height is padded to 12 digits for sequential iteration.