### PR TITLE
Testing post-balance calculation logic

### DIFF
--- a/src/state/ledger/account.rs
+++ b/src/state/ledger/account.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use super::PublicKey;
 
-#[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash, Serialize, Deserialize,
+)]
 pub struct Amount(pub u64);
 
 #[derive(PartialEq, Eq, Clone, Default, Serialize, Deserialize)]
@@ -26,23 +28,23 @@ impl Account {
         }
     }
 
-    pub fn from_deduction(pre: Self, amount: u64) -> Option<Self> {
-        if amount > pre.balance.0 {
+    pub fn from_deduction(pre: Self, amount: Amount) -> Option<Self> {
+        if amount > pre.balance {
             None
         } else {
             Some(Account {
                 public_key: pre.public_key.clone(),
-                balance: Amount(pre.balance.0 - amount),
+                balance: pre.balance.sub(&amount),
                 nonce: Nonce(pre.nonce.0 + 1),
                 delegate: pre.delegate,
             })
         }
     }
 
-    pub fn from_deposit(pre: Self, amount: u64) -> Self {
+    pub fn from_deposit(pre: Self, amount: Amount) -> Self {
         Account {
             public_key: pre.public_key.clone(),
-            balance: Amount(pre.balance.0 + amount),
+            balance: pre.balance.add(&amount),
             nonce: Nonce(pre.nonce.0 + 1),
             delegate: pre.delegate,
         }

--- a/src/state/ledger/diff/account.rs
+++ b/src/state/ledger/diff/account.rs
@@ -1,15 +1,13 @@
+use crate::{
+    block::precomputed::PrecomputedBlock,
+    state::ledger::{account::Amount, command::Command, PublicKey},
+};
 use mina_serialization_types::{
     staged_ledger_diff::{SignedCommandPayloadCommon, UserCommand},
     v1::PublicKeyV1,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    block::precomputed::PrecomputedBlock,
-    state::ledger::{command::Command, PublicKey},
-};
-
-// add delegations later
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
 pub enum UpdateType {
     Deposit,
@@ -19,7 +17,7 @@ pub enum UpdateType {
 #[derive(PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 pub struct PaymentDiff {
     pub public_key: PublicKey,
-    pub amount: u64,
+    pub amount: Amount,
     pub update_type: UpdateType,
 }
 
@@ -64,7 +62,7 @@ impl AccountDiff {
         } * (1e9 as u64);
         AccountDiff::Payment(PaymentDiff {
             public_key: coinbase_receiver.into(),
-            amount,
+            amount: amount.into(),
             update_type: UpdateType::Deposit,
         })
     }
@@ -113,12 +111,12 @@ impl AccountDiff {
                         vec![
                             AccountDiff::Payment(PaymentDiff {
                                 public_key: fee_payer_pk.into(),
-                                amount: fee.clone().inner().inner(),
+                                amount: fee.clone().inner().inner().into(),
                                 update_type: UpdateType::Deduction,
                             }),
                             AccountDiff::Payment(PaymentDiff {
                                 public_key: coinbase_receiver.clone().into(),
-                                amount: fee.inner().inner(),
+                                amount: fee.inner().inner().into(),
                                 update_type: UpdateType::Deposit,
                             }),
                         ]
@@ -134,7 +132,7 @@ impl std::fmt::Debug for PaymentDiff {
         write!(
             f,
             "{:?} | {:?} | {}",
-            self.public_key, self.update_type, self.amount
+            self.public_key, self.update_type, self.amount.0
         )
     }
 }
@@ -166,6 +164,7 @@ impl std::fmt::Debug for UpdateType {
 #[cfg(test)]
 mod tests {
     use super::{AccountDiff, DelegationDiff, PaymentDiff, UpdateType};
+    use crate::state::ledger::account::Amount;
     use crate::state::ledger::command::{Command, Delegation, Payment};
     use crate::state::ledger::PublicKey;
 
@@ -183,18 +182,18 @@ mod tests {
         let payment_command = Command::Payment(Payment {
             source: source_public_key.into(),
             receiver: receiver_public_key.into(),
-            amount: 536900000000,
+            amount: 536900000000.into(),
         });
 
         let expected_result = vec![
             AccountDiff::Payment(PaymentDiff {
                 public_key: source_public_key_result.into(),
-                amount: 536900000000,
+                amount: 536900000000.into(),
                 update_type: UpdateType::Deduction,
             }),
             AccountDiff::Payment(PaymentDiff {
                 public_key: receiver_public_key_result.into(),
-                amount: 536900000000,
+                amount: 536900000000.into(),
                 update_type: UpdateType::Deposit,
             }),
         ];
@@ -241,7 +240,7 @@ mod tests {
 
         let expected_payment_diff = PaymentDiff {
             public_key: coinbase_receiver.into(),
-            amount: 1440 * (1e9 as u64),
+            amount: Amount(1440 * (1e9 as u64)),
             update_type: UpdateType::Deposit,
         };
         let expected_account_diff = AccountDiff::Payment(expected_payment_diff);
@@ -256,7 +255,7 @@ mod tests {
                 "B62qqmveaSLtpcfNeaF9KsEvLyjsoKvnfaHy4LHyApihPVzR3qDNNEG",
             )
             .unwrap(),
-            amount: 536900000000,
+            amount: 536900000000.into(),
             update_type: UpdateType::Deduction,
         };
         let account_diff = AccountDiff::Payment(payment_diff);

--- a/src/state/ledger/mod.rs
+++ b/src/state/ledger/mod.rs
@@ -311,7 +311,7 @@ mod tests {
         let mut account = Account::empty(public_key.clone());
         account.balance = Amount(10); // Set the balance explicitly
         let mut accounts = HashMap::new();
-        accounts.insert(public_key.clone(), account);
+        accounts.insert(public_key.clone(), account.clone());
         let mut ledger = Ledger { accounts };
 
         let ledger_diff = LedgerDiff {
@@ -327,8 +327,10 @@ mod tests {
             .apply_diff(&ledger_diff)
             .expect("ledger diff application");
 
+        let account_before = account.clone();
         let account_after = ledger.accounts.get(&public_key).expect("account get");
 
+        assert_eq!(account_before.balance, Amount(10)); // with cloning
         assert_eq!(account_after.balance, Amount(11)); // Assert against the balance
     }
 
@@ -343,7 +345,7 @@ mod tests {
         let mut account = Account::empty(public_key.clone());
         account.balance = Amount(20); // Set the balance explicitly
         let mut accounts = HashMap::new();
-        accounts.insert(public_key.clone(), account);
+        accounts.insert(public_key.clone(), account.clone());
         let mut ledger = Ledger { accounts };
 
         let ledger_diff = LedgerDiff {
@@ -358,8 +360,10 @@ mod tests {
             .apply_diff(&ledger_diff)
             .expect("ledger diff application");
 
+        let account_before = account.clone();
         let account_after = ledger.accounts.get(&public_key).expect("account get");
 
+        assert_eq!(account_before.balance, account_after.balance); // with cloning
         assert_eq!(account_after.delegate, Some(delegate_key));
         assert_eq!(account_after.balance, Amount(20)); // Balance should remain unchanged
     }

--- a/src/state/ledger/mod.rs
+++ b/src/state/ledger/mod.rs
@@ -63,7 +63,7 @@ impl Ledger {
                                     pk.clone(),
                                     Account {
                                         public_key: pk,
-                                        balance: Amount(balance),
+                                        balance: balance.into(),
                                         nonce: Nonce(nonce.unwrap_or_default()),
                                         delegate: Some(delegate),
                                     },
@@ -74,7 +74,7 @@ impl Ledger {
                     } else {
                         let acct = Account {
                             public_key: pk.clone(),
-                            balance: Amount(balance),
+                            balance: balance.into(),
                             nonce: Nonce(nonce.unwrap_or_default()),
                             delegate: None,
                         };
@@ -231,7 +231,11 @@ impl std::error::Error for LedgerError {}
 
 impl Amount {
     pub fn add(&self, other: &Amount) -> Amount {
-        Amount(self.0 + other.0)
+        Self(self.0 + other.0)
+    }
+
+    pub fn sub(&self, other: &Amount) -> Amount {
+        Self(self.0 - other.0)
     }
 }
 
@@ -259,19 +263,21 @@ mod tests {
 
     #[test]
     fn apply_diff_payment() {
+        let diff_amount = 1.into();
         let public_key =
             PublicKey::from_address("B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy")
                 .expect("public key creation");
         let account = Account::empty(public_key.clone());
         let mut accounts = HashMap::new();
-        accounts.insert(public_key.clone(), account);
-        let mut ledger = Ledger { accounts };
 
+        accounts.insert(public_key.clone(), account);
+
+        let mut ledger = Ledger { accounts };
         let ledger_diff = LedgerDiff {
             public_keys_seen: vec![],
             account_diffs: vec![AccountDiff::Payment(PaymentDiff {
                 public_key: public_key.clone(),
-                amount: 1,
+                amount: diff_amount,
                 update_type: UpdateType::Deposit,
             })],
         };
@@ -281,8 +287,7 @@ mod tests {
             .expect("ledger diff application");
 
         let account_after = ledger.accounts.get(&public_key).expect("account get");
-
-        assert_eq!(account_after.balance, Amount(1));
+        assert_eq!(account_after.balance, diff_amount);
     }
 
     #[test]
@@ -311,27 +316,30 @@ mod tests {
             .expect("ledger diff application");
 
         let account_after = ledger.accounts.get(&public_key).expect("account get");
-
         assert_eq!(account_after.delegate, Some(delegate_key));
     }
 
     #[test]
     fn apply_diff_payment_with_post_balance() {
+        let diff_amount = 1.into();
         let public_key =
             PublicKey::from_address("B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy")
                 .expect("public key creation");
         let mut account = Account::empty(public_key.clone());
+
         account.balance = Amount(10); // Set the balance explicitly
+
         let account_before = account.clone();
         let mut accounts = HashMap::new();
-        accounts.insert(public_key.clone(), account);
-        let mut ledger = Ledger { accounts };
 
+        accounts.insert(public_key.clone(), account);
+
+        let mut ledger = Ledger { accounts };
         let ledger_diff = LedgerDiff {
             public_keys_seen: vec![],
             account_diffs: vec![AccountDiff::Payment(PaymentDiff {
                 public_key: public_key.clone(),
-                amount: 1, // Pass the underlying value
+                amount: diff_amount,
                 update_type: UpdateType::Deposit,
             })],
         };
@@ -341,15 +349,10 @@ mod tests {
             .expect("ledger diff application");
 
         let account_after = ledger.accounts.get(&public_key).expect("account get");
-
-        if let AccountDiff::Payment(payment_diff) = &ledger_diff.account_diffs[0] {
-            assert_eq!(
-                account_after.balance,
-                account_before.balance.add(&payment_diff.amount.into())
-            );
-        } else {
-            panic!("Expected payment diff");
-        }
+        assert_eq!(
+            account_after.balance,
+            account_before.balance.add(&diff_amount)
+        );
     }
 
     #[test]
@@ -361,11 +364,13 @@ mod tests {
             PublicKey::from_address("B62qmMypEDCchUgPD6RU99gVKXJcY46urKdjbFmG5cYtaVpfKysXTz6")
                 .expect("delegate public key creation");
         let mut account = Account::empty(public_key.clone());
-        account.balance = Amount(20); // Set the balance explicitly
+
+        account.balance = Amount(20);
+
         let mut accounts = HashMap::new();
         accounts.insert(public_key.clone(), account.clone());
-        let mut ledger = Ledger { accounts };
 
+        let mut ledger = Ledger { accounts };
         let ledger_diff = LedgerDiff {
             public_keys_seen: vec![],
             account_diffs: vec![AccountDiff::Delegation(DelegationDiff {
@@ -381,7 +386,7 @@ mod tests {
         let account_before = account.clone();
         let account_after = ledger.accounts.get(&public_key).expect("account get");
 
-        assert_eq!(account_before.balance, account_after.balance); // with cloning
+        assert_eq!(account_before.balance, account_after.balance);
         assert_eq!(account_after.delegate, Some(delegate_key));
     }
 }

--- a/tests/state/ledger/diff_from_precomputed.rs
+++ b/tests/state/ledger/diff_from_precomputed.rs
@@ -68,24 +68,24 @@ async fn account_diffs() {
             }) => {
                 println!("\n* Payment");
                 println!("public_key:  {public_key:?}");
-                println!("amount:      {amount}");
+                println!("amount:      {}", amount.0);
                 println!("update_type: {update_type:?}");
 
                 match update_type {
                     UpdateType::Deduction => {
                         if let Some(balance) = ledger.get_mut(&public_key) {
-                            if amount as i64 > *balance {
+                            if amount.0 as i64 > *balance {
                                 println!("deduction amount exceeded balance");
                                 panic!();
                             }
-                            *balance -= amount as i64;
+                            *balance -= amount.0 as i64;
                         }
                     }
                     UpdateType::Deposit => {
                         if let Some(balance) = ledger.get_mut(&public_key) {
-                            *balance += amount as i64;
+                            *balance += amount.0 as i64;
                         } else {
-                            ledger.insert(public_key, amount as i64);
+                            ledger.insert(public_key, amount.0 as i64);
                         }
                     }
                 }


### PR DESCRIPTION
Adding additional testing where I set the initial balance of the account explicitly before applying the diffs. This allows us to verify that the post-balance calculation logic is working as expected. By explicitly setting the initial balance and applying the diff with a specific amount, we can check if the resulting balance in the ledger matches our expectations. These tests ensure that the ledger takes into account the existing balance of the account when applying the diffs and correctly updates the balance based on the diff type (deposit or deduction). Whereas the previous tests focus on testing the application of account diffs, while the new tests extend the testing to include the verification of balance calculations based on the initial balance and the applied diff.

https://app.asana.com/0/1203669416123378/1204865169394590
