### PR TITLE
Best chain improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,24 @@ Build (install [nix](#about-the-development-environment) first)
 
 ```sh
 nix develop
-nix build '.?submodules=1'
+nix build
 ```
 
-alternatively, you can build with `cargo` inside the nix shell.
+Alternatively, you can build with `cargo` inside the nix shell
+(replace `mina-indexer` by `cargo run --release --bin mina-indexer --` in all following commands).
 
 ### Starting the indexer
 
 For example, from the root of this project, you can start the `mina-indexer` for mainnet via
 
 ```sh
-mina-indexer server -i -l tests/data/genesis_ledgers/mainnet.json -s path/to/your/precomputed/blocks/dir
+mina-indexer server -l tests/data/genesis_ledgers/mainnet.json -s path/to/your/precomputed/blocks/dir
 ```
 
-### Some other useful CLI flags
+### Some useful `server` options
 
 * `--ledger`, `-l`
   * genesis ledger `.json` file to use to initialize the indexer
-* `--ignore-db`, `-i`
-  * determines if the indexer will restore from an existing database
-  * for now, it's required to start without a db
 * `--root-hash`, `-r`
   * state hash of the genesis block
   * defaults to mainnet genesis state hash `3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ`
@@ -70,7 +68,7 @@ mina-indexer server -i -l tests/data/genesis_ledgers/mainnet.json -s path/to/you
   * directory to store the indexer's internal RocksDB database
   * defaults to `$HOME/.mina-indexer/database`
 
-### Some useful client commands
+### Some useful `client` commands
 
 Query data with the `mina-indexer` client (from another terminal window)
 
@@ -79,9 +77,9 @@ Query data with the `mina-indexer` client (from another terminal window)
 mina-indexer client account --public-key PUBLIC_KEY
 ```
 
-* Get the current best chain of block hashes within the root branch
+* Get the current best chain of blocks from the tip, length `NUM`
 ```sh
-mina-indexer client best-chain
+mina-indexer client best-chain --num NUM
 ```
 
 * Dump the best ledger to a file

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Build (install [nix](#about-the-development-environment) first)
 
 ```sh
 nix develop
-nix build
+nix build '.?submodules=1'
 ```
 
 Alternatively, you can build with `cargo` inside the nix shell

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,7 +40,7 @@ pub struct AccountArgs {
 #[command(author, version, about, long_about = None)]
 pub struct ChainArgs {
     /// Number of blocks to include
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = 10)]
     num: usize,
     /// Path to write the best chain (default: stdout)
     #[arg(short, long)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -310,9 +310,9 @@ async fn handle_conn(
             let num = String::from_utf8(data_buffer[..data_buffer.len() - 1].to_vec())?
                 .parse::<usize>()?;
             let mut parent_hash = best_tip.parent_hash;
-            let mut best_chain = vec![db.get_block(&best_tip.state_hash).unwrap().unwrap()];
+            let mut best_chain = vec![db.get_block(&best_tip.state_hash)?.unwrap()];
             for _ in 1..num {
-                let parent_pcb = db.get_block(&parent_hash).unwrap().unwrap();
+                let parent_pcb = db.get_block(&parent_hash)?.unwrap();
                 parent_hash =
                     BlockHash::from_hashv1(parent_pcb.protocol_state.previous_state_hash.clone());
                 best_chain.push(parent_pcb);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     block::{
-        parser::BlockParser, precomputed::PrecomputedBlock, receiver::BlockReceiver,
-        store::BlockStore, BlockHash, BlockWithoutHeight,
+        parser::BlockParser, receiver::BlockReceiver, store::BlockStore, Block, BlockHash,
+        BlockWithoutHeight,
     },
     state::{
         ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
@@ -246,7 +246,7 @@ pub async fn run(
             conn_fut = listener.accept() => {
                 let conn = conn_fut?;
                 info!("Receiving connection");
-                let best_chain = indexer_state.root_branch.longest_chain();
+                let best_tip = indexer_state.best_tip_block().clone();
 
                 let primary_path = database_dir.clone();
                 let mut secondary_path = primary_path.clone();
@@ -260,7 +260,7 @@ pub async fn run(
                 // handle the connection
                 tokio::spawn(async move {
                     debug!("Handling connection");
-                    if let Err(e) = handle_conn(conn, block_store_readonly, best_chain, ledger, summary).await {
+                    if let Err(e) = handle_conn(conn, block_store_readonly, best_tip, ledger, summary).await {
                         error!("Error handling connection: {e}");
                     }
 
@@ -276,7 +276,7 @@ pub async fn run(
 async fn handle_conn(
     conn: LocalSocketStream,
     db: IndexerStore,
-    best_chain: Vec<BlockHash>,
+    best_tip: Block,
     ledger: Ledger,
     summary: SummaryVerbose,
 ) -> Result<(), anyhow::Error> {
@@ -309,12 +309,14 @@ async fn handle_conn(
             let data_buffer = buffers.next().unwrap();
             let num = String::from_utf8(data_buffer[..data_buffer.len() - 1].to_vec())?
                 .parse::<usize>()?;
-            let best_chain: Vec<PrecomputedBlock> = best_chain[..best_chain.len() - 1]
-                .iter()
-                .take(num)
-                .cloned()
-                .map(|state_hash| db.get_block(&state_hash).unwrap().unwrap())
-                .collect();
+            let mut parent_hash = best_tip.parent_hash;
+            let mut best_chain = vec![db.get_block(&best_tip.state_hash).unwrap().unwrap()];
+            for _ in 1..num {
+                let parent_pcb = db.get_block(&parent_hash).unwrap().unwrap();
+                parent_hash =
+                    BlockHash::from_hashv1(parent_pcb.protocol_state.previous_state_hash.clone());
+                best_chain.push(parent_pcb);
+            }
             let bytes = bcs::to_bytes(&best_chain)?;
             writer.write_all(&bytes).await?;
         }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -74,59 +74,6 @@ impl Branch {
         self.branches.height() == 0
     }
 
-    /// Returns the node id of the best tip
-    pub fn best_tip_id(&self) -> NodeId {
-        let mut best_tip_id = self
-            .branches
-            .root_node_id()
-            .expect("branch always has root node")
-            .clone();
-        for node_id in self
-            .branches
-            .traverse_post_order_ids(&best_tip_id)
-            .expect("branch always has root node")
-        {
-            let best_tip = self
-                .branches
-                .get(&best_tip_id)
-                .expect("branch always has root node")
-                .data()
-                .clone();
-            let node = self
-                .branches
-                .get(&node_id)
-                .expect("node_id from iterator")
-                .data()
-                .clone();
-            if best_tip.height > node.height {
-                best_tip_id = node_id.clone();
-            }
-        }
-        best_tip_id
-    }
-
-    /// Returns the node id of the canonical tip, if it exists
-    pub fn canonical_tip_id(&self, canonical_update_threshold: u32) -> Option<NodeId> {
-        let mut generation_removed = 0;
-        let mut canonical_tip_id = self.best_tip_id();
-        for node_id in self
-            .branches
-            .ancestor_ids(&canonical_tip_id)
-            .expect("best tip guaranteed")
-        {
-            canonical_tip_id = node_id.clone();
-            generation_removed += 1;
-            if generation_removed > canonical_update_threshold {
-                break;
-            }
-        }
-        if generation_removed <= canonical_update_threshold {
-            None
-        } else {
-            Some(canonical_tip_id)
-        }
-    }
-
     /// Returns the new node's id in the branch and its data
     pub fn simple_extension(&mut self, block: &PrecomputedBlock) -> Option<(NodeId, Block)> {
         let root_node_id = self

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -6,25 +6,16 @@ use id_tree::{
     RemoveBehavior::{DropChildren, OrphanChildren},
     Tree,
 };
-use serde::ser::SerializeStruct;
-use serde::Serialize;
 use std::collections::HashMap;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Branch {
     pub root: NodeId,
     pub branches: Tree<Block>,
 }
 
-pub type Path = Vec<Block>;
-
-#[derive(Clone)]
-pub struct Leaf<T> {
-    pub block: Block,
-    ledger: T,
-}
-
 impl Branch {
+    /// Creates a new `Branch` from a genesis hash
     pub fn new_genesis(root_hash: BlockHash) -> Self {
         let genesis_block = Block {
             state_hash: root_hash.clone(),
@@ -40,6 +31,7 @@ impl Branch {
         Self { root, branches }
     }
 
+    /// Creates a new `Branch` from an arbitrary starting hash
     pub fn new_non_genesis(
         root_hash: BlockHash,
         blockchain_length: Option<u32>,
@@ -58,6 +50,7 @@ impl Branch {
         Self { root, branches }
     }
 
+    /// Creates a new `Branch` from a `PrecomputedBlock` for testing
     pub fn new_testing(precomputed_block: &PrecomputedBlock) -> Self {
         let root_block = Block::from_precomputed(precomputed_block, 0);
         let mut branches = Tree::new();
@@ -65,14 +58,10 @@ impl Branch {
 
         Self { root, branches }
     }
-
-    // only the genesis block should work here
-    pub fn new_rooted(root_precomputed: &PrecomputedBlock) -> Self {
-        Branch::new(root_precomputed).unwrap()
-    }
 }
 
 impl Branch {
+    /// Creates a new `Branch` from a given `PrecomputedBlock`
     pub fn new(root_precomputed: &PrecomputedBlock) -> anyhow::Result<Self> {
         let root_block = Block::from_precomputed(root_precomputed, 0);
         let mut branches = Tree::new();
@@ -85,7 +74,60 @@ impl Branch {
         self.branches.height() == 0
     }
 
-    /// Returns the new node's id in the branch
+    /// Returns the node id of the best tip
+    pub fn best_tip_id(&self) -> NodeId {
+        let mut best_tip_id = self
+            .branches
+            .root_node_id()
+            .expect("branch always has root node")
+            .clone();
+        for node_id in self
+            .branches
+            .traverse_post_order_ids(&best_tip_id)
+            .expect("branch always has root node")
+        {
+            let best_tip = self
+                .branches
+                .get(&best_tip_id)
+                .expect("branch always has root node")
+                .data()
+                .clone();
+            let node = self
+                .branches
+                .get(&node_id)
+                .expect("node_id from iterator")
+                .data()
+                .clone();
+            if best_tip.height > node.height {
+                best_tip_id = node_id.clone();
+            }
+        }
+        best_tip_id
+    }
+
+    /// Returns the node id of the canonical tip, if it exists
+    pub fn canonical_tip_id(&self, canonical_update_threshold: u32) -> Option<NodeId> {
+        let mut generation_removed = 0;
+        let mut canonical_tip_id = self.best_tip_id();
+        for node_id in self
+            .branches
+            .ancestor_ids(&canonical_tip_id)
+            .expect("best tip guaranteed")
+        {
+            canonical_tip_id = node_id.clone();
+            generation_removed += 1;
+            if generation_removed > canonical_update_threshold {
+                break;
+            }
+        }
+        if generation_removed <= canonical_update_threshold {
+            None
+        } else {
+            Some(canonical_tip_id)
+        }
+    }
+
+    /// Returns the new node's id in the branch and its data
     pub fn simple_extension(&mut self, block: &PrecomputedBlock) -> Option<(NodeId, Block)> {
         let root_node_id = self
             .branches
@@ -193,7 +235,7 @@ impl Branch {
     }
 
     /// Merges two trees:
-    /// incoming is placed under junction_id in self
+    /// the `incoming` tree is placed under `junction_id` in `self`
     ///
     /// Returns the id of the best tip in the merged subtree
     pub fn merge_on(&mut self, junction_id: &NodeId, incoming: &mut Branch) -> Option<NodeId> {
@@ -369,10 +411,12 @@ impl Branch {
         leaves.first().cloned()
     }
 
+    /// Returns the `BlockHash`es of the longest chain in the branch,
+    /// sorted from highest to lowest
     pub fn longest_chain(&self) -> Vec<BlockHash> {
         let mut longest_chain = Vec::new();
         if let Some((node_id, _)) = self.best_tip_with_id() {
-            // push the leaf itself
+            // push the tip itself
             longest_chain.push(
                 self.branches
                     .get(&node_id)
@@ -382,7 +426,7 @@ impl Branch {
                     .clone(),
             );
 
-            // push the leaf's ancestors
+            // push the tip's ancestors
             for node in self.branches.ancestors(&node_id).expect("node_id is valid") {
                 longest_chain.push(node.data().state_hash.clone());
             }
@@ -419,36 +463,8 @@ impl Branch {
     }
 }
 
-impl<T> Leaf<T> {
-    pub fn new(data: Block, ledger: T) -> Self {
-        Self {
-            block: data,
-            ledger,
-        }
-    }
-
-    pub fn get_ledger(&self) -> &T {
-        &self.ledger
-    }
-}
-
-impl<T> Serialize for Leaf<T>
-where
-    T: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("Leaf", 2)?;
-        state.serialize_field("block", &self.block)?;
-        state.serialize_field("ledger", &self.ledger)?;
-        state.end()
-    }
-}
-
 // only display the underlying tree
-impl std::fmt::Debug for Branch {
+impl std::fmt::Display for Branch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut tree = String::new();
         self.branches.write_formatted(&mut tree)?;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -431,6 +431,7 @@ impl IndexerState {
         // now add the successive non-canoical blocks
         self.add_blocks(block_parser, block_count).await
     }
+
     /// Initialize indexer state without contiguous canonical blocks
     pub async fn initialize_without_contiguous_canonical(
         &mut self,
@@ -931,7 +932,7 @@ impl IndexerState {
             num_dangling: self.dangling_branches.len() as u32,
             max_dangling_height,
             max_dangling_length,
-            witness_tree: format!("{self:?}"),
+            witness_tree: format!("{self}"),
         };
 
         SummaryVerbose {
@@ -976,16 +977,16 @@ fn should_report_from_block_count(block_count: u32) -> bool {
     block_count > 0 && block_count % BLOCK_REPORTING_FREQ_NUM == 0
 }
 
-impl std::fmt::Debug for IndexerState {
+impl std::fmt::Display for IndexerState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "=== Root branch ===")?;
-        writeln!(f, "{:?}", self.root_branch)?;
+        writeln!(f, "{}", self.root_branch)?;
 
         if !self.dangling_branches.is_empty() {
             writeln!(f, "=== Dangling branches ===")?;
             for (n, branch) in self.dangling_branches.iter().enumerate() {
                 writeln!(f, "Dangling branch {n}:")?;
-                writeln!(f, "{branch:?}")?;
+                writeln!(f, "{branch}")?;
             }
         }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -34,6 +34,7 @@ pub mod summary;
 /// Rooted forest of precomputed block summaries aka the witness tree
 /// `root_branch` - represents the tree of blocks connecting back to a known ledger state, e.g. genesis
 /// `dangling_branches` - trees of blocks stemming from an unknown ledger state
+#[derive(Debug)]
 pub struct IndexerState {
     /// Indexer mode
     pub mode: IndexerMode,
@@ -428,7 +429,7 @@ impl IndexerState {
             indexer_store.add_ledger(&self.root_branch.root_block().state_hash, ledger.clone())?;
         }
 
-        // now add the successive non-canoical blocks
+        // now add the successive non-canonical blocks
         self.add_blocks(block_parser, block_count).await
     }
 

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -20,7 +20,7 @@ async fn extension() {
             n += 1;
         }
 
-        println!("{state:?}");
+        println!("{state}");
 
         // All 24 blocks are parsed successfully
         println!("Blocks added: {n}");

--- a/tests/state/dangling_branches/add_same_block_twice.rs
+++ b/tests/state/dangling_branches/add_same_block_twice.rs
@@ -48,7 +48,7 @@ async fn test() {
     assert_eq!(extension_type, ExtensionType::DanglingNew);
 
     println!("=== Before state ===");
-    print!("{state:?}");
+    print!("{state}");
 
     println!("Root:     {}", state.root_branch.len());
     println!("Dangling: {}", state.dangling_branches.len());

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -119,7 +119,7 @@ async fn merge() {
         .for_each(|tree| assert_eq!(tree.leaves().len(), 1));
 
     println!("=== Before state ===");
-    println!("{state:?}");
+    println!("{state}");
 
     // ----------------
     // add middle block
@@ -129,7 +129,7 @@ async fn merge() {
     assert_eq!(extension_type, ExtensionType::RootComplex);
 
     println!("=== After state ===");
-    println!("{state:?}");
+    println!("{state}");
 
     // Root branch
     // - len = 4

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -92,7 +92,7 @@ async fn extension() {
         .next()
         .is_none());
 
-    println!("Before state:\n{state:?}");
+    println!("Before state:\n{state}");
 
     // ---------------
     // add child block
@@ -139,7 +139,7 @@ async fn extension() {
             .data()
     );
 
-    println!("After state:\n{state:?}");
+    println!("After state:\n{state}");
 
     assert_eq!(extension, ExtensionType::DanglingSimpleForward);
 

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -80,13 +80,13 @@ async fn extension() {
     assert_eq!(before_root, before_root_leaf);
 
     println!("=== Before state ===");
-    println!("{state:?}");
+    println!("{state}");
 
     // extend the branch with new_dangling_root_block (the parent)
     let extension_type = state.add_block(&new_dangling_root_block).unwrap();
 
     println!("=== After state ===");
-    println!("{:?}", &state);
+    println!("{}", &state);
 
     assert_eq!(extension_type, ExtensionType::DanglingSimpleReverse);
 
@@ -101,7 +101,7 @@ async fn extension() {
     assert_eq!(leaves1.len(), 1);
     assert_eq!(branches1.height(), 2);
     println!("=== After state ===");
-    println!("{:?}", &state);
+    println!("{}", &state);
 
     // after root has one child
     let after_children = branches1


### PR DESCRIPTION
These are commits independent of and cherry-picked from the `snapshot` branch.

- adds a default `--num 10` for the `best-chain` command
- improves the `best-chain` calculation by fetching blocks from the db
- uses `Display` over `Debug` for displaying `IndexerState` and `Branch`
- updates README with correct CLI flags