### PR TITLE
New RocksDB for DelegationTotals-GQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "home"

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -1,0 +1,29 @@
+// RocksDB for DelegationTotals
+use crate::gql::schema::delegations::DelegationTotals;
+use rocksdb::{Options, DB};
+
+pub fn create_delegation_totals_db(path: &str) -> Result<DB, rocksdb::Error> {
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    DB::open(&options, path)
+}
+
+pub fn update_delegation_totals(
+    db: &DB,
+    public_key: &str,
+    epoch: i32,
+    total_delegated: i32,
+    count_delegates: i32,
+) -> Result<(), rocksdb::Error> {
+    // placeholder for update delegation totals function
+    unimplemented!()
+}
+
+pub fn get_delegation_totals_from_db(
+    db: &DB,
+    public_key: &str,
+    epoch: i32,
+) -> Result<Option<DelegationTotals>, rocksdb::Error> {
+    // placeholder for function to retrieve delegation totals
+    unimplemented!()
+}

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -1,5 +1,5 @@
 // RocksDB for DelegationTotals
-use crate::gql::schema::delegations::DelegationTotals;
+use crate::gql::schema::delegations::{DelegationTotals, TotalDelegated};
 use rocksdb::{Options, WriteBatch, DB};
 
 pub fn create_delegation_totals_db(path: &str) -> Result<DB, rocksdb::Error> {
@@ -54,12 +54,12 @@ pub fn get_delegation_totals_from_db(
         let count_delegates_bytes_array: [u8; 4] =
             count_delegates_bytes.as_slice().try_into().unwrap();
 
-        let total_delegated = i32::from_le_bytes(total_delegated_bytes_array);
+        let total_delegated = f64::from_bits(u64::from_le_bytes(total_delegated_bytes[..].try_into().unwrap()));
         let count_delegates = i32::from_le_bytes(count_delegates_bytes_array);
 
         let delegation_totals = DelegationTotals {
-            total_delegated,
             count_delegates,
+            total_delegated: TotalDelegated(total_delegated),
         };
         Ok(Some(delegation_totals))
     } else {

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -12,7 +12,7 @@ pub fn update_delegation_totals(
     db: &DB,
     public_key: &str,
     epoch: i32,
-    total_delegated: i32,
+    total_delegated: TotalDelegated,
     count_delegates: i32,
 ) -> Result<(), rocksdb::Error> {
     let mut batch = WriteBatch::default();
@@ -23,7 +23,7 @@ pub fn update_delegation_totals(
     let count_key = format!("{}_{}_count", public_key, epoch);
     let count_key_bytes = count_key.as_bytes();
 
-    let total_delegated_value = total_delegated.to_le_bytes();
+    let total_delegated_value = total_delegated.0.to_bits().to_le_bytes();
     let count_delegates_value = count_delegates.to_le_bytes();
 
     batch.put(total_key_bytes, total_delegated_value);

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -26,8 +26,8 @@ pub fn update_delegation_totals(
     let total_delegated_value = total_delegated.to_le_bytes();
     let count_delegates_value = count_delegates.to_le_bytes();
 
-    batch.put(&total_key_bytes, &total_delegated_value);
-    batch.put(&count_key_bytes, &count_delegates_value);
+    batch.put(total_key_bytes, total_delegated_value);
+    batch.put(count_key_bytes, count_delegates_value);
 
     db.write(batch)?;
 
@@ -42,8 +42,8 @@ pub fn get_delegation_totals_from_db(
     let combined_key = format!("{}_{}", public_key, epoch);
     let key = combined_key.as_bytes();
 
-    let total_delegated_value = db.get(&key)?;
-    let count_delegates_value = db.get(&key)?;
+    let total_delegated_value = db.get(key)?;
+    let count_delegates_value = db.get(key)?;
 
     if let (Some(total_delegated_bytes), Some(count_delegates_bytes)) = (
         total_delegated_value.as_ref(),

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -54,7 +54,9 @@ pub fn get_delegation_totals_from_db(
         let count_delegates_bytes_array: [u8; 4] =
             count_delegates_bytes.as_slice().try_into().unwrap();
 
-        let total_delegated = f64::from_bits(u64::from_le_bytes(total_delegated_bytes[..].try_into().unwrap()));
+        let total_delegated = f64::from_bits(u64::from_le_bytes(
+            total_delegated_bytes[..].try_into().unwrap(),
+        ));
         let count_delegates = i32::from_le_bytes(count_delegates_bytes_array);
 
         let delegation_totals = DelegationTotals {

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -1,6 +1,6 @@
 // RocksDB for DelegationTotals
 use crate::gql::schema::delegations::DelegationTotals;
-use rocksdb::{Options, DB};
+use rocksdb::{Options, WriteBatch, DB};
 
 pub fn create_delegation_totals_db(path: &str) -> Result<DB, rocksdb::Error> {
     let mut options = Options::default();
@@ -15,8 +15,23 @@ pub fn update_delegation_totals(
     total_delegated: i32,
     count_delegates: i32,
 ) -> Result<(), rocksdb::Error> {
-    // placeholder for update delegation totals function
-    unimplemented!()
+    let mut batch = WriteBatch::default();
+
+    let total_key = format!("{}_{}_total", public_key, epoch);
+    let total_key_bytes = total_key.as_bytes();
+
+    let count_key = format!("{}_{}_count", public_key, epoch);
+    let count_key_bytes = count_key.as_bytes();
+
+    let total_delegated_value = total_delegated.to_le_bytes();
+    let count_delegates_value = count_delegates.to_le_bytes();
+
+    batch.put(&total_key_bytes, &total_delegated_value);
+    batch.put(&count_key_bytes, &count_delegates_value);
+
+    db.write(batch)?;
+
+    Ok(())
 }
 
 pub fn get_delegation_totals_from_db(
@@ -24,6 +39,30 @@ pub fn get_delegation_totals_from_db(
     public_key: &str,
     epoch: i32,
 ) -> Result<Option<DelegationTotals>, rocksdb::Error> {
-    // placeholder for function to retrieve delegation totals
-    unimplemented!()
+    let combined_key = format!("{}_{}", public_key, epoch);
+    let key = combined_key.as_bytes();
+
+    let total_delegated_value = db.get(&key)?;
+    let count_delegates_value = db.get(&key)?;
+
+    if let (Some(total_delegated_bytes), Some(count_delegates_bytes)) = (
+        total_delegated_value.as_ref(),
+        count_delegates_value.as_ref(),
+    ) {
+        let total_delegated_bytes_array: [u8; 4] =
+            total_delegated_bytes.as_slice().try_into().unwrap();
+        let count_delegates_bytes_array: [u8; 4] =
+            count_delegates_bytes.as_slice().try_into().unwrap();
+
+        let total_delegated = i32::from_le_bytes(total_delegated_bytes_array);
+        let count_delegates = i32::from_le_bytes(count_delegates_bytes_array);
+
+        let delegation_totals = DelegationTotals {
+            total_delegated,
+            count_delegates,
+        };
+        Ok(Some(delegation_totals))
+    } else {
+        Ok(None)
+    }
 }

--- a/src/delegation_totals_store.rs
+++ b/src/delegation_totals_store.rs
@@ -49,7 +49,7 @@ pub fn get_delegation_totals_from_db(
         total_delegated_value.as_ref(),
         count_delegates_value.as_ref(),
     ) {
-        let total_delegated_bytes_array: [u8; 4] =
+        let _total_delegated_bytes_array: [u8; 4] =
             total_delegated_bytes.as_slice().try_into().unwrap();
         let count_delegates_bytes_array: [u8; 4] =
             count_delegates_bytes.as_slice().try_into().unwrap();
@@ -65,6 +65,10 @@ pub fn get_delegation_totals_from_db(
         };
         Ok(Some(delegation_totals))
     } else {
-        Ok(None)
+        // default values if delegation totals not found
+        Ok(Some(DelegationTotals {
+            count_delegates: 0,
+            total_delegated: TotalDelegated(0.0),
+        }))
     }
 }

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -13,12 +13,14 @@ use actix_web::Responder;
 use actix_web_lab::respond::Html;
 use juniper::http::graphiql::graphiql_source;
 use juniper::http::GraphQLRequest;
+use rocksdb::DB;
 
+use crate::delegation_totals_store::create_delegation_totals_db;
 use crate::gql::root::Context;
 use crate::store::IndexerStore;
 
 mod root;
-mod schema;
+pub(crate) mod schema;
 
 #[get("/graphql")]
 #[allow(clippy::unused_async)]
@@ -26,22 +28,33 @@ async fn graphql_playground() -> impl Responder {
     Html(graphiql_source("/gql", None))
 }
 
-/// GraphQL endpoint
+// GraphQL endpoint
 #[route("/gql", method = "GET", method = "POST")]
 pub async fn gql(
     db: Data<Arc<IndexerStore>>,
+    delegation_totals_db: Data<Arc<DB>>,
     schema: Data<root::Schema>,
     data: Json<GraphQLRequest>,
 ) -> impl Responder {
-    let ctx = Context::new(db.as_ref().clone());
+    let ctx = Context::new(db.as_ref().clone(), delegation_totals_db.as_ref().clone());
     let res = data.execute(&schema, &ctx).await;
     HttpResponse::Ok().json(res)
 }
 
+// need to fix path to delegation_totals_db
 pub async fn start_gql(db: Arc<IndexerStore>) -> std::io::Result<()> {
+    //placeholder code for path to delegation_totals_db
+    let delegation_totals_db = Arc::new(
+        create_delegation_totals_db("/path/to/delegation_totals_db")
+            .expect("Failed to create delegation totals DB"),
+    );
+
     HttpServer::new(move || {
         App::new()
-            .app_data(Data::new(db.clone()))
+            .app_data(Data::new(Context::new(
+                db.clone(),
+                delegation_totals_db.clone(),
+            )))
             .app_data(Data::new(root::create_schema()))
             .service(gql)
             .service(graphql_playground)

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -62,7 +62,10 @@ pub async fn start_gql(db: Arc<IndexerStore>) -> std::io::Result<()> {
     if let Some(staking_ledger) = staking_ledger {
         for account in staking_ledger.accounts {
             if let Some(delegation_totals) = &account.delegationTotals {
-                total_delegated.0 += delegation_totals.totalDelegated.unwrap_or(TotalDelegated(0.0)).0;
+                total_delegated.0 += delegation_totals
+                    .totalDelegated
+                    .unwrap_or(TotalDelegated(0.0))
+                    .0;
                 count_delegates += delegation_totals.countDelegates.unwrap_or(0);
             }
         }

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -16,6 +16,7 @@ use juniper::http::GraphQLRequest;
 use rocksdb::DB;
 
 use crate::delegation_totals_store::create_delegation_totals_db;
+use crate::delegation_totals_store::update_delegation_totals;
 use crate::gql::root::Context;
 use crate::store::IndexerStore;
 
@@ -50,6 +51,18 @@ pub async fn start_gql(db: Arc<IndexerStore>) -> std::io::Result<()> {
     );
 
     let default_epoch = 1;
+    // delegation totals for the default epoch (1) here
+    let total_delegated = 100; // Placeholder value, replace with actual total_delegated value
+    let count_delegates = 10; // Placeholder value, replace with actual count_delegates value
+
+    update_delegation_totals(
+        &delegation_totals_db,
+        "public_key_here",
+        default_epoch,
+        total_delegated,
+        count_delegates,
+    )
+    .expect("Failed to update delegation totals");
 
     HttpServer::new(move || {
         App::new()

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -21,6 +21,8 @@ use crate::gql::root::Context;
 use crate::gql::root::QueryRoot;
 use crate::store::IndexerStore;
 
+use self::schema::delegations::TotalDelegated;
+
 pub(crate) mod root;
 pub(crate) mod schema;
 
@@ -51,17 +53,16 @@ pub async fn start_gql(db: Arc<IndexerStore>) -> std::io::Result<()> {
             .expect("Failed to create delegation totals DB"),
     );
 
-    let epoch_number = 1; // default epoch set to 1
-    let staking_ledger = QueryRoot::stakingLedgerByEpoch(&ctx, epoch_number);
-
     // delegation totals for the default epoch (1) here
-    let mut total_delegated = 0.0;
+    let epoch_number = 1;
+    let staking_ledger = QueryRoot::stakingLedgerByEpoch(&ctx, epoch_number);
+    let mut total_delegated = TotalDelegated(0.0);
     let mut count_delegates = 0;
 
     if let Some(staking_ledger) = staking_ledger {
         for account in staking_ledger.accounts {
             if let Some(delegation_totals) = &account.delegationTotals {
-                total_delegated += delegation_totals.totalDelegated.unwrap_or(0.0);
+                total_delegated.0 += delegation_totals.totalDelegated.unwrap_or(TotalDelegated(0.0)).0;
                 count_delegates += delegation_totals.countDelegates.unwrap_or(0);
             }
         }

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -49,6 +49,8 @@ pub async fn start_gql(db: Arc<IndexerStore>) -> std::io::Result<()> {
             .expect("Failed to create delegation totals DB"),
     );
 
+    let default_epoch = 1;
+
     HttpServer::new(move || {
         App::new()
             .app_data(Data::new(Context::new(

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -52,7 +52,7 @@ impl QueryRoot {
     }
 
     #[graphql(description = "Get staking ledger by epoch number")]
-    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
+    pub fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
         ctx.db
             .get_by_epoch(epoch_number as u32)
             .unwrap_or(None)

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -5,7 +5,10 @@ use juniper::EmptySubscription;
 use juniper::RootNode;
 use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
 use mina_serialization_types::v1::UserCommandWithStatusV1;
+use rocksdb::DB;
 
+use crate::gql::schema::delegations::get_delegation_totals_from_ctx;
+use crate::gql::schema::delegations::DelegationTotals;
 use crate::gql::schema::Stakes;
 use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
@@ -15,11 +18,15 @@ use crate::store::TransactionKey;
 
 pub struct Context {
     pub db: Arc<IndexerStore>,
+    pub delegation_totals_db: Arc<DB>,
 }
 
 impl Context {
-    pub fn new(db: Arc<IndexerStore>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<IndexerStore>, delegation_totals_db: Arc<DB>) -> Self {
+        Self {
+            db,
+            delegation_totals_db,
+        }
     }
 }
 
@@ -117,6 +124,29 @@ impl QueryRoot {
             .get_by_ledger_hash(&ledger_hash)
             .unwrap_or(None)
             .map(|ledger| Stakes::from_staking_ledger(&ledger))
+    }
+
+    #[graphql(
+        description = "Get delegation totals from delegation_totals_db based on public key and epoch"
+    )]
+    async fn delegationTotals(
+        ctx: &Context,
+        public_key: String,
+        epoch: i32,
+    ) -> Option<DelegationTotals> {
+        // placeholder to get delegations totals from ctx.delegation_totals_store
+        /*
+        let delegation_totals = get_delegation_totals_from_ctx(
+            &ctx.delegation_totals_db,
+            &public_key,
+            epoch,
+        )
+        .await
+        .unwrap_or(None);
+
+        delegation_totals
+         */
+        unimplemented!()
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -106,14 +106,16 @@ impl QueryRoot {
 
     #[graphql(description = "Get staking ledger by epoch number")]
     fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<CamelCasedStakes> {
-        ctx.db.get_by_epoch(epoch_number as u32)
+        ctx.db
+            .get_by_epoch(epoch_number as u32)
             .unwrap_or(None)
             .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
     }
 
     #[graphql(description = "Get staking ledger by ledger hash")]
     fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<CamelCasedStakes> {
-        ctx.db.get_by_ledger_hash(&ledger_hash)
+        ctx.db
+            .get_by_ledger_hash(&ledger_hash)
             .unwrap_or(None)
             .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
     }

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -6,6 +6,7 @@ use juniper::RootNode;
 use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
 use mina_serialization_types::v1::UserCommandWithStatusV1;
 
+use crate::gql::schema::CamelCasedStakes;
 use crate::gql::schema::Stakes;
 use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
@@ -104,23 +105,17 @@ impl QueryRoot {
     }
 
     #[graphql(description = "Get staking ledger by epoch number")]
-    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
-        let ledger = ctx.db.get_by_epoch(epoch_number as u32).unwrap_or(None);
-        if let Some(ledger) = ledger {
-            Some(Stakes::from_staking_ledger(&ledger))
-        } else {
-            None
-        }
+    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<CamelCasedStakes> {
+        ctx.db.get_by_epoch(epoch_number as u32)
+            .unwrap_or(None)
+            .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
     }
 
     #[graphql(description = "Get staking ledger by ledger hash")]
-    fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<Stakes> {
-        let ledger = ctx.db.get_by_ledger_hash(&ledger_hash).unwrap_or(None);
-        if let Some(ledger) = ledger {
-            Some(Stakes::from_staking_ledger(&ledger))
-        } else {
-            None
-        }
+    fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<CamelCasedStakes> {
+        ctx.db.get_by_ledger_hash(&ledger_hash)
+            .unwrap_or(None)
+            .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -6,7 +6,6 @@ use juniper::RootNode;
 use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
 use mina_serialization_types::v1::UserCommandWithStatusV1;
 
-use crate::gql::schema::CamelCasedStakes;
 use crate::gql::schema::Stakes;
 use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
@@ -105,19 +104,19 @@ impl QueryRoot {
     }
 
     #[graphql(description = "Get staking ledger by epoch number")]
-    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<CamelCasedStakes> {
+    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
         ctx.db
             .get_by_epoch(epoch_number as u32)
             .unwrap_or(None)
-            .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
+            .map(|ledger| Stakes::from_staking_ledger(&ledger))
     }
 
     #[graphql(description = "Get staking ledger by ledger hash")]
-    fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<CamelCasedStakes> {
+    fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<Stakes> {
         ctx.db
             .get_by_ledger_hash(&ledger_hash)
             .unwrap_or(None)
-            .map(|ledger| Stakes::from_staking_ledger(&ledger).to_camel_case())
+            .map(|ledger| Stakes::from_staking_ledger(&ledger))
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -53,10 +53,7 @@ impl QueryRoot {
 
     #[graphql(description = "Get staking ledger by epoch number")]
     pub fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
-        ctx.db
-            .get_by_epoch(epoch_number as u32)
-            .unwrap_or(None)
-            .map(|ledger| Stakes::from_staking_ledger(&ledger))
+        staking_ledger_by_epoch(ctx, epoch_number)
     }
 
     #[graphql(description = "Get staking ledger by ledger hash")]
@@ -77,6 +74,13 @@ impl QueryRoot {
     ) -> Option<DelegationTotals> {
         get_delegation_totals_from_ctx(ctx, &public_key, epoch).await
     }
+}
+
+pub fn staking_ledger_by_epoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
+    ctx.db
+        .get_by_epoch(epoch_number as u32)
+        .unwrap_or(None)
+        .map(|ledger| Stakes::from_staking_ledger(&ledger))
 }
 
 pub type Schema = RootNode<'static, QueryRoot, EmptyMutation<Context>, EmptySubscription<Context>>;

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -134,19 +134,7 @@ impl QueryRoot {
         public_key: String,
         epoch: i32,
     ) -> Option<DelegationTotals> {
-        // placeholder to get delegations totals from ctx.delegation_totals_store
-        /*
-        let delegation_totals = get_delegation_totals_from_ctx(
-            &ctx.delegation_totals_db,
-            &public_key,
-            epoch,
-        )
-        .await
-        .unwrap_or(None);
-
-        delegation_totals
-         */
-        unimplemented!()
+        get_delegation_totals_from_ctx(ctx, &public_key, epoch).await
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -6,6 +6,8 @@ use juniper::RootNode;
 use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
 use mina_serialization_types::v1::UserCommandWithStatusV1;
 
+use crate::gql::schema::Stakes;
+use crate::gql::schema::StakesQueryInput;
 use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
 use crate::store::IndexerStore;
@@ -99,6 +101,23 @@ impl QueryRoot {
         }
 
         transactions
+    }
+
+    #[graphql(description = "List of all stakes")]
+    fn stakes(ctx: &Context, query: Option<StakesQueryInput>, limit: Option<i32>) -> Vec<Stakes> {
+        // placeholder below -- work in progress
+        let stakes_data = vec![
+            Stakes {
+                epochNumber: 1,
+                ledgerHash: "ledger_hash_1".to_string(),
+            },
+            Stakes {
+                epochNumber: 2,
+                ledgerHash: "ledger_hash_2".to_string(),
+            },
+        ];
+
+        stakes_data
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use juniper::EmptyMutation;
 use juniper::EmptySubscription;
+use juniper::FieldResult;
 use juniper::RootNode;
-use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
-use mina_serialization_types::v1::UserCommandWithStatusV1;
 use rocksdb::DB;
 
 use crate::gql::schema::delegations::get_delegation_totals_from_ctx;
@@ -16,10 +15,6 @@ use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
 use crate::staking_ledger::staking_ledger_store::StakingLedgerStore;
 use crate::store::IndexerStore;
-use juniper::EmptyMutation;
-use juniper::EmptySubscription;
-use juniper::FieldResult;
-use juniper::RootNode;
 
 pub struct Context {
     pub db: Arc<IndexerStore>,

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -7,9 +7,9 @@ use mina_serialization_types::staged_ledger_diff::UserCommandWithStatusJson;
 use mina_serialization_types::v1::UserCommandWithStatusV1;
 
 use crate::gql::schema::Stakes;
-use crate::gql::schema::StakesQueryInput;
 use crate::gql::schema::Transaction;
 use crate::gql::schema::TransactionQueryInput;
+use crate::staking_ledger::staking_ledger_store::StakingLedgerStore;
 use crate::store::IndexerStore;
 use crate::store::TransactionKey;
 
@@ -103,21 +103,24 @@ impl QueryRoot {
         transactions
     }
 
-    #[graphql(description = "List of all stakes")]
-    fn stakes(ctx: &Context, query: Option<StakesQueryInput>, limit: Option<i32>) -> Vec<Stakes> {
-        // placeholder below -- work in progress
-        let stakes_data = vec![
-            Stakes {
-                epochNumber: 1,
-                ledgerHash: "ledger_hash_1".to_string(),
-            },
-            Stakes {
-                epochNumber: 2,
-                ledgerHash: "ledger_hash_2".to_string(),
-            },
-        ];
+    #[graphql(description = "Get staking ledger by epoch number")]
+    fn stakingLedgerByEpoch(ctx: &Context, epoch_number: i32) -> Option<Stakes> {
+        let ledger = ctx.db.get_by_epoch(epoch_number as u32).unwrap_or(None);
+        if let Some(ledger) = ledger {
+            Some(Stakes::from_staking_ledger(&ledger))
+        } else {
+            None
+        }
+    }
 
-        stakes_data
+    #[graphql(description = "Get staking ledger by ledger hash")]
+    fn stakingLedgerByHash(ctx: &Context, ledger_hash: String) -> Option<Stakes> {
+        let ledger = ctx.db.get_by_ledger_hash(&ledger_hash).unwrap_or(None);
+        if let Some(ledger) = ledger {
+            Some(Stakes::from_staking_ledger(&ledger))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/gql/root.rs
+++ b/src/gql/root.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-
 use juniper::EmptyMutation;
 use juniper::EmptySubscription;
 use juniper::RootNode;

--- a/src/gql/schema/delegations.rs
+++ b/src/gql/schema/delegations.rs
@@ -1,0 +1,40 @@
+use juniper::GraphQLInputObject;
+use serde::{Deserialize, Serialize};
+
+use crate::gql::root::Context;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DelegationTotals {
+    pub total_delegated: i32,
+    pub count_delegates: i32,
+}
+
+#[juniper::graphql_object(Context = Context)]
+#[graphql(description = "Delegation Totals")]
+impl DelegationTotals {
+    #[graphql(description = "Total Delegated")]
+    fn totalDelegated(&self) -> &i32 {
+        &self.total_delegated
+    }
+
+    #[graphql(description = "Count Delegates")]
+    fn countDelegates(&self) -> &i32 {
+        &self.count_delegates
+    }
+}
+
+#[derive(GraphQLInputObject)]
+#[graphql(description = "Delegation Totals query input")]
+pub struct DelegationTotalsQueryInput {
+    pub total_delegated: Option<i32>,
+    pub count_delegates: Option<i32>,
+}
+
+pub async fn get_delegation_totals_from_ctx(
+    ctx: &Context,
+    public_key: &str,
+    epoch: i32,
+) -> Result<Option<DelegationTotals>, rocksdb::Error> {
+    // placeholder to get delegations totals from ctx.delegation_totals_store
+    unimplemented!()
+}

--- a/src/gql/schema/delegations.rs
+++ b/src/gql/schema/delegations.rs
@@ -1,7 +1,7 @@
 use juniper::GraphQLInputObject;
 use serde::{Deserialize, Serialize};
 
-use crate::gql::root::Context;
+use crate::{delegation_totals_store::get_delegation_totals_from_db, gql::root::Context};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DelegationTotals {
@@ -34,7 +34,9 @@ pub async fn get_delegation_totals_from_ctx(
     ctx: &Context,
     public_key: &str,
     epoch: i32,
-) -> Result<Option<DelegationTotals>, rocksdb::Error> {
-    // placeholder to get delegations totals from ctx.delegation_totals_store
-    unimplemented!()
+) -> Option<DelegationTotals> {
+    match get_delegation_totals_from_db(&ctx.delegation_totals_db, public_key, epoch) {
+        Ok(Some(delegation_totals)) => Some(delegation_totals),
+        _ => None,
+    }
 }

--- a/src/gql/schema/delegations.rs
+++ b/src/gql/schema/delegations.rs
@@ -14,10 +14,10 @@ use juniper::GraphQLScalarValue;
 #[derive(Debug, Clone, PartialEq, GraphQLScalarValue, Serialize, Deserialize)]
 pub struct TotalDelegated(pub f64);
 
-// Implement conversion traits for TotalDelegated
-impl Into<f64> for TotalDelegated {
-    fn into(self) -> f64 {
-        self.0
+// Implement traits (conversion and others) for TotalDelegated
+impl From<TotalDelegated> for f64 {
+    fn from(val: TotalDelegated) -> Self {
+        val.0
     }
 }
 
@@ -27,7 +27,6 @@ impl From<f64> for TotalDelegated {
     }
 }
 
-// Implement more traits for TotalDelegated
 impl Eq for TotalDelegated {}
 
 impl Ord for TotalDelegated {

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -3,5 +3,6 @@ pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;
 
+pub(crate) mod delegations;
 mod stakes;
 mod transaction;

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -1,4 +1,7 @@
+pub use crate::gql::schema::stakes::Stakes;
+pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;
 
+mod stakes;
 mod transaction;

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -3,7 +3,6 @@ pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;
 
-
 pub(crate) mod delegations;
 mod stakes;
 pub mod transaction;

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -1,5 +1,6 @@
+pub use crate::gql::schema::stakes::CamelCasedStakes;
+pub use crate::gql::schema::stakes::CamelCasedStakesQueryInput;
 pub use crate::gql::schema::stakes::Stakes;
-pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;
 

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -1,5 +1,5 @@
-pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::stakes::Stakes;
+pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;
 

--- a/src/gql/schema/mod.rs
+++ b/src/gql/schema/mod.rs
@@ -1,5 +1,4 @@
-pub use crate::gql::schema::stakes::CamelCasedStakes;
-pub use crate::gql::schema::stakes::CamelCasedStakesQueryInput;
+pub use crate::gql::schema::stakes::StakesQueryInput;
 pub use crate::gql::schema::stakes::Stakes;
 pub use crate::gql::schema::transaction::Transaction;
 pub use crate::gql::schema::transaction::TransactionQueryInput;

--- a/src/gql/schema/stakes.rs
+++ b/src/gql/schema/stakes.rs
@@ -1,0 +1,39 @@
+use juniper::GraphQLInputObject;
+
+use crate::gql::root::Context;
+
+#[allow(non_snake_case)]
+pub struct Stakes {
+    pub epochNumber: i32,
+    pub ledgerHash: String,
+}
+
+impl Stakes {
+    pub fn new(epoch_number: i32, ledger_hash: String) -> Self {
+        Self {
+            epochNumber: epoch_number,
+            ledgerHash: ledger_hash,
+        }
+    }
+}
+
+#[derive(GraphQLInputObject)]
+#[graphql(description = "Stakes query input")]
+pub struct StakesQueryInput {
+    pub epoch_number: Option<i32>,
+    pub ledger_hash: Option<String>,
+}
+
+#[juniper::graphql_object(Context = Context)]
+#[graphql(description = "Stakes")]
+impl Stakes {
+    #[graphql(description = "Epoch Number")]
+    fn epochNumber(&self) -> &i32 {
+        &self.epochNumber
+    }
+
+    #[graphql(description = "Ledger Hash")]
+    fn ledgerHash(&self) -> &str {
+        &self.ledgerHash
+    }
+}

--- a/src/gql/schema/stakes.rs
+++ b/src/gql/schema/stakes.rs
@@ -1,27 +1,25 @@
 use juniper::GraphQLInputObject;
 
-use crate::gql::root::Context;
+use crate::{
+    gql::root::Context,
+    staking_ledger::{StakingLedger, StakingLedgerAccount},
+};
 
 #[allow(non_snake_case)]
 pub struct Stakes {
     pub epochNumber: i32,
     pub ledgerHash: String,
+    pub accounts: Vec<StakingLedgerAccount>,
 }
 
 impl Stakes {
-    pub fn new(epoch_number: i32, ledger_hash: String) -> Self {
+    pub fn from_staking_ledger(ledger: &StakingLedger) -> Self {
         Self {
-            epochNumber: epoch_number,
-            ledgerHash: ledger_hash,
+            epochNumber: ledger.epochNumber,
+            ledgerHash: ledger.ledgerHash.clone(),
+            accounts: ledger.accounts.clone(),
         }
     }
-}
-
-#[derive(GraphQLInputObject)]
-#[graphql(description = "Stakes query input")]
-pub struct StakesQueryInput {
-    pub epoch_number: Option<i32>,
-    pub ledger_hash: Option<String>,
 }
 
 #[juniper::graphql_object(Context = Context)]
@@ -36,4 +34,11 @@ impl Stakes {
     fn ledgerHash(&self) -> &str {
         &self.ledgerHash
     }
+}
+
+#[derive(GraphQLInputObject)]
+#[graphql(description = "Stakes query input")]
+pub struct StakesQueryInput {
+    pub epoch_number: Option<i32>,
+    pub ledger_hash: Option<String>,
 }

--- a/src/gql/schema/stakes.rs
+++ b/src/gql/schema/stakes.rs
@@ -21,47 +21,25 @@ impl Stakes {
             accounts: ledger.accounts.clone(),
         }
     }
-
-    pub fn to_camel_case(&self) -> CamelCasedStakes {
-        CamelCasedStakes::to_camel_case(self)
-    }
-}
-
-#[allow(non_snake_case)]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CamelCasedStakes {
-    pub epochNumber: i32,
-    pub ledgerHash: String,
-    pub accounts: Vec<StakingLedgerAccount>,
-}
-
-impl CamelCasedStakes {
-    pub fn to_camel_case(ledger: &Stakes) -> CamelCasedStakes {
-        CamelCasedStakes {
-            epochNumber: ledger.epoch_number,
-            ledgerHash: ledger.ledger_hash.clone(),
-            accounts: ledger.accounts.clone(),
-        }
-    }
 }
 
 #[juniper::graphql_object(Context = Context)]
 #[graphql(description = "Stakes")]
-impl CamelCasedStakes {
+impl Stakes {
     #[graphql(description = "Epoch Number")]
     fn epochNumber(&self) -> &i32 {
-        &self.epochNumber
+        &self.epoch_number
     }
 
     #[graphql(description = "Ledger Hash")]
     fn ledgerHash(&self) -> &str {
-        &self.ledgerHash
+        &self.ledger_hash
     }
 }
 
 #[derive(GraphQLInputObject)]
 #[graphql(description = "Stakes query input")]
-pub struct CamelCasedStakesQueryInput {
+pub struct StakesQueryInput {
     pub epoch_number: Option<i32>,
     pub ledger_hash: Option<String>,
 }

--- a/src/gql/schema/stakes.rs
+++ b/src/gql/schema/stakes.rs
@@ -1,22 +1,45 @@
 use juniper::GraphQLInputObject;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     gql::root::Context,
     staking_ledger::{StakingLedger, StakingLedgerAccount},
 };
 
-#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Stakes {
-    pub epochNumber: i32,
-    pub ledgerHash: String,
+    pub epoch_number: i32,
+    pub ledger_hash: String,
     pub accounts: Vec<StakingLedgerAccount>,
 }
 
 impl Stakes {
     pub fn from_staking_ledger(ledger: &StakingLedger) -> Self {
         Self {
-            epochNumber: ledger.epochNumber,
-            ledgerHash: ledger.ledgerHash.clone(),
+            epoch_number: ledger.epoch_number,
+            ledger_hash: ledger.ledger_hash.clone(),
+            accounts: ledger.accounts.clone(),
+        }
+    }
+
+    pub fn to_camel_case(&self) -> CamelCasedStakes {
+        CamelCasedStakes::to_camel_case(self)
+    }
+}
+
+#[allow(non_snake_case)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CamelCasedStakes {
+    pub epochNumber: i32,
+    pub ledgerHash: String,
+    pub accounts: Vec<StakingLedgerAccount>,
+}
+
+impl CamelCasedStakes {
+    pub fn to_camel_case(ledger: &Stakes) -> CamelCasedStakes {
+        CamelCasedStakes {
+            epochNumber: ledger.epoch_number,
+            ledgerHash: ledger.ledger_hash.clone(),
             accounts: ledger.accounts.clone(),
         }
     }
@@ -24,7 +47,7 @@ impl Stakes {
 
 #[juniper::graphql_object(Context = Context)]
 #[graphql(description = "Stakes")]
-impl Stakes {
+impl CamelCasedStakes {
     #[graphql(description = "Epoch Number")]
     fn epochNumber(&self) -> &i32 {
         &self.epochNumber
@@ -38,7 +61,7 @@ impl Stakes {
 
 #[derive(GraphQLInputObject)]
 #[graphql(description = "Stakes query input")]
-pub struct StakesQueryInput {
+pub struct CamelCasedStakesQueryInput {
     pub epoch_number: Option<i32>,
     pub ledger_hash: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod client;
+pub mod delegation_totals_store;
 pub mod gql;
 pub mod server;
 pub mod staking_ledger;

--- a/src/staking_ledger/mod.rs
+++ b/src/staking_ledger/mod.rs
@@ -18,8 +18,8 @@ use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StakingLedger {
-    pub epochNumber: i32,
-    pub ledgerHash: String,
+    pub epoch_number: i32,
+    pub ledger_hash: String,
     pub accounts: Vec<StakingLedgerAccount>,
 }
 

--- a/src/staking_ledger/mod.rs
+++ b/src/staking_ledger/mod.rs
@@ -34,7 +34,8 @@ pub struct StakingLedgerAccount {
     pub pk: String,
     pub balance: NanoMina,
     pub delegate: String,
-    //pub ledger_hash: String,
+    pub epoch_number: i32,
+    pub ledger_hash: String,
     pub nonce: Option<Nonce>, // u32
     pub receipt_chain_hash: String,
     pub token: String, // u32

--- a/src/staking_ledger/mod.rs
+++ b/src/staking_ledger/mod.rs
@@ -17,7 +17,11 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StakingLedger(pub Vec<StakingLedgerAccount>);
+pub struct StakingLedger {
+    pub epochNumber: i32,
+    pub ledgerHash: String,
+    pub accounts: Vec<StakingLedgerAccount>,
+}
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NanoMina(u64);

--- a/src/staking_ledger/mod.rs
+++ b/src/staking_ledger/mod.rs
@@ -16,6 +16,8 @@ use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
 
+use crate::gql::schema::delegations::DelegationTotals;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StakingLedger {
     pub epoch_number: i32,
@@ -40,6 +42,7 @@ pub struct StakingLedgerAccount {
     pub receipt_chain_hash: String,
     pub token: String, // u32
     pub voting_for: String,
+    pub delegation_totals: Option<DelegationTotals>,
 }
 
 impl<'de> Deserialize<'de> for NanoMina {

--- a/src/staking_ledger/staking_ledger_store.rs
+++ b/src/staking_ledger/staking_ledger_store.rs
@@ -3,4 +3,6 @@ use super::StakingLedger;
 pub trait StakingLedgerStore {
     fn add_epoch(&self, epoch: u32, ledger: &StakingLedger) -> anyhow::Result<()>;
     fn get_epoch(&self, ledger_hash: &str) -> anyhow::Result<Option<StakingLedger>>;
+    fn get_by_ledger_hash(&self, ledger_hash: &str) -> anyhow::Result<Option<StakingLedger>>;
+    fn get_by_epoch(&self, epoch_number: u32) -> anyhow::Result<Option<StakingLedger>>;
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,3 +1,4 @@
+// RocksDB for IndexerStore
 use crate::{
     block::{precomputed::PrecomputedBlock, store::BlockStore, BlockHash},
     staking_ledger::{staking_ledger_store::StakingLedgerStore, StakingLedger},


### PR DESCRIPTION
With these changes, we have a separate RocksDB database specifically designed to store delegation totals. This approach provides a clean separation of concerns, ensuring efficient retrieval of delegation totals for specific public keys and epochs without interfering with other blockchain-related data in the existing IndexerStore. Work in progress.