### PR TITLE
feat: Add logical operators to transactions query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "home"

--- a/src/gql/schema/transaction.rs
+++ b/src/gql/schema/transaction.rs
@@ -130,7 +130,7 @@ impl TransactionQueryInput {
 
         if let Some(ref query) = self.or {
             if !query.is_empty() {
-                matches = query.iter().any(|or| or.matches(transaction));
+                matches = matches && query.iter().any(|or| or.matches(transaction));
             }
         }
 


### PR DESCRIPTION
## Changes
This PR adds support for the `AND` / `OR` operators on the transactions query, as well as DateTime filtering.


## Testing
Run the following query in GraphiQL:
```gql
query Transactions {
  transactions(limit: 10000, query: {canonical: true, OR: [{memo: "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH"}, {memo: "E4YvxPhU2fXZvSLeTBN7tZVrA2FmxyqWfxr6eXJfpdgQ4VLQuW7Ub"}], dateTime_gte: "2022-01-01T00:00:00Z", dateTime_lte: "2022-12-31T00:00:00Z"}, sortBy: NONCE_DESC) {
    memo
    canonical
    from
    to
    blockHeight
    dateTime
  }
}
