### PR TITLE
WIP Transaction hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bin-prot"
+version = "0.1.0"
+source = "git+https://github.com/ChainSafe/mina-rs?rev=0b4883170505cadad2edc2d041330b2433f762fa#0b4883170505cadad2edc2d041330b2433f762fa"
+dependencies = [
+ "byteorder",
+ "num",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "sha2 0.10.7",
+ "tinyvec",
 ]
 
 [[package]]
@@ -2374,6 +2395,9 @@ dependencies = [
  "async-trait",
  "async_executors",
  "bcs",
+ "bin-prot 0.1.0 (git+https://github.com/ChainSafe/mina-rs?rev=0b4883170505cadad2edc2d041330b2433f762fa)",
+ "blake2",
+ "bs58 0.5.0",
  "bytesize",
  "chrono",
  "clap",
@@ -2427,8 +2451,8 @@ name = "mina-serialization-types"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
- "bin-prot",
- "bs58",
+ "bin-prot 0.1.0",
+ "bs58 0.4.0",
  "derive_more",
  "hex",
  "mina-serialization-types-macros",
@@ -2458,7 +2482,7 @@ dependencies = [
  "ark-ff",
  "bitvec",
  "blake2",
- "bs58",
+ "bs58 0.4.0",
  "hex",
  "mina-curves",
  "mina-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+bin-prot = {git = "https://github.com/ChainSafe/mina-rs", rev = "0b4883170505cadad2edc2d041330b2433f762fa"}
+
 actix-web = "4.3.1"
 actix-web-lab = "0.19.1"
 actix-cors = "0.6.4"
@@ -57,6 +60,8 @@ tracing-subscriber = "0.3.17"
 bytesize = "1.2.0"
 rust_decimal = "1.30.0"
 rust_decimal_macros = "1.30"
+bs58 = { version = "0.5.0", features = ["check"] }
+blake2 = "0.10.6"
 
 [dependencies.tokio]
 version = "1.25.0"

--- a/src/block/signed_command.rs
+++ b/src/block/signed_command.rs
@@ -1,13 +1,14 @@
+use crate::state::ledger::{command::UserCommandWithStatus, public_key::PublicKey};
+use blake2::digest::VariableOutput;
 use mina_serialization_types::staged_ledger_diff::{SignedCommandPayload, UserCommand};
+use std::io::Write;
 use versioned::Versioned;
 
-use crate::state::ledger::{command::UserCommandWithStatus, public_key::PublicKey};
-
-pub struct SignedCommand(mina_serialization_types::staged_ledger_diff::SignedCommand);
+pub struct SignedCommand(mina_serialization_types::staged_ledger_diff::SignedCommandV1);
 
 impl SignedCommand {
     pub fn payload(&self) -> &SignedCommandPayload {
-        &self.0.payload.t.t
+        &self.0.t.t.payload.t.t
     }
 
     pub fn from_user_command(uc: UserCommandWithStatus) -> Self {
@@ -17,15 +18,27 @@ impl SignedCommand {
     }
 
     pub fn source_nonce(&self) -> i32 {
-        self.0.payload.t.t.common.t.t.t.nonce.t.t
+        self.0.t.t.payload.t.t.common.t.t.t.nonce.t.t
     }
 
     pub fn fee_payer(&self) -> PublicKey {
-        self.0.payload.t.t.common.t.t.t.fee_payer_pk.clone().into()
+        self.0
+            .t
+            .t
+            .payload
+            .t
+            .t
+            .common
+            .t
+            .t
+            .t
+            .fee_payer_pk
+            .clone()
+            .into()
     }
 
     pub fn receiver_pk(&self) -> PublicKey {
-        match self.0.payload.t.t.body.t.t.clone() {
+        match self.0.t.t.payload.t.t.body.t.t.clone() {
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::PaymentPayload(payment_payload)
                 => payment_payload.t.t.receiver_pk.into(),
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::StakeDelegation(delegation_payload)
@@ -37,7 +50,7 @@ impl SignedCommand {
     }
 
     pub fn source_pk(&self) -> PublicKey {
-        match self.0.payload.t.t.body.t.t.clone() {
+        match self.0.t.t.payload.t.t.body.t.t.clone() {
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::PaymentPayload(payment_payload)
                 => payment_payload.t.t.source_pk.into(),
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::StakeDelegation(delegation_payload)
@@ -49,12 +62,30 @@ impl SignedCommand {
     }
 
     pub fn is_delegation(&self) -> bool {
-        match self.0.payload.t.t.body.t.t.clone() {
+        match self.0.t.t.payload.t.t.body.t.t.clone() {
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::PaymentPayload(_payment_payload)
                 => false,
             mina_serialization_types::staged_ledger_diff::SignedCommandPayloadBody::StakeDelegation(_delegation_payload)
                 => true,
         }
+    }
+
+    pub fn hash_signed_command(&self) -> anyhow::Result<String> {
+        let mut binprot_bytes = Vec::new();
+        bin_prot::to_writer(&mut binprot_bytes, &self.0).map_err(anyhow::Error::from)?;
+
+        let binprot_bytes_bs58 = bs58::encode(&binprot_bytes[..])
+            .with_check_version(0x13)
+            .into_string();
+        let mut hasher = blake2::Blake2bVar::new(32).unwrap();
+
+        hasher.write_all(binprot_bytes_bs58.as_bytes()).unwrap();
+
+        let mut hash = hasher.finalize_boxed().to_vec();
+        hash.insert(0, hash.len() as u8);
+        hash.insert(0, 1);
+
+        Ok(bs58::encode(hash).with_check_version(0x12).into_string())
     }
 }
 
@@ -67,6 +98,40 @@ impl From<Versioned<Versioned<mina_serialization_types::staged_ledger_diff::Sign
             1,
         >,
     ) -> Self {
-        SignedCommand(value.t.t)
+        SignedCommand(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SignedCommand;
+    use crate::block::parse_file;
+    use mina_serialization_types::staged_ledger_diff::UserCommand;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn transaction_hash() {
+        // refer to the hashes on Minascan
+        // https://minascan.io/mainnet/tx/CkpZDcqGWQVpckXjcg99hh4EzmCrnPzMM8VzHaLAYxPU5tMubuLaj
+        // https://minascan.io/mainnet/tx/CkpZZsSm9hQpGkGzMi8rcsQEWPZwGJXktiqGYADNwLoBeeamhzqnX
+
+        let block_file = PathBuf::from("./tests/data/sequential_blocks/mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json");
+        let precomputed_block = parse_file(&block_file).await.unwrap();
+        let commands = precomputed_block.commands();
+        let hashes: Vec<String> = commands
+            .iter()
+            .map(|commandv1| {
+                let UserCommand::SignedCommand(signed_commandv1) = commandv1.t.data.t.t.clone();
+                SignedCommand(signed_commandv1)
+                    .hash_signed_command()
+                    .unwrap()
+            })
+            .collect();
+        let expect = vec![
+            "CkpZZsSm9hQpGkGzMi8rcsQEWPZwGJXktiqGYADNwLoBeeamhzqnX".to_string(),
+            "CkpZDcqGWQVpckXjcg99hh4EzmCrnPzMM8VzHaLAYxPU5tMubuLaj".to_string(),
+        ];
+
+        assert_eq!(hashes, expect);
     }
 }


### PR DESCRIPTION
Follows ChainSafe's [signed command hash](https://github.com/ChainSafe/mina-signer-wasm/blob/48286bd00d0e62d8a2783194dbc5c73b7f73e516/src/client.rs#L292)

- makes `SignedCommand` a wrapper around mina-rs's `SignedCommandV1`
- adds transaction/signed command hash
- adds unit test