### PR TITLE
Mainnet test logging and filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub fn display_duration(duration: std::time::Duration) -> String {
     if duration_as_mins < 2. {
         format!("{duration:?}")
     } else if duration_as_hrs < 2. {
-        format!("{duration_as_mins} min")
+        format!("{duration_as_mins}min")
     } else {
-        format!("{duration_as_hrs} hr")
+        format!("{duration_as_hrs}hr")
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -172,7 +172,6 @@ pub async fn run(
     } = config;
 
     let database_dir = PathBuf::from(indexer_store.db_path());
-
     let mode = if keep_noncanonical_blocks {
         IndexerMode::Full
     } else {


### PR DESCRIPTION
- fixes `std::time::Duration` display error
- adds logging and block length filtering to the `mainnet-test` binary