### PR TITLE
Delete existing RocksDB dir

### DIFF
--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -4,7 +4,8 @@ use mina_indexer::{
     server::{self, create_dir_if_non_existent, handle_command_line_arguments},
     store::IndexerStore,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc};
+use tracing::debug;
 use tracing_subscriber::prelude::*;
 
 #[derive(Parser, Debug)]
@@ -65,6 +66,10 @@ pub async fn main() -> anyhow::Result<()> {
                 let indexer_store = IndexerStore::from_backup(&snapshot_path, &database_dir)?;
                 Arc::new(indexer_store)
             } else {
+                if database_dir.exists() {
+                    debug!("Deleting the existing db and creating a fresh one just for you!");
+                    fs::remove_dir_all(database_dir.clone())?;
+                }
                 Arc::new(IndexerStore::new(&database_dir)?)
             };
             tokio::spawn(server::run(config, db.clone()));


### PR DESCRIPTION
Adds functionality to `mina-indexer` to delete the database dir and create a new on if it exists

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205196244475473