### PR TITLE
Server Testability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.3.6",
  "serde",
 ]
 
@@ -1561,6 +1561,19 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -2314,6 +2327,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2348,15 @@ checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2444,6 +2480,7 @@ dependencies = [
  "log",
  "mina-serialization-types",
  "mina-signer",
+ "oneshot",
  "r2d2",
  "rocksdb",
  "rust_decimal",
@@ -2755,6 +2792,15 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oneshot"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc22d22931513428ea6cc089e942d38600e3d00976eef8c86de6b8a3aadec6eb"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -3131,8 +3177,17 @@ checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3143,8 +3198,14 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3279,6 +3340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3368,12 @@ checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3887,10 +3960,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -1904,6 +1905,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "home"
@@ -2412,6 +2416,7 @@ name = "mina-indexer"
 version = "0.1.1"
 dependencies = [
  "actix-cors",
+ "actix-rt",
  "actix-web",
  "actix-web-lab",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ ctrlc = "3.4.0"
 serde_yaml = "0.9.25"
 data-encoding = "2.4.0"
 actix-rt = "2.8.0"
+oneshot = "0.1.5"
 
 [dependencies.tokio]
 version = "1.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ async-ringbuf = "0.1.3"
 ctrlc = "3.4.0"
 serde_yaml = "0.9.25"
 data-encoding = "2.4.0"
+actix-rt = "2.8.0"
 
 [dependencies.tokio]
 version = "1.25.0"

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -1,11 +1,15 @@
 use clap::{Parser, Subcommand};
 use mina_indexer::{
+    MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT, CANONICAL_UPDATE_THRESHOLD,
     client,
-    server::{self, create_dir_if_non_existent, handle_command_line_arguments, MinaIndexer},
-    store::IndexerStore,
+    server::{create_dir_if_non_existent, MinaIndexer, IndexerConfiguration},
+    store::IndexerStore, block::BlockHash, state::ledger,
 };
+use serde::Deserializer;
+use serde_derive::Deserialize;
+use tracing::{trace, instrument, info, error};
 use std::{path::PathBuf, sync::Arc};
-use tracing_subscriber::prelude::*;
+use tracing_subscriber::{prelude::*, filter::LevelFilter};
 
 #[derive(Parser, Debug)]
 #[command(name = "mina-indexer", author, version, about, long_about = Some("Mina Indexer\n\n\
@@ -40,7 +44,56 @@ enum ServerCommand {
         path: PathBuf,
     },
     /// Start the mina indexer by passing in arguments manually on the command line
-    Cli(server::ServerArgs),
+    Cli(ServerArgs),
+}
+
+#[derive(Parser, Debug, Clone, Deserialize)]
+#[command(author, version, about, long_about = None)]
+pub struct ServerArgs {
+    /// Path to the root ledger (if non-genesis, set --non-genesis-ledger and --root-hash)
+    #[arg(short, long)]
+    ledger: PathBuf,
+    /// Use a non-genesis ledger
+    #[arg(short, long, default_value_t = false)]
+    non_genesis_ledger: bool,
+    /// Hash of the base ledger
+    #[arg(
+        long,
+        default_value = MAINNET_GENESIS_HASH
+    )]
+    root_hash: String,
+    /// Path to startup blocks directory
+    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/startup-blocks"))]
+    startup_dir: PathBuf,
+    /// Path to directory to watch for new blocks
+    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/watch-blocks"))]
+    watch_dir: PathBuf,
+    /// Path to directory for rocksdb
+    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/database"))]
+    pub database_dir: PathBuf,
+    /// Path to directory for logs
+    #[arg(long, default_value = concat!(env!("HOME"), "/.mina-indexer/logs"))]
+    pub log_dir: PathBuf,
+    /// Only store canonical blocks in the db
+    #[arg(short, long, default_value_t = false)]
+    keep_non_canonical_blocks: bool,
+    /// Max file log level
+    #[serde(deserialize_with = "level_filter_deserializer")]
+    #[arg(long, default_value_t = LevelFilter::DEBUG)]
+    pub log_level: LevelFilter,
+    /// Max stdout log level
+    #[serde(deserialize_with = "level_filter_deserializer")]
+    #[arg(long, default_value_t = LevelFilter::INFO)]
+    pub log_level_stdout: LevelFilter,
+    /// Interval for pruning the root branch
+    #[arg(short, long, default_value_t = PRUNE_INTERVAL_DEFAULT)]
+    prune_interval: u32,
+    /// Threshold for updating the canonical tip/ledger
+    #[arg(short, long, default_value_t = CANONICAL_UPDATE_THRESHOLD)]
+    canonical_update_threshold: u32,
+    /// Path to an indexer snapshot
+    #[arg(long)]
+    pub snapshot_path: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -97,4 +150,96 @@ pub async fn main() -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+#[instrument(skip_all)]
+pub async fn handle_command_line_arguments(
+    args: ServerArgs,
+) -> anyhow::Result<IndexerConfiguration> {
+    trace!("Parsing server args");
+
+    let ledger = args.ledger;
+    let non_genesis_ledger = args.non_genesis_ledger;
+    let root_hash = BlockHash(args.root_hash.to_string());
+    let startup_dir = args.startup_dir;
+    let watch_dir = args.watch_dir;
+    let keep_noncanonical_blocks = args.keep_non_canonical_blocks;
+    let prune_interval = args.prune_interval;
+    let canonical_update_threshold = args.canonical_update_threshold;
+
+    assert!(
+        ledger.is_file(),
+        "Ledger file does not exist at {}",
+        ledger.display()
+    );
+    assert!(
+        // bad things happen if this condition fails
+        canonical_update_threshold < MAINNET_TRANSITION_FRONTIER_K,
+        "canonical update threshold must be strictly less than the transition frontier length!"
+    );
+
+    create_dir_if_non_existent(watch_dir.to_str().unwrap()).await;
+
+    info!("Parsing ledger file at {}", ledger.display());
+
+    match ledger::genesis::parse_file(&ledger).await {
+        Err(err) => {
+            error!(
+                reason = "Unable to parse ledger",
+                error = err.to_string(),
+                path = &ledger.display().to_string()
+            );
+            std::process::exit(100)
+        }
+        Ok(ledger) => {
+            info!("Ledger parsed successfully!");
+
+            Ok(IndexerConfiguration {
+                ledger,
+                non_genesis_ledger,
+                root_hash,
+                startup_dir,
+                watch_dir,
+                keep_noncanonical_blocks,
+                prune_interval,
+                canonical_update_threshold,
+                from_snapshot: args.snapshot_path.is_some(),
+            })
+        }
+    }
+}
+
+pub fn level_filter_deserializer<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct YAMLStringVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for YAMLStringVisitor {
+        type Value = LevelFilter;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string containing yaml data")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            // unfortunately we lose some typed information
+            // from errors deserializing the json string
+            let level_filter_str: &str = serde_yaml::from_str(v).map_err(E::custom)?;
+            match level_filter_str {
+                "info" => Ok(LevelFilter::INFO),
+                "debug" => Ok(LevelFilter::DEBUG),
+                "error" => Ok(LevelFilter::ERROR),
+                "trace" => Ok(LevelFilter::TRACE),
+                "warn" => Ok(LevelFilter::TRACE),
+                "off" => Ok(LevelFilter::OFF),
+                other => Err(E::custom(format!("{} is not a valid level filter", other))),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(YAMLStringVisitor)
 }

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use mina_indexer::{
     client,
-    server::{self, create_dir_if_non_existent, handle_command_line_arguments},
+    server::{self, create_dir_if_non_existent, handle_command_line_arguments, MinaIndexer},
     store::IndexerStore,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -91,7 +91,8 @@ pub async fn main() -> anyhow::Result<()> {
             } else {
                 Arc::new(IndexerStore::new(&database_dir)?)
             };
-            tokio::spawn(server::run(config, db.clone()));
+
+            MinaIndexer::new(config, db.clone()).await?;
             mina_indexer::gql::start_gql(db).await.unwrap();
             Ok(())
         }

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -1,15 +1,18 @@
 use clap::{Parser, Subcommand};
 use mina_indexer::{
-    MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT, CANONICAL_UPDATE_THRESHOLD,
+    block::BlockHash,
     client,
-    server::{create_dir_if_non_existent, MinaIndexer, IndexerConfiguration},
-    store::IndexerStore, block::BlockHash, state::ledger,
+    server::{create_dir_if_non_existent, IndexerConfiguration, MinaIndexer},
+    state::ledger,
+    store::IndexerStore,
+    CANONICAL_UPDATE_THRESHOLD, MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K,
+    PRUNE_INTERVAL_DEFAULT,
 };
 use serde::Deserializer;
 use serde_derive::Deserialize;
-use tracing::{trace, instrument, info, error};
 use std::{path::PathBuf, sync::Arc};
-use tracing_subscriber::{prelude::*, filter::LevelFilter};
+use tracing::{error, info, instrument, trace};
+use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 #[derive(Parser, Debug)]
 #[command(name = "mina-indexer", author, version, about, long_about = Some("Mina Indexer\n\n\

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -119,19 +119,19 @@ impl BlockWithoutHeight {
 
 impl std::cmp::PartialOrd for Block {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.state_hash == other.state_hash {
-            Some(std::cmp::Ordering::Equal)
-        } else if self.height > other.height {
-            Some(std::cmp::Ordering::Greater)
-        } else {
-            Some(std::cmp::Ordering::Less)
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl std::cmp::Ord for Block {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        if self.state_hash == other.state_hash {
+            std::cmp::Ordering::Equal
+        } else if self.height > other.height {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Less
+        }
     }
 }
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -121,8 +121,7 @@ impl std::cmp::PartialOrd for Block {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         if self.state_hash == other.state_hash {
             Some(std::cmp::Ordering::Equal)
-        } else if self.height > other.height
-        {
+        } else if self.height > other.height {
             Some(std::cmp::Ordering::Greater)
         } else {
             Some(std::cmp::Ordering::Less)

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -122,7 +122,6 @@ impl std::cmp::PartialOrd for Block {
         if self.state_hash == other.state_hash {
             Some(std::cmp::Ordering::Equal)
         } else if self.height > other.height
-            || self.height == other.height && self.state_hash.0 > other.state_hash.0
         {
             Some(std::cmp::Ordering::Greater)
         } else {

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -17,7 +17,7 @@ use juniper::http::GraphQLRequest;
 use crate::gql::root::Context;
 use crate::store::IndexerStore;
 
-mod root;
+pub mod root;
 mod schema;
 
 #[get("/graphql")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,19 +2,19 @@ use crate::{
     block::{parser::BlockParser, store::BlockStore, Block, BlockHash, BlockWithoutHeight},
     receiver::{filesystem::FilesystemReceiver, BlockReceiver},
     state::{
-        ledger::{self, genesis::GenesisRoot, public_key::PublicKey, Ledger},
+        ledger::{genesis::GenesisRoot, public_key::PublicKey, Ledger},
         summary::{SummaryShort, SummaryVerbose},
         IndexerMode, IndexerState,
     },
     store::IndexerStore,
-    CANONICAL_UPDATE_THRESHOLD, MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K,
-    PRUNE_INTERVAL_DEFAULT, SOCKET_NAME,
+    MAINNET_TRANSITION_FRONTIER_K,
+    SOCKET_NAME,
 };
-use clap::Parser;
+
 use futures::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use interprocess::local_socket::tokio::{LocalSocketListener, LocalSocketStream};
 use log::trace;
-use serde::Deserializer;
+
 use serde_derive::{Deserialize, Serialize};
 use std::{path::PathBuf, process, sync::Arc};
 use tokio::{
@@ -22,68 +22,39 @@ use tokio::{
     io,
     sync::{mpsc, watch}, task::JoinHandle,
 };
-use tracing::{debug, error, info, instrument, level_filters::LevelFilter};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
-#[derive(Parser, Debug, Clone, Deserialize)]
-#[command(author, version, about, long_about = None)]
-pub struct ServerArgs {
-    /// Path to the root ledger (if non-genesis, set --non-genesis-ledger and --root-hash)
-    #[arg(short, long)]
-    ledger: PathBuf,
-    /// Use a non-genesis ledger
-    #[arg(short, long, default_value_t = false)]
-    non_genesis_ledger: bool,
-    /// Hash of the base ledger
-    #[arg(
-        long,
-        default_value = MAINNET_GENESIS_HASH
-    )]
-    root_hash: String,
-    /// Path to startup blocks directory
-    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/startup-blocks"))]
-    startup_dir: PathBuf,
-    /// Path to directory to watch for new blocks
-    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/watch-blocks"))]
-    watch_dir: PathBuf,
-    /// Path to directory for rocksdb
-    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/database"))]
-    pub database_dir: PathBuf,
-    /// Path to directory for logs
-    #[arg(long, default_value = concat!(env!("HOME"), "/.mina-indexer/logs"))]
-    pub log_dir: PathBuf,
-    /// Only store canonical blocks in the db
-    #[arg(short, long, default_value_t = false)]
-    keep_non_canonical_blocks: bool,
-    /// Max file log level
-    #[serde(deserialize_with = "level_filter_deserializer")]
-    #[arg(long, default_value_t = LevelFilter::DEBUG)]
-    pub log_level: LevelFilter,
-    /// Max stdout log level
-    #[serde(deserialize_with = "level_filter_deserializer")]
-    #[arg(long, default_value_t = LevelFilter::INFO)]
-    pub log_level_stdout: LevelFilter,
-    /// Interval for pruning the root branch
-    #[arg(short, long, default_value_t = PRUNE_INTERVAL_DEFAULT)]
-    prune_interval: u32,
-    /// Threshold for updating the canonical tip/ledger
-    #[arg(short, long, default_value_t = CANONICAL_UPDATE_THRESHOLD)]
-    canonical_update_threshold: u32,
-    /// Path to an indexer snapshot
-    #[arg(long)]
-    pub snapshot_path: Option<PathBuf>,
+pub struct IndexerConfiguration {
+    pub ledger: GenesisRoot,
+    pub non_genesis_ledger: bool,
+    pub root_hash: BlockHash,
+    pub startup_dir: PathBuf,
+    pub watch_dir: PathBuf,
+    pub keep_noncanonical_blocks: bool,
+    pub prune_interval: u32,
+    pub canonical_update_threshold: u32,
+    pub from_snapshot: bool,
 }
 
-pub struct IndexerConfiguration {
-    ledger: GenesisRoot,
-    non_genesis_ledger: bool,
-    root_hash: BlockHash,
-    startup_dir: PathBuf,
-    watch_dir: PathBuf,
-    keep_noncanonical_blocks: bool,
-    prune_interval: u32,
-    canonical_update_threshold: u32,
-    from_snapshot: bool,
+#[derive(Debug, Serialize, Deserialize)]
+struct SaveCommand(PathBuf);
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SaveResponse(String);
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum MinaIndexerRunPhase {
+    JustStarted,
+    IPCSocketConnected,
+    SIGINTHandlerSet,
+    StateInitializedFromParser,
+    StateInitializedFromSnapshot,
+    StartedBlockReceiver,
+    IPCSocketListenerStarted,
+    ReceivingBlock,
+    ReceivingIPCConnection,
+    SavingStateSnapshot,
 }
 
 pub struct MinaIndexer {
@@ -116,83 +87,6 @@ impl MinaIndexer {
     pub fn state(&self) -> MinaIndexerRunPhase {
         *self.indexer_phase_receiver.borrow()
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct SaveCommand(PathBuf);
-
-#[derive(Debug, Serialize, Deserialize)]
-struct SaveResponse(String);
-
-#[instrument(skip_all)]
-pub async fn handle_command_line_arguments(
-    args: ServerArgs,
-) -> anyhow::Result<IndexerConfiguration> {
-    trace!("Parsing server args");
-
-    let ledger = args.ledger;
-    let non_genesis_ledger = args.non_genesis_ledger;
-    let root_hash = BlockHash(args.root_hash.to_string());
-    let startup_dir = args.startup_dir;
-    let watch_dir = args.watch_dir;
-    let keep_noncanonical_blocks = args.keep_non_canonical_blocks;
-    let prune_interval = args.prune_interval;
-    let canonical_update_threshold = args.canonical_update_threshold;
-
-    assert!(
-        ledger.is_file(),
-        "Ledger file does not exist at {}",
-        ledger.display()
-    );
-    assert!(
-        // bad things happen if this condition fails
-        canonical_update_threshold < MAINNET_TRANSITION_FRONTIER_K,
-        "canonical update threshold must be strictly less than the transition frontier length!"
-    );
-
-    create_dir_if_non_existent(watch_dir.to_str().unwrap()).await;
-
-    info!("Parsing ledger file at {}", ledger.display());
-
-    match ledger::genesis::parse_file(&ledger).await {
-        Err(err) => {
-            error!(
-                reason = "Unable to parse ledger",
-                error = err.to_string(),
-                path = &ledger.display().to_string()
-            );
-            process::exit(100)
-        }
-        Ok(ledger) => {
-            info!("Ledger parsed successfully!");
-
-            Ok(IndexerConfiguration {
-                ledger,
-                non_genesis_ledger,
-                root_hash,
-                startup_dir,
-                watch_dir,
-                keep_noncanonical_blocks,
-                prune_interval,
-                canonical_update_threshold,
-                from_snapshot: args.snapshot_path.is_some(),
-            })
-        }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub enum MinaIndexerRunPhase {
-    JustStarted,
-    IPCSocketConnected,
-    SIGINTHandlerSet,
-    StateInitializedFromParser,
-    StateInitializedFromSnapshot,
-    StartedBlockReceiver,
-    IPCSocketListenerStarted,
-    ReceivingBlock,
-    ReceivingIPCConnection,
-    SavingStateSnapshot,
 }
 
 #[instrument(skip_all)]
@@ -465,39 +359,4 @@ pub async fn create_dir_if_non_existent(path: &str) {
         debug!("Creating directory {path}");
         create_dir_all(path).await.unwrap();
     }
-}
-
-pub fn level_filter_deserializer<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct YAMLStringVisitor;
-
-    impl<'de> serde::de::Visitor<'de> for YAMLStringVisitor {
-        type Value = LevelFilter;
-
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("a string containing yaml data")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-        {
-            // unfortunately we lose some typed information
-            // from errors deserializing the json string
-            let level_filter_str: &str = serde_yaml::from_str(v).map_err(E::custom)?;
-            match level_filter_str {
-                "info" => Ok(LevelFilter::INFO),
-                "debug" => Ok(LevelFilter::DEBUG),
-                "error" => Ok(LevelFilter::ERROR),
-                "trace" => Ok(LevelFilter::TRACE),
-                "warn" => Ok(LevelFilter::TRACE),
-                "off" => Ok(LevelFilter::OFF),
-                other => Err(E::custom(format!("{} is not a valid level filter", other))),
-            }
-        }
-    }
-
-    deserializer.deserialize_any(YAMLStringVisitor)
 }

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -240,7 +240,7 @@ impl Branch {
     /// the `incoming` tree is placed under `junction_id` in `self`
     ///
     /// Returns the id of the best tip in the merged subtree
-    pub fn merge_on(&mut self, junction_id: &NodeId, incoming: &mut Branch) -> Option<NodeId> {
+    pub fn merge_on(&mut self, junction_id: &NodeId, incoming: &Branch) -> Option<NodeId> {
         let (merged_tip_id, _) = incoming.best_tip_with_id().unwrap();
         let mut merge_id_map = HashMap::new();
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use id_tree::NodeId;
 use serde_derive::{Deserialize, Serialize};
-use uuid::Uuid;
 use std::{
     collections::HashMap,
     process,
@@ -32,6 +31,7 @@ use std::{
 };
 use time::{format_description, OffsetDateTime};
 use tracing::{debug, error, info, instrument, trace};
+use uuid::Uuid;
 
 pub mod branch;
 pub mod ledger;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -29,7 +29,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use time::{format_description, OffsetDateTime, PrimitiveDateTime};
+use time::{format_description, OffsetDateTime};
 use tracing::{debug, error, info, instrument, trace};
 
 pub mod branch;
@@ -68,7 +68,7 @@ pub struct IndexerState {
     /// Number of blocks added to the state
     pub blocks_processed: u32,
     /// Datetime the indexer started running
-    pub init_time: OffsetDateTime,
+    pub init_time: Instant,
 }
 
 #[derive(Debug, Clone)]
@@ -150,7 +150,7 @@ impl IndexerState {
             prune_interval,
             canonical_update_threshold,
             blocks_processed: 0,
-            init_time: OffsetDateTime::now_utc(),
+            init_time: Instant::now(),
         })
     }
 
@@ -195,7 +195,7 @@ impl IndexerState {
             prune_interval,
             canonical_update_threshold,
             blocks_processed: 0,
-            init_time: OffsetDateTime::now_utc(),
+            init_time: Instant::now(),
         })
     }
 
@@ -236,7 +236,7 @@ impl IndexerState {
             prune_interval: PRUNE_INTERVAL_DEFAULT,
             canonical_update_threshold: CANONICAL_UPDATE_THRESHOLD,
             blocks_processed: 0,
-            init_time: OffsetDateTime::now_utc(),
+            init_time: Instant::now(),
         })
     }
 
@@ -336,7 +336,7 @@ impl IndexerState {
                 prune_interval,
                 canonical_update_threshold,
                 blocks_processed: 0,
-                init_time: time::OffsetDateTime::now_utc(),
+                init_time: Instant::now(),
             })
         } else {
             Err(anyhow::Error::msg(
@@ -1003,8 +1003,7 @@ impl IndexerState {
         };
 
         SummaryShort {
-            uptime: OffsetDateTime::now_utc() - self.init_time,
-            date_time: PrimitiveDateTime::new(self.init_time.date(), self.init_time.time()),
+            uptime: Instant::now() - self.init_time,
             blocks_processed: self.blocks_processed,
             witness_tree,
             db_stats: db_stats_str.map(|s| DbStats::from_str(&format!("{mem}\n{s}")).unwrap()),
@@ -1046,8 +1045,7 @@ impl IndexerState {
         };
 
         SummaryVerbose {
-            uptime: OffsetDateTime::now_utc() - self.init_time,
-            date_time: PrimitiveDateTime::new(self.init_time.date(), self.init_time.time()),
+            uptime: Instant::now() - self.init_time,
             blocks_processed: self.blocks_processed,
             witness_tree,
             db_stats: db_stats_str.map(|s| DbStats::from_str(&format!("{mem}\n{s}")).unwrap()),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -720,7 +720,7 @@ impl IndexerState {
                     .data()
                     .clone();
 
-                if merged_tip_block > self.best_tip_block().clone() {
+                if merged_tip_block.state_hash.0 > self.best_tip_block().state_hash.0 {
                     self.update_best_tip(&merged_tip_block, &merged_tip_id);
                 }
             }

--- a/src/state/summary.rs
+++ b/src/state/summary.rs
@@ -1,11 +1,9 @@
 use bytesize::ByteSize;
 use serde_derive::{Deserialize, Serialize};
 use std::str::Lines;
-use time::{Duration, PrimitiveDateTime};
 
 pub trait Summary {
-    fn uptime(&self) -> Duration;
-    fn date_time(&self) -> PrimitiveDateTime;
+    fn uptime(&self) -> std::time::Duration;
     fn blocks_processed(&self) -> u32;
     fn best_tip_length(&self) -> u32;
     fn best_tip_hash(&self) -> String;
@@ -23,8 +21,7 @@ pub trait Summary {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummaryShort {
-    pub uptime: Duration,
-    pub date_time: PrimitiveDateTime,
+    pub uptime: std::time::Duration,
     pub blocks_processed: u32,
     pub witness_tree: WitnessTreeSummaryShort,
     pub db_stats: Option<DbStats>,
@@ -32,8 +29,7 @@ pub struct SummaryShort {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummaryVerbose {
-    pub uptime: Duration,
-    pub date_time: PrimitiveDateTime,
+    pub uptime: std::time::Duration,
     pub blocks_processed: u32,
     pub witness_tree: WitnessTreeSummaryVerbose,
     pub db_stats: Option<DbStats>,
@@ -101,7 +97,6 @@ impl From<SummaryVerbose> for SummaryShort {
     fn from(value: SummaryVerbose) -> Self {
         Self {
             uptime: value.uptime,
-            date_time: value.date_time,
             blocks_processed: value.blocks_processed,
             witness_tree: value.witness_tree.into(),
             db_stats: value.db_stats,
@@ -129,8 +124,7 @@ impl From<WitnessTreeSummaryVerbose> for WitnessTreeSummaryShort {
 
 fn summary_short(state: &impl Summary, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     writeln!(f, "===== Mina-indexer summary =====")?;
-    writeln!(f, "  Uptime:       {}", state.uptime())?;
-    writeln!(f, "  Started:      {}", state.date_time())?;
+    writeln!(f, "  Uptime:       {:?}", state.uptime())?;
     writeln!(f, "  Blocks added: {}", state.blocks_processed())?;
 
     writeln!(f, "\n=== Root branch ===")?;
@@ -193,10 +187,6 @@ impl Summary for SummaryShort {
         self.witness_tree.canonical_tip_length
     }
 
-    fn date_time(&self) -> PrimitiveDateTime {
-        self.date_time
-    }
-
     fn db_stats(&self) -> DbStats {
         self.db_stats.as_ref().unwrap().clone()
     }
@@ -229,7 +219,7 @@ impl Summary for SummaryShort {
         self.witness_tree.root_length
     }
 
-    fn uptime(&self) -> Duration {
+    fn uptime(&self) -> std::time::Duration {
         self.uptime
     }
 }
@@ -255,10 +245,6 @@ impl Summary for SummaryVerbose {
         self.witness_tree.canonical_tip_length
     }
 
-    fn date_time(&self) -> PrimitiveDateTime {
-        self.date_time
-    }
-
     fn db_stats(&self) -> DbStats {
         self.db_stats.as_ref().unwrap().clone()
     }
@@ -291,7 +277,7 @@ impl Summary for SummaryVerbose {
         self.witness_tree.root_length
     }
 
-    fn uptime(&self) -> Duration {
+    fn uptime(&self) -> std::time::Duration {
         self.uptime
     }
 }


### PR DESCRIPTION
Creates a query interface into the `server::{initialize, run}` functions to allow for testing of the Mina Indexer in situ
* Create `MinaIndexer` class to serve as the interface into a running indexer
* separate `server::run` into `server::run` and `server::initialize`
* add various channels to `MinaIndexer` and `server::run` to query the `IndexerState` while it is running

<hr>

Asana Tasks Referenced
* https://app.asana.com/0/1203669416123378/1205355603199909/f
* https://app.asana.com/0/1203669416123378/1205188527548527/f