### PR TITLE
Cli improvements

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -91,13 +91,14 @@ pub async fn run(command: &ClientCli, output_json: bool) -> Result<(), anyhow::E
     let (reader, mut writer) = conn.into_split();
     let mut reader = BufReader::new(reader);
 
-    let mut buffer = Vec::with_capacity(1280000);
+    let mut buffer = Vec::with_capacity(1024 * 1024); // 1mb
 
     match command {
         ClientCli::Account(account_args) => {
             let command = format!("account {}\0", account_args.public_key);
             writer.write_all(command.as_bytes()).await?;
             reader.read_to_end(&mut buffer).await?;
+
             let account: Account = bcs::from_bytes(&buffer)?;
             if output_json {
                 stdout()

--- a/src/client.rs
+++ b/src/client.rs
@@ -144,9 +144,7 @@ pub async fn run(command: &ClientCli, output_json: bool) -> Result<(), anyhow::E
                         .write_all(serde_json::to_string(&summary)?.as_bytes())
                         .await?;
                 } else {
-                    stdout()
-                        .write_all(format!("{summary:?}").as_bytes())
-                        .await?;
+                    stdout().write_all(format!("{summary}").as_bytes()).await?;
                 }
             } else {
                 let summary: SummaryShort = bcs::from_bytes(&buffer)?;
@@ -155,9 +153,7 @@ pub async fn run(command: &ClientCli, output_json: bool) -> Result<(), anyhow::E
                         .write_all(serde_json::to_string(&summary)?.as_bytes())
                         .await?;
                 } else {
-                    stdout()
-                        .write_all(format!("{summary:?}").as_bytes())
-                        .await?;
+                    stdout().write_all(format!("{summary}").as_bytes()).await?;
                 }
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -401,10 +401,18 @@ async fn handle_conn(
             let data_buffer = buffers.next().unwrap();
             let path = &String::from_utf8(data_buffer[..data_buffer.len() - 1].to_vec())?
                 .parse::<PathBuf>()?;
-            debug!("Writing ledger to {}", path.display());
-            fs::write(path, format!("{ledger:?}")).await?;
-            let bytes = bcs::to_bytes(&format!("Ledger written to {}", path.display()))?;
-            writer.write_all(&bytes).await?;
+            if !path.is_dir() {
+                debug!("Writing ledger to {}", path.display());
+                fs::write(path, format!("{ledger:?}")).await?;
+                let bytes = bcs::to_bytes(&format!("Ledger written to {}", path.display()))?;
+                writer.write_all(&bytes).await?;
+            } else {
+                let bytes = bcs::to_bytes(&format!(
+                    "The path provided must be a file: {}",
+                    path.display()
+                ))?;
+                writer.write_all(&bytes).await?;
+            }
         }
         "summary" => {
             info!("Received summary command");


### PR DESCRIPTION
Verify the account returns mina instead of nanomina
```sh
cargo build --release
// Start indexer
target/release/mina-indexer client account -p B62qmqMrgPshhHKLJ7DqWn1KeizEgga5MuGmWb2bXajUnyivfeMW6JE
```

Verify summary output for verbose and non-verbose JSON and summary output
```sh
target/release/mina-indexer client summary
target/release/mina-indexer client summary -v
target/release/mina-indexer client -o summary
target/release/mina-indexer client -o summary -v
```

```sh
target/release/mina-indexer client best-ledger -p /tmp
The path provided must be a file: /tmp

target/release/mina-indexer client best-ledger -p /tmp/foobar.txt
Ledger written to /tmp/foobar.txt
```
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205500191741605
  - https://app.asana.com/0/0/1205500191741594
  - https://app.asana.com/0/0/1205103570662676