### PR TITLE
Refactor regression tests to be their own functions and general improvements

### DIFF
--- a/test
+++ b/test
@@ -5,11 +5,11 @@ DOMAIN_SOCKET="$(pwd)/mina-indexer.sock"
 
 TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 BLOCKS_DIR="${TMPDIR}/blocks"
-mkdir $BLOCKS_DIR
+mkdir "${BLOCKS_DIR}"
 
 cleanup() {
     echo "Exiting with $?"
-    rm -rf $TMPDIR 2>/dev/null
+    rm -rf ${TMPDIR} 2>/dev/null
 }
 
 trap cleanup EXIT
@@ -20,7 +20,7 @@ idxr() {
 
 dl_mainnet() {
     MAX_SLOT=$1; OUT_DIR=$2
-    ./download_blocks mina_network_block_data $MAX_SLOT mainnet $OUT_DIR
+    ./download_blocks mina_network_block_data "${MAX_SLOT}" mainnet "${OUT_DIR}"
 }
 
 assert() {
@@ -40,10 +40,10 @@ setup() {
 }
 
 teardown() {
-    echo "Cleaning up and killing the background indexer with PID: $idxr_pid"
-    kill $idxr_pid 2>/dev/null
-    rm -rf $HOME/.mina-indexer/database || true
-    rm -rf $HOME/.mina-indexer/logs || true
+    echo "Cleaning up and killing the background indexer with PID: ${idxr_pid}"
+    kill "${idxr_pid}" 2>/dev/null
+    rm -rf "${HOME}/.mina-indexer/database" || true
+    rm -rf "${HOME}/.mina-indexer/logs" || true
 }
 
 
@@ -153,4 +153,5 @@ else
         esac
     done
 fi
+
 echo "Done"

--- a/test
+++ b/test
@@ -3,51 +3,19 @@ set -ex
 
 DOMAIN_SOCKET="$(pwd)/mina-indexer.sock"
 
-# Create temporary directory for blocks and things in a cross platform
-# compatible way
 TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 BLOCKS_DIR="${TMPDIR}/blocks"
 mkdir $BLOCKS_DIR
 
 cleanup() {
     echo "Exiting with $?"
-    rm -rf $TMPDIR
+    rm -rf $TMPDIR 2>/dev/null
 }
+
 trap cleanup EXIT
 
-cargo build
-
-teardown() {
-    rm -rf $HOME/.mina-indexer/database || true
-    rm -rf $HOME/.mina-indexer/logs || true
-}
-
-shutdown() {
-    echo "shutdown \0" | nc -U $DOMAIN_SOCKET
-}
-
-account_balance() {
-    echo "account $1\0" | nc -U $DOMAIN_SOCKET | jq .balance
-}
-
-best_ledger() {
-    echo "best-ledger\0" | nc -U $DOMAIN_SOCKET | jq .ledger
-}
-
-summary() {
-    echo "summary\0" | nc -U $DOMAIN_SOCKET | jq .summary
-}
-
-idxr() { 
-    ./target/debug/mina-indexer "$@" 
-}
-
-server() {
-    ./target/debug/mina-indexer server "$@"
-}
-
-client() {
-    ./target/debug/mina-indexer client "$@"
+idxr() {
+    ./target/debug/mina-indexer "$@"
 }
 
 dl_mainnet() {
@@ -55,83 +23,134 @@ dl_mainnet() {
     ./download_blocks mina_network_block_data $MAX_SLOT mainnet $OUT_DIR
 }
 
-# Indexer reports usage with no arguments
-idxr 2>&1 | 
-    grep -iq "Usage:"
+assert() {
+    expected="$1"
+    actual="$2"
 
-# Indexer reports usage for server subcommand
-idxr server 2>&1 |
-    grep -iq "Usage: mina-indexer server"
+    if [ "$expected" != "$actual" ]; then
+        echo "Test Failed: Expected $expected, but got $actual"
+        exit 1
+    else
+        echo "Test Passed!"
+    fi
+}
 
-# Indexer reports usage for client subcommand
-idxr client 2>&1 | 
-    grep -iq "Usage: mina-indexer client"
+setup() {
+    echo "setup"
+}
 
-# Indexer server config subcommand exists
-idxr server config 2>&1 | 
-    grep -iq "Usage: mina-indexer server config"
+teardown() {
+    echo "Cleaning up and killing the background indexer with PID: $idxr_pid"
+    kill $idxr_pid 2>/dev/null
+    rm -rf $HOME/.mina-indexer/database || true
+    rm -rf $HOME/.mina-indexer/logs || true
+}
 
-# Indexer server cli subcommand works
-idxr server cli --help 2>/dev/null
+
+test_indexer_cli_reports() {
+    # Indexer reports usage with no arguments
+    idxr 2>&1 |
+        grep -iq "Usage:"
+
+    # Indexer reports usage for server subcommand
+    idxr server 2>&1 |
+        grep -iq "Usage: mina-indexer server"
+
+    # Indexer reports usage for client subcommand
+    idxr client 2>&1 |
+        grep -iq "Usage: mina-indexer client"
+
+    # Indexer server config subcommand exists
+    idxr server config 2>&1 |
+        grep -iq "Usage: mina-indexer server config"
+
+    # Indexer server cli subcommand works
+    idxr server cli --help 2>/dev/null
+}
 
 # Indexer server config passes cli with minimal args
-idxr server cli \
-    --initial-ledger tests/ledgers/mainnet-genesis.json \
-    --is-genesis-ledger \
-    --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
-IDXR_PID=$(pgrep mina-indexer)
-kill $IDXR_PID
-teardown
+test_indexer_basic_start() {
+    setup
+    idxr server cli \
+         --initial-ledger tests/ledgers/mainnet-genesis.json \
+         --is-genesis-ledger \
+         --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
+    idxr_pid=$(pgrep mina-indexer)
+    teardown
+}
 
 # Indexer server starts up on a minimal selection of blocks
-dl_mainnet 15 $BLOCKS_DIR
-server cli \
-    --startup-dir $BLOCKS_DIR \
-    --watch-dir $BLOCKS_DIR \
-    --initial-ledger tests/ledgers/mainnet-genesis.json \
-    --is-genesis-ledger \
-    --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
-IDXR_PID=$(pgrep mina-indexer)
-sleep 5
-client -o summary |
-    jq .witness_tree.canonical_tip_hash | 
-    grep -iq "3NKQUoBfi9vkbuqtDJmSEYBQrcSo4GjwG8bPCiii4yqM8AxEQvtY"
-kill $IDXR_PID
-teardown
+test_best_canonical_tip() {
+    setup
+
+    dl_mainnet 15 $BLOCKS_DIR
+    idxr server cli \
+           --startup-dir $BLOCKS_DIR \
+           --watch-dir $BLOCKS_DIR \
+           --initial-ledger tests/ledgers/mainnet-genesis.json \
+           --is-genesis-ledger \
+           --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
+    idxr_pid=$(pgrep mina-indexer)
+    sleep 5
+    result=$(idxr client -o summary | jq -r .witness_tree.canonical_tip_hash)
+    assert '3NKQUoBfi9vkbuqtDJmSEYBQrcSo4GjwG8bPCiii4yqM8AxEQvtY' $result
+    teardown
+}
 
 # Indexer server ipc is available during initialization
-dl_mainnet 250 $BLOCKS_DIR
-server cli \
-    --startup-dir $BLOCKS_DIR \
-    --watch-dir $BLOCKS_DIR \
-    --initial-ledger tests/ledgers/mainnet-genesis.json \
-    --is-genesis-ledger \
-    --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
-IDXR_PID=$(pgrep mina-indexer)
-sleep 5
-client -o summary |
-    jq .
-kill $IDXR_PID
-teardown
+test_ipc_is_available_immediately() {
+    setup
 
-# Signal indexer to shutdown
-idxr server cli \
-    --initial-ledger tests/ledgers/mainnet-genesis.json \
-    --is-genesis-ledger \
-    --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
-sleep 3
-shutdown
+    dl_mainnet 250 $BLOCKS_DIR
+    idxr server cli \
+           --startup-dir $BLOCKS_DIR \
+           --watch-dir $BLOCKS_DIR \
+           --initial-ledger tests/ledgers/mainnet-genesis.json \
+           --is-genesis-ledger \
+           --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
+    idxr_pid=$(pgrep mina-indexer)
+    sleep 5
+    idxr client -o summary | jq .
+    teardown
+}
 
 # Indexer server reports correct balance for Genesis Ledger Account
-server cli \
-    --initial-ledger tests/ledgers/mainnet-genesis.json \
-    --is-genesis-ledger \
-    --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
-IDXR_PID=$(pgrep mina-indexer)
-sleep 5
-client -o account --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk |
-    jq .balance |
-    grep -iq "148837200000000"
-kill $IDXR_PID
-teardown
+test_account_balance_cli() {
+    setup
+
+    idxr server cli \
+           --initial-ledger tests/ledgers/mainnet-genesis.json \
+           --is-genesis-ledger \
+           --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
+    idxr_pid=$(pgrep mina-indexer)
+    sleep 5
+    result=$(idxr client -o account --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .balance)
+    assert '148837200000000' $result
+
+    teardown
+}
+
+cargo build
+
+# Check command-line arguments
+if [[ "$#" -eq 0 ]]; then
+    # No arguments provided, run all tests
+    test_indexer_cli_reports
+    test_indexer_basic_start
+    test_best_canonical_tip
+    test_ipc_is_available_immediately
+    test_account_balance_cli
+else
+    # Run only specified tests
+    for test_name in "$@"; do
+        case $test_name in
+            "test_indexer_cli_reports") test_indexer_cli_reports ;;
+            "test_indexer_basic_start") test_indexer_basic_start ;;
+            "test_best_canonical_tip") test_best_canonical_tip ;;
+            "test_ipc_is_available_immediately") test_ipc_is_available_immediately ;;
+            "test_account_balance_cli") ;;
+            *) echo "Unknown test: $test_name" ;;
+        esac
+    done
+fi
 echo "Done"


### PR DESCRIPTION
Add the ability to run individual tests.

`./test` runs all the tests
`./test test_best_canonical_tip test_indexer_cli_reports` would only run those two tests