### PR TITLE
Client Account Pubkey Display

### DIFF
--- a/src/state/ledger/account.rs
+++ b/src/state/ledger/account.rs
@@ -1,5 +1,5 @@
 use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer, Deserializer, de::Visitor};
 
 use super::PublicKey;
 
@@ -13,6 +13,8 @@ pub struct Nonce(pub u32);
 
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Account {
+    #[serde(serialize_with = "serialize_public_key")]
+    #[serde(deserialize_with = "deserialize_public_key")]
     pub public_key: PublicKey,
     pub balance: Amount,
     pub nonce: Nonce,
@@ -116,4 +118,36 @@ fn test_nanomina_to_mina_conversion() {
     let actual = 1_000_000_000;
     let val = nanomina_to_mina(actual);
     assert_eq!("1", val);
+}
+
+fn serialize_public_key<S>(public_key: &PublicKey, s: S) 
+    -> Result<<S as Serializer>::Ok, <S as Serializer>::Error> where S: Serializer 
+{
+    let pub_key_address = public_key.to_address();
+    s.serialize_str(&pub_key_address)
+}
+
+fn deserialize_public_key<'de, D>(deserializer: D) 
+    -> Result<PublicKey, D::Error> where D: Deserializer<'de> 
+{
+    pub struct StringVisitor;
+
+    impl <'de> Visitor<'de> for StringVisitor {
+        type Value = PublicKey;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a valid Mina public key address")
+        }
+
+        fn visit_str<E>(self, v: &str) 
+            -> Result<Self::Value, E> where E: serde::de::Error 
+        {
+            match PublicKey::from_address(v) {
+                Err(e) => Err(E::custom(e.to_string())),
+                Ok(public_key) => Ok(public_key)
+            }
+        }
+    }
+
+    deserializer.deserialize_any(StringVisitor)
 }

--- a/src/state/ledger/account.rs
+++ b/src/state/ledger/account.rs
@@ -1,5 +1,5 @@
 use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize, Serializer, Deserializer, de::Visitor};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::PublicKey;
 
@@ -120,31 +120,37 @@ fn test_nanomina_to_mina_conversion() {
     assert_eq!("1", val);
 }
 
-fn serialize_public_key<S>(public_key: &PublicKey, s: S) 
-    -> Result<<S as Serializer>::Ok, <S as Serializer>::Error> where S: Serializer 
+fn serialize_public_key<S>(
+    public_key: &PublicKey,
+    s: S,
+) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+where
+    S: Serializer,
 {
     let pub_key_address = public_key.to_address();
     s.serialize_str(&pub_key_address)
 }
 
-fn deserialize_public_key<'de, D>(deserializer: D) 
-    -> Result<PublicKey, D::Error> where D: Deserializer<'de> 
+fn deserialize_public_key<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+where
+    D: Deserializer<'de>,
 {
     pub struct StringVisitor;
 
-    impl <'de> Visitor<'de> for StringVisitor {
+    impl<'de> Visitor<'de> for StringVisitor {
         type Value = PublicKey;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
             formatter.write_str("a valid Mina public key address")
         }
 
-        fn visit_str<E>(self, v: &str) 
-            -> Result<Self::Value, E> where E: serde::de::Error 
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
         {
             match PublicKey::from_address(v) {
                 Err(e) => Err(E::custom(e.to_string())),
-                Ok(public_key) => Ok(public_key)
+                Ok(public_key) => Ok(public_key),
             }
         }
     }

--- a/test
+++ b/test
@@ -10,6 +10,7 @@ mkdir "${BLOCKS_DIR}"
 cleanup() {
     echo "Exiting with $?"
     rm -rf ${TMPDIR} 2>/dev/null
+    teardown
 }
 
 trap cleanup EXIT
@@ -130,6 +131,21 @@ test_account_balance_cli() {
     teardown
 }
 
+test_account_public_key_json() {
+    setup
+
+    idxr server cli \
+        --initial-ledger tests/ledgers/mainnet-genesis.json \
+        --is-genesis-ledger \
+        --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
+    idxr_pid=$(pgrep mina-indexer)
+    sleep 5
+    result = $(idxr client -o account --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .public_key)
+    assert 'B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk' $result
+
+    teardown
+}
+
 cargo build
 
 # Check command-line arguments
@@ -140,6 +156,7 @@ if [[ "$#" -eq 0 ]]; then
     test_best_canonical_tip
     test_ipc_is_available_immediately
     test_account_balance_cli
+    test_account_public_key_json
 else
     # Run only specified tests
     for test_name in "$@"; do
@@ -149,6 +166,7 @@ else
             "test_best_canonical_tip") test_best_canonical_tip ;;
             "test_ipc_is_available_immediately") test_ipc_is_available_immediately ;;
             "test_account_balance_cli") ;;
+            "test_account_public_key_json") test_account_public_key_json ;;
             *) echo "Unknown test: $test_name" ;;
         esac
     done

--- a/test
+++ b/test
@@ -10,7 +10,6 @@ mkdir "${BLOCKS_DIR}"
 cleanup() {
     echo "Exiting with $?"
     rm -rf ${TMPDIR} 2>/dev/null
-    teardown
 }
 
 trap cleanup EXIT

--- a/test
+++ b/test
@@ -140,7 +140,7 @@ test_account_public_key_json() {
         --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ &
     idxr_pid=$(pgrep mina-indexer)
     sleep 5
-    result = $(idxr client -o account --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .public_key)
+    result=$(idxr client -o account --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .public_key)
     assert 'B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk' $result
 
     teardown


### PR DESCRIPTION
Solves #242, When asking for JSON from the client for an account, the client displays internal implementation details for the `PublicKey` struct. This PR overrides the serialization and deserialization of the `public_key` field on the `Account` record to use the address format, and adds a test to ensure the proper data is being returned on the client