### PR TITLE
Add canonical threshold unit test

### DIFF
--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -429,7 +429,7 @@ fn next_length_start_index(paths: &[PathBuf], path_idx: usize) -> Option<usize> 
 }
 
 /// Finds the _canonical tip_, i.e. the _highest_ block in the
-/// _lowest contiguous chain_ with `cacnonical_threshold` ancestors.
+/// _lowest contiguous chain_ with `canonical_threshold` ancestors.
 /// Unfortunately, the existence of this value does not necessarily imply
 /// the existence of a canonical chain within the collection of blocks.
 ///

--- a/tests/block/canonical_chain_discovery.rs
+++ b/tests/block/canonical_chain_discovery.rs
@@ -63,5 +63,26 @@ async fn one_block() {
     let block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
     assert_eq!(block_parser.num_canonical, 0);
-    assert_eq!(block_parser.total_num_blocks, 1)
+    assert_eq!(block_parser.total_num_blocks, 1);
+}
+
+#[tokio::test]
+async fn canonical_threshold() {
+    let canonical_threshold = 2;
+    let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
+    let mut block_parser = BlockParser::new(&blocks_dir, canonical_threshold).unwrap();
+
+    while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+        println!(
+            "length: {}, hash: {}",
+            precomputed_block.blockchain_length, precomputed_block.state_hash
+        );
+    }
+
+    // lengths 2..19 are known to be canonical
+    assert_eq!(
+        block_parser.num_canonical,
+        block_parser.total_num_blocks - canonical_threshold
+    );
+    assert_eq!(block_parser.total_num_blocks, 20);
 }


### PR DESCRIPTION
- adds a unit test for `canonical_threshold` during canonical chain discovery

Closes https://github.com/Granola-Team/mina-indexer/issues/171