### PR TITLE
Disable default supported features in rust-rockdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,8 +2210,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "lz4-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -2276,16 +2274,6 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bin-prot = {path = "./mina-rs/protocol/bin-prot", version = "0.1.0"}
 mina-serialization-types = { path = "./mina-rs/protocol/serialization-types", version = "0.1.0" }
 versioned = { path = "./mina-rs/protocol/versioned", version = "0.1.0" }
 mina-signer = { path = "./mina-rs/proof-systems/signer", version = "0.1.0" }
-rocksdb = "0.21.0"
+rocksdb = { default-features = false, version = "0.21.0"}
 bcs = "0.1.5"
 id_tree = { version = "1.8.0", features = ["serde_support"]}
 watchexec = "2.3.0"
@@ -66,4 +66,8 @@ version = "1.25.0"
 features = ["full"]
 
 [profile.release]
-lto = true
+lto = "fat"
+incremental = true
+
+[profile.dev]
+lto = "off"


### PR DESCRIPTION
Use the correct LTO param for the release profile and add incremental builds

Turn off LTO in the dev release

Improves: https://github.com/Granola-Team/mina-indexer/issues/248
Fixes: https://github.com/Granola-Team/mina-indexer/issues/258