### PR TITLE
Remove async from parse file

### DIFF
--- a/src/bin/mainnet-test.rs
+++ b/src/bin/mainnet-test.rs
@@ -150,7 +150,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         let parse_time = Instant::now();
-        match bp.next().await {
+        match bp.next() {
             Err(err) => {
                 println!("{err:?}");
             }

--- a/src/bin/mainnet-test.rs
+++ b/src/bin/mainnet-test.rs
@@ -150,7 +150,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         let parse_time = Instant::now();
-        match bp.next() {
+        match bp.next_block() {
             Err(err) => {
                 println!("{err:?}");
             }

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -285,7 +285,7 @@ impl BlockParser {
     }
 
     /// Traverses `self`'s internal paths. First canonical, then successive.
-    pub fn next(&mut self) -> anyhow::Result<Option<PrecomputedBlock>> {
+    pub fn next_block(&mut self) -> anyhow::Result<Option<PrecomputedBlock>> {
         if let Some(next_path) = self.canonical_paths.next() {
             return self.parse_file(&next_path).map(Some);
         }
@@ -303,7 +303,7 @@ impl BlockParser {
         &mut self,
         state_hash: &str,
     ) -> anyhow::Result<PrecomputedBlock> {
-        let mut next_block = self.next()?.ok_or(anyhow!(
+        let mut next_block = self.next_block()?.ok_or(anyhow!(
             "
 [BlockPasrser::get_precomputed_block]
     Looking in blocks dir: {}
@@ -313,7 +313,7 @@ impl BlockParser {
         ))?;
 
         while next_block.state_hash != state_hash {
-            next_block = self.next()?.ok_or(anyhow!(
+            next_block = self.next_block()?.ok_or(anyhow!(
                 "
 [BlockPasrser::get_precomputed_block]
     Looking in blocks dir: {}

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -57,9 +57,7 @@ impl BlockParser {
                 successive_paths: paths.into_iter(),
             })
         } else {
-            Err(anyhow!(
-                "[BlockParser::new_testing] log path {blocks_dir:?} does not exist!"
-            ))
+            Err(anyhow!("blocks_dir: {blocks_dir:?}, does not exist!"))
         }
     }
 
@@ -278,9 +276,7 @@ impl BlockParser {
                 successive_paths: successive_paths.into_iter(),
             })
         } else {
-            Err(anyhow!(
-                "[BlockParser::new_internal] log path {blocks_dir:?} does not exist!"
-            ))
+            Err(anyhow!("blocks_dir: {blocks_dir:?}, does not exist!"))
         }
     }
 
@@ -303,24 +299,14 @@ impl BlockParser {
         &mut self,
         state_hash: &str,
     ) -> anyhow::Result<PrecomputedBlock> {
-        let mut next_block = self.next_block()?.ok_or(anyhow!(
-            "
-[BlockPasrser::get_precomputed_block]
-    Looking in blocks dir: {}
-    Did not find state hash: {state_hash}
-    It may have been skipped unintentionally!",
-            self.blocks_dir.display()
-        ))?;
+        let mut next_block = self
+            .next_block()?
+            .ok_or(anyhow!("Did not find state hash: {state_hash}"))?;
 
         while next_block.state_hash != state_hash {
-            next_block = self.next_block()?.ok_or(anyhow!(
-                "
-[BlockPasrser::get_precomputed_block]
-    Looking in blocks dir: {}
-    Did not find state hash: {state_hash}
-    It may have been skipped unintentionally!",
-                self.blocks_dir.display()
-            ))?;
+            next_block = self
+                .next_block()?
+                .ok_or(anyhow!("Did not find state hash: {state_hash}"))?;
         }
 
         Ok(next_block)

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -14,7 +14,7 @@ use std::{
     time::Instant,
     vec::IntoIter,
 };
-    use tracing::{debug, info};
+use tracing::{debug, info};
 
 /// Splits block paths into two collections: canonical and successive
 ///
@@ -285,7 +285,7 @@ impl BlockParser {
     }
 
     /// Traverses `self`'s internal paths. First canonical, then successive.
-    pub async fn next(&mut self) -> anyhow::Result<Option<PrecomputedBlock>> {
+    pub fn next(&mut self) -> anyhow::Result<Option<PrecomputedBlock>> {
         if let Some(next_path) = self.canonical_paths.next() {
             return self.parse_file(&next_path).map(Some);
         }
@@ -303,7 +303,7 @@ impl BlockParser {
         &mut self,
         state_hash: &str,
     ) -> anyhow::Result<PrecomputedBlock> {
-        let mut next_block = self.next().await?.ok_or(anyhow!(
+        let mut next_block = self.next()?.ok_or(anyhow!(
             "
 [BlockPasrser::get_precomputed_block]
     Looking in blocks dir: {}
@@ -313,7 +313,7 @@ impl BlockParser {
         ))?;
 
         while next_block.state_hash != state_hash {
-            next_block = self.next().await?.ok_or(anyhow!(
+            next_block = self.next()?.ok_or(anyhow!(
                 "
 [BlockPasrser::get_precomputed_block]
     Looking in blocks dir: {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -144,10 +144,7 @@ impl MinaIndexer {
         let _ = self._ipc_join_handle.await;
     }
 
-    fn send_query(
-        &self,
-        command: MinaIndexerQuery,
-    ) -> anyhow::Result<MinaIndexerQueryResponse> {
+    fn send_query(&self, command: MinaIndexerQuery) -> anyhow::Result<MinaIndexerQueryResponse> {
         let (response_sender, response_receiver) = oneshot::channel();
         self.query_sender
             .send((command, response_sender))
@@ -168,9 +165,7 @@ impl MinaIndexer {
     }
 
     pub fn blocks_processed(&self) -> anyhow::Result<u32> {
-        match self
-            .send_query(MinaIndexerQuery::NumBlocksProcessed)?
-        {
+        match self.send_query(MinaIndexerQuery::NumBlocksProcessed)? {
             MinaIndexerQueryResponse::NumBlocksProcessed(blocks_processed) => Ok(blocks_processed),
             _ => Err(anyhow!("unexpected response!")),
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -392,7 +392,7 @@ impl IndexerState {
                     debug!("Rate: {rate} blocks/s");
                 }
 
-                let precomputed_block = block_parser.next()?.unwrap();
+                let precomputed_block = block_parser.next_block()?.unwrap();
 
                 // apply and add to db
                 ledger.apply_post_balances(&precomputed_block);
@@ -447,7 +447,7 @@ impl IndexerState {
             );
         }
 
-        while let Some(block) = block_parser.next()? {
+        while let Some(block) = block_parser.next_block()? {
             if should_report_from_block_count(self.blocks_processed)
                 || self.should_report_from_time(step_time.elapsed())
             {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -392,7 +392,7 @@ impl IndexerState {
                     debug!("Rate: {rate} blocks/s");
                 }
 
-                let precomputed_block = block_parser.next().await?.unwrap();
+                let precomputed_block = block_parser.next()?.unwrap();
 
                 // apply and add to db
                 ledger.apply_post_balances(&precomputed_block);
@@ -447,7 +447,7 @@ impl IndexerState {
             );
         }
 
-        while let Some(block) = block_parser.next().await? {
+        while let Some(block) = block_parser.next()? {
             if should_report_from_block_count(self.blocks_processed)
                 || self.should_report_from_time(step_time.elapsed())
             {

--- a/tests/block/canonical_chain_discovery.rs
+++ b/tests/block/canonical_chain_discovery.rs
@@ -6,7 +6,7 @@ async fn gaps() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/gaps");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+    while let Some(precomputed_block) = block_parser.next().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -23,7 +23,7 @@ async fn contiguous() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+    while let Some(precomputed_block) = block_parser.next().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -40,7 +40,7 @@ async fn missing_parent() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/missing_parent");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+    while let Some(precomputed_block) = block_parser.next().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -72,7 +72,7 @@ async fn canonical_threshold() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, canonical_threshold).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+    while let Some(precomputed_block) = block_parser.next().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash

--- a/tests/block/canonical_chain_discovery.rs
+++ b/tests/block/canonical_chain_discovery.rs
@@ -6,7 +6,7 @@ async fn gaps() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/gaps");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().unwrap() {
+    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -23,7 +23,7 @@ async fn contiguous() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().unwrap() {
+    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -40,7 +40,7 @@ async fn missing_parent() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/missing_parent");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().unwrap() {
+    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash
@@ -72,7 +72,7 @@ async fn canonical_threshold() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, canonical_threshold).unwrap();
 
-    while let Some(precomputed_block) = block_parser.next().unwrap() {
+    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
         println!(
             "length: {}, hash: {}",
             precomputed_block.blockchain_length, precomputed_block.state_hash

--- a/tests/block/parser.rs
+++ b/tests/block/parser.rs
@@ -9,11 +9,7 @@ async fn representative_benches() {
     let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
 
-    while let Some(precomputed_block) = block_parser0
-        .next()
-        .await
-        .expect("IO Error on block_parser")
-    {
+    while let Some(precomputed_block) = block_parser0.next().expect("IO Error on block_parser") {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }
@@ -28,11 +24,7 @@ async fn representative_benches() {
     let mut block_parser1 = BlockParser::new_testing(&sample_dir1).unwrap();
 
     logs_processed = 0;
-    while let Some(precomputed_block) = block_parser1
-        .next()
-        .await
-        .expect("IO Error on block_parser")
-    {
+    while let Some(precomputed_block) = block_parser1.next().expect("IO Error on block_parser") {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }

--- a/tests/block/parser.rs
+++ b/tests/block/parser.rs
@@ -9,7 +9,10 @@ async fn representative_benches() {
     let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
 
-    while let Some(precomputed_block) = block_parser0.next().expect("IO Error on block_parser") {
+    while let Some(precomputed_block) = block_parser0
+        .next_block()
+        .expect("IO Error on block_parser")
+    {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }
@@ -24,7 +27,10 @@ async fn representative_benches() {
     let mut block_parser1 = BlockParser::new_testing(&sample_dir1).unwrap();
 
     logs_processed = 0;
-    while let Some(precomputed_block) = block_parser1.next().expect("IO Error on block_parser") {
+    while let Some(precomputed_block) = block_parser1
+        .next_block()
+        .expect("IO Error on block_parser")
+    {
         logs_processed += 1;
         dbg!(precomputed_block.state_hash);
     }

--- a/tests/block/store/add_and_get_blocks.rs
+++ b/tests/block/store/add_and_get_blocks.rs
@@ -25,7 +25,7 @@ async fn rocksdb() {
 
     let mut n = 0;
     let adding = Instant::now();
-    while let Some(block) = bp.next().unwrap() {
+    while let Some(block) = bp.next_block().unwrap() {
         let state_hash = block.state_hash.clone();
         db.add_block(&block).unwrap();
         blocks.insert(state_hash.clone(), block);

--- a/tests/block/store/add_and_get_blocks.rs
+++ b/tests/block/store/add_and_get_blocks.rs
@@ -25,7 +25,7 @@ async fn rocksdb() {
 
     let mut n = 0;
     let adding = Instant::now();
-    while let Some(block) = bp.next().await.unwrap() {
+    while let Some(block) = bp.next().unwrap() {
         let state_hash = block.state_hash.clone();
         db.add_block(&block).unwrap();
         blocks.insert(state_hash.clone(), block);

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -11,11 +11,11 @@ async fn extension() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     let mut n = 0;
-    if let Some(precomputed_block) = block_parser.next().unwrap() {
+    if let Some(precomputed_block) = block_parser.next_block().unwrap() {
         let mut state = IndexerState::new_testing(&precomputed_block, None, None, None).unwrap();
         n += 1;
 
-        while let Some(precomputed_block) = block_parser.next().unwrap() {
+        while let Some(precomputed_block) = block_parser.next_block().unwrap() {
             state.add_block(&precomputed_block).unwrap();
             n += 1;
         }

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -11,11 +11,11 @@ async fn extension() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     let mut n = 0;
-    if let Some(precomputed_block) = block_parser.next().await.unwrap() {
+    if let Some(precomputed_block) = block_parser.next().unwrap() {
         let mut state = IndexerState::new_testing(&precomputed_block, None, None, None).unwrap();
         n += 1;
 
-        while let Some(precomputed_block) = block_parser.next().await.unwrap() {
+        while let Some(precomputed_block) = block_parser.next().unwrap() {
             state.add_block(&precomputed_block).unwrap();
             n += 1;
         }


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/317, https://github.com/Granola-Team/mina-indexer/issues/316

Remove async from function definition from `parse_file` and improve logging