### PR TITLE
Disentangle canonical chain discovery from block parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,18 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,47 +406,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "26d4d6dafc1a3bb54687538972158f07b2c948bc57d5890df22c0739098b3028"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.13.2",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "bf4918709cc4dd777ad2b6303ed03cb37f3ca0ccede8c1b0d28ac6db8f4710e0"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "once_cell",
  "proc-macro-crate",
  "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
+ "syn_derive",
 ]
 
 [[package]]
@@ -575,6 +542,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clang-sys"
@@ -1266,15 +1239,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
+checksum = "b686a35799b53a9825575ca3f06481d0a053a409c4d97ffcf5ddd67a8760b497"
 
 [[package]]
 name = "gix-utils"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f"
+checksum = "9f82c41937f00e15a1f6cb0b55307f0ca1f77f4407ff2bf440be35aa688c6a3e"
 dependencies = [
  "fastrand",
 ]
@@ -1314,7 +1287,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash",
 ]
 
 [[package]]
@@ -1323,16 +1296,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.6",
+ "ahash",
 ]
 
 [[package]]
@@ -1541,6 +1505,17 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -2185,11 +2160,35 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
- "toml",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2325,15 +2324,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -2352,12 +2342,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -2454,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.32.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
+checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2470,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.32.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86444b802de0b10ac5e563b5ddb43b541b9705de4e01a50e82194d2b183c1835"
+checksum = "2e43721f4ef7060ebc2c3ede757733209564ca8207f47674181bcd425dd76945"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -2639,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "a15e0ef66bf939a7c890a0bf6d5a733c70202225f9888a89ed5c62298b019129"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2806,6 +2796,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,12 +2963,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "serde",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3063,9 +3073,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "utf8parse"
@@ -3125,9 +3135,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "watchexec"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b97d05a9305a9aa6a7bedef64cd012ebc9b6f1f5ed0368fb48f0fe58f96988"
+checksum = "5931215e14de2355a3039477138ae08a905abd7ad0265519fd79717ff1380f88"
 dependencies = [
  "async-priority-channel",
  "async-recursion",
@@ -3356,32 +3366,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "winnow"
+version = "0.5.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686b7e407015242119c33dab17b8f61ba6843534de936d94368856528eae4dcc"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020f3dfe25dfc38dfea49ce62d5d45ecdd7f0d8a724fa63eb36b6eba4ec76806"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,37 +15,37 @@ test = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = {version = "1.0.69"}
+anyhow = { version = "1.0.69" }
 async-trait = "0.1.64"
 futures = "0.3.26"
 futures-util = "0.3.26"
 serde = "1.0.152"
 serde_derive = "1.0.152"
-serde_json = {version = "1.0.92", features = [ "raw_value" ] }
-clap = { version = "4.1.4", features = [ "derive" ] }
+serde_json = { version = "1.0.92", features = ["raw_value"] }
+clap = { version = "4.1.4", features = ["derive"] }
 thiserror = "1.0.38"
 glob = "0.3.1"
-bin-prot = {path = "./mina-rs/protocol/bin-prot", version = "0.1.0"}
+bin-prot = { path = "./mina-rs/protocol/bin-prot", version = "0.1.0" }
 mina-serialization-types = { path = "./mina-rs/protocol/serialization-types", version = "0.1.0" }
 versioned = { path = "./mina-rs/protocol/versioned", version = "0.1.0" }
 mina-signer = { path = "./mina-rs/proof-systems/signer", version = "0.1.0" }
-rocksdb = { default-features = false, version = "0.21.0"}
+rocksdb = { default-features = false, version = "0.21.0" }
 bcs = "0.1.5"
-id_tree = { version = "1.8.0", features = ["serde_support"]}
+id_tree = { version = "1.8.0", features = ["serde_support"] }
 watchexec = "2.3.0"
 async-priority-channel = "0.1.0"
-interprocess = {version = "1.2.1", features = ["tokio", "tokio_support"]}
-uuid = { version = "1.3.1", features = [ "v4"] }
+interprocess = { version = "1.2.1", features = ["tokio", "tokio_support"] }
+uuid = { version = "1.3.1", features = ["v4"] }
 time = { version = "0.3.20", features = ["serde", "serde-human-readable"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 bytesize = "1.2.0"
-rust_decimal = {version = "1.32.0", features = ["serde"]}
-rust_decimal_macros = "1.32.0"
+rust_decimal = { version = "1.33.1", features = ["serde"] }
+rust_decimal_macros = "1.33.1"
 bs58 = { version = "0.5.0", features = ["check"] }
 blake2 = "0.10.6"
 ctrlc = "3.4.0"
-serde_yaml = "0.9.25"
+serde_yaml = "0.9.29"
 oneshot = "0.1.5"
 
 [dependencies.tokio]

--- a/src/block/canonical_chain_discovery.rs
+++ b/src/block/canonical_chain_discovery.rs
@@ -1,0 +1,342 @@
+use crate::{
+    block::{get_blockchain_length, get_state_hash, is_valid_block_file},
+    display_duration, BLOCK_REPORTING_FREQ_NUM,
+};
+use std::{
+    fs::File,
+    io::{prelude::*, SeekFrom},
+    path::{Path, PathBuf},
+    time::Instant,
+};
+use tracing::{debug, info};
+
+pub fn discovery(
+    length_filter: Option<u32>,
+    canonical_threshold: u32,
+    mut paths: Vec<&PathBuf>,
+) -> anyhow::Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+    // separate all blocks into the canonical chain
+    // and the blocks that follow the canonical tip
+    let mut canonical_paths = vec![];
+    let mut successive_paths = vec![];
+
+    if !paths.is_empty() {
+        info!("Sorting startup blocks by length");
+
+        let time = Instant::now();
+        paths.sort_by_key(|x| length_from_path_or_max(x));
+
+        info!(
+            "{} blocks sorted by length in {}",
+            paths.len(),
+            display_duration(time.elapsed()),
+        );
+
+        if let Some(blockchain_length) = length_filter {
+            info!("Applying block filter: blockchain_length < {blockchain_length}");
+            let filtered_paths: Vec<&PathBuf> = paths
+                .iter()
+                .map_while(|&path| {
+                    if length_from_path_or_max(path) < blockchain_length {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            paths = filtered_paths;
+        }
+
+        // keep track of:
+        // - diffs between blocks of successive lengths (to find gaps)
+        // - starting index for each collection of blocks of a fixed length
+        // - length of the current path under investigation
+        let mut length_start_indices_and_diffs = vec![];
+        let mut curr_length = length_from_path(paths.first().unwrap()).unwrap();
+
+        info!("Searching for canonical chain in startup blocks");
+
+        for (idx, path) in paths.iter().enumerate() {
+            let length = length_from_path_or_max(path);
+            if length > curr_length || idx == 0 {
+                length_start_indices_and_diffs.push((idx, length - curr_length));
+                curr_length = length;
+            } else {
+                continue;
+            }
+        }
+
+        // check that there are enough contiguous blocks for a canonical chain
+        let last_contiguous_first_noncontiguous_start_idx =
+            last_contiguous_first_noncontiguous_start_idx(&length_start_indices_and_diffs);
+        let last_contiguous_start_idx = last_contiguous_first_noncontiguous_start_idx
+            .map(|i| i.0)
+            .unwrap_or(length_start_indices_and_diffs.last().unwrap().0);
+        let last_contiguous_idx = last_contiguous_first_noncontiguous_start_idx
+            .map(|i| i.1.saturating_sub(1))
+            .unwrap_or(paths.len() - 1);
+        let canonical_tip_opt = find_canonical_tip(
+            paths.as_slice(),
+            &length_start_indices_and_diffs,
+            length_start_indices_and_diffs
+                .iter()
+                .position(|x| x.0 == last_contiguous_start_idx)
+                .unwrap_or(0),
+            last_contiguous_idx,
+            canonical_threshold,
+        );
+
+        if canonical_tip_opt.is_none()
+            || max_num_canonical_blocks(&length_start_indices_and_diffs, last_contiguous_start_idx)
+                < canonical_threshold
+        {
+            info!("No canoncial blocks can be confidently found. Adding all blocks to the witness tree.");
+            return Ok((vec![], paths.iter().cloned().cloned().collect()));
+        }
+
+        // backtrack `MAINNET_CANONICAL_THRESHOLD` blocks from
+        // the `last_contiguous_idx` to find the canonical tip
+        let time = Instant::now();
+        let (mut curr_length_idx, mut curr_start_idx) = canonical_tip_opt.unwrap();
+        let mut curr_path = paths[curr_length_idx];
+
+        info!(
+            "Found canonical tip with length {} and hash {} in {}",
+            length_from_path(curr_path).unwrap_or(0),
+            hash_from_path(curr_path),
+            display_duration(time.elapsed()),
+        );
+
+        // handle all blocks that are higher than the canonical tip
+        if let Some(successive_start_idx) =
+            next_length_start_index(paths.as_slice(), curr_length_idx)
+        {
+            debug!("Handle successive blocks");
+            if successive_start_idx < length_start_indices_and_diffs.len() {
+                for path in paths[successive_start_idx..]
+                    .iter()
+                    .filter(|p| length_from_path(p).is_some())
+                {
+                    successive_paths.push(path.to_path_buf());
+                }
+            }
+        }
+
+        // collect the canonical blocks
+        canonical_paths.push(curr_path.clone());
+
+        if canonical_paths.len() < BLOCK_REPORTING_FREQ_NUM as usize {
+            info!("Walking the canonical chain back to the beginning.");
+        } else {
+            info!("Walking the canonical chain back to the beginning, reporting every {BLOCK_REPORTING_FREQ_NUM} blocks.");
+        }
+
+        let time = Instant::now();
+        let mut count = 1;
+
+        // descend from the canonical tip to the lowest block in the dir,
+        // segment by segment, searching for ancestors
+        while curr_start_idx > 0 {
+            if count % BLOCK_REPORTING_FREQ_NUM == 0 {
+                info!(
+                    "Found {count} canonical blocks in {}",
+                    display_duration(time.elapsed())
+                );
+            }
+
+            // search for parent in previous segment's blocks
+            let mut parent_found = false;
+            let prev_length_idx = length_start_indices_and_diffs[curr_start_idx - 1].0;
+            let parent_hash = extract_parent_hash_from_path(curr_path)?;
+
+            for path in paths[prev_length_idx..curr_length_idx].iter() {
+                if parent_hash == hash_from_path(path) {
+                    canonical_paths.push(path.to_path_buf());
+                    curr_path = path;
+                    curr_length_idx = prev_length_idx;
+                    count += 1;
+                    curr_start_idx -= 1;
+                    parent_found = true;
+                    continue;
+                }
+            }
+
+            // handle case where we fail to find parent
+            if !parent_found {
+                info!(
+                    "Unable to locate parent block: mainnet-{}-{parent_hash}.json",
+                    length_from_path_or_max(curr_path) - 1,
+                );
+                return Ok((vec![], paths.iter().cloned().cloned().collect()));
+            }
+        }
+
+        // push the lowest canonical block
+        for path in paths[..curr_length_idx].iter() {
+            if extract_parent_hash_from_path(curr_path)? == hash_from_path(path) {
+                canonical_paths.push(path.to_path_buf());
+                break;
+            }
+        }
+
+        info!("Canonical chain discovery finished!");
+        info!(
+            "Found {} blocks in the canonical chain in {}",
+            canonical_paths.len(),
+            display_duration(time.elapsed()),
+        );
+
+        // sort lowest to highest
+        canonical_paths.reverse();
+    }
+
+    Ok((canonical_paths.to_vec(), successive_paths.to_vec()))
+}
+
+/// Gets the parent hash from the contents of the block's JSON file.
+/// This function depends on the current JSON layout for precomputed blocks
+/// and should be modified to use a custom `prev_state_hash` field deserializer.
+fn extract_parent_hash_from_path(path: &Path) -> anyhow::Result<String> {
+    let mut parent_hash_offset = 75;
+    let mut parent_hash = read_parent_hash(path, parent_hash_offset)?;
+
+    while !parent_hash.starts_with("3N") {
+        parent_hash_offset += 1;
+        parent_hash = read_parent_hash(path, parent_hash_offset)?;
+    }
+    Ok(parent_hash)
+}
+
+fn read_parent_hash(path: &Path, parent_hash_offset: u64) -> anyhow::Result<String> {
+    let parent_hash_length = 52;
+    let mut f = File::open(path)?;
+    let mut buf = vec![0; parent_hash_length];
+
+    f.seek(SeekFrom::Start(parent_hash_offset))?;
+    f.read_exact(&mut buf)?;
+    drop(f);
+    String::from_utf8(buf).map_err(anyhow::Error::from)
+}
+
+/// Checks if the block at `curr_path` is the _parent_ of the block at `path`.
+fn is_parent(path: &Path, curr_path: &Path) -> bool {
+    extract_parent_hash_from_path(curr_path).unwrap() == hash_from_path(path)
+}
+
+/// Returns the start index of the paths with next higher length.
+fn next_length_start_index(paths: &[&PathBuf], path_idx: usize) -> Option<usize> {
+    let length = length_from_path_or_max(paths[path_idx]);
+    for (n, path) in paths[path_idx..].iter().enumerate() {
+        if length_from_path_or_max(path) > length {
+            return Some(path_idx + n);
+        }
+    }
+    None
+}
+
+/// Finds the _canonical tip_, i.e. the _highest_ block in the
+/// _lowest contiguous chain_ with `canonical_threshold` ancestors.
+/// Unfortunately, the existence of this value does not necessarily imply
+/// the existence of a canonical chain within the collection of blocks.
+///
+/// Returns the index of the caonical tip in `paths` and the start index of the first successive block.
+fn find_canonical_tip(
+    paths: &[&PathBuf],
+    length_start_indices_and_diffs: &[(usize, u32)],
+    mut curr_start_idx: usize,
+    mut curr_length_idx: usize,
+    canonical_threshold: u32,
+) -> Option<(usize, usize)> {
+    if length_start_indices_and_diffs.len() <= canonical_threshold as usize {
+        None
+    } else {
+        let mut curr_path = &paths[curr_length_idx];
+
+        for n in 1..=canonical_threshold {
+            let mut parent_found = false;
+            let prev_length_start_idx = if curr_start_idx > 0 {
+                length_start_indices_and_diffs[curr_start_idx - 1].0
+            } else {
+                0
+            };
+
+            for path in paths[prev_length_start_idx..curr_length_idx].iter() {
+                // if the parent is found, check that it has a parent, etc
+                if is_parent(path, curr_path) {
+                    curr_path = path;
+                    curr_length_idx = prev_length_start_idx;
+                    curr_start_idx = curr_start_idx.saturating_sub(1);
+                    parent_found = true;
+                    continue;
+                }
+            }
+
+            // if a parent was not found
+            if !parent_found {
+                // begin the search again at the previous length
+                if curr_start_idx > canonical_threshold as usize {
+                    return find_canonical_tip(
+                        paths,
+                        length_start_indices_and_diffs,
+                        curr_start_idx.saturating_sub(1),
+                        prev_length_start_idx,
+                        canonical_threshold,
+                    );
+                } else {
+                    // canonical tip cannot be found
+                    return None;
+                }
+            }
+
+            // canonical tip found
+            if n == canonical_threshold && parent_found {
+                break;
+            }
+        }
+        Some((curr_length_idx, curr_start_idx))
+    }
+}
+
+/// Finds the index of the _highest possible block in the lowest contiguous chain_
+/// and the starting index of the next higher blocks.
+fn last_contiguous_first_noncontiguous_start_idx(
+    length_start_indices_and_diffs: &[(usize, u32)],
+) -> Option<(usize, usize)> {
+    let mut prev = 0;
+    for (idx, diff) in length_start_indices_and_diffs.iter() {
+        if *diff > 1 {
+            return Some((prev, *idx));
+        } else {
+            prev = *idx;
+        }
+    }
+    None
+}
+
+fn max_num_canonical_blocks(
+    length_start_indices_and_diffs: &[(usize, u32)],
+    last_contiguous_start_idx: usize,
+) -> u32 {
+    length_start_indices_and_diffs
+        .iter()
+        .position(|x| x.0 == last_contiguous_start_idx)
+        .unwrap_or(0) as u32
+        + 1
+}
+
+// path helpers
+fn length_from_path(path: &Path) -> Option<u32> {
+    if is_valid_block_file(path) {
+        get_blockchain_length(path.file_name()?)
+    } else {
+        None
+    }
+}
+
+fn length_from_path_or_max(path: &Path) -> u32 {
+    length_from_path(path).unwrap_or(u32::MAX)
+}
+
+fn hash_from_path(path: &Path) -> String {
+    get_state_hash(path.file_name().unwrap()).unwrap()
+}

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use self::precomputed::{BlockLogContents, PrecomputedBlock};
 
+pub mod canonical_chain_discovery;
 pub mod parser;
 pub mod precomputed;
 pub mod signed_command;

--- a/src/block/parser.rs
+++ b/src/block/parser.rs
@@ -1,19 +1,14 @@
-use crate::{
-    block::{get_blockchain_length, get_state_hash, precomputed::PrecomputedBlock},
-    display_duration, BLOCK_REPORTING_FREQ_NUM,
+use crate::block::{
+    canonical_chain_discovery, get_blockchain_length, is_valid_block_file, parse_file,
+    precomputed::PrecomputedBlock,
 };
 use anyhow::anyhow;
 use glob::glob;
 use std::{
-    fs::File,
-    io::{prelude::*, SeekFrom},
     path::{Path, PathBuf},
-    time::Instant,
     vec::IntoIter,
 };
-use tracing::{debug, info};
-
-use super::{is_valid_block_file, parse_file};
+use tracing::debug;
 
 /// Splits block paths into two collections: canonical and successive
 ///
@@ -47,13 +42,7 @@ impl BlockParser {
                 .filter_map(|x| x.ok())
                 .collect();
 
-            Ok(Self {
-                num_canonical: 0,
-                total_num_blocks: paths.len() as u32,
-                blocks_dir,
-                canonical_paths: vec![].into_iter(),
-                successive_paths: paths.into_iter(),
-            })
+            Ok(Self::empty(&blocks_dir, &paths))
         } else {
             Err(anyhow!("blocks_dir: {blocks_dir:?}, does not exist!"))
         }
@@ -72,206 +61,25 @@ impl BlockParser {
         if blocks_dir.exists() {
             let pattern = format!("{}/*.json", blocks_dir.display());
             let blocks_dir = blocks_dir.to_owned();
-            let mut paths: Vec<PathBuf> = glob(&pattern)?
+            let paths: Vec<PathBuf> = glob(&pattern)?
                 .filter_map(|x| x.ok())
                 .filter(|path| length_from_path(path).is_some())
                 .collect();
-
-            // separate all blocks into the canonical chain
-            // and the blocks that follow the canonical tip
-            let mut canonical_paths = vec![];
-            let mut successive_paths = vec![];
-
-            if !paths.is_empty() {
-                info!("Sorting startup blocks by length");
-
-                let time = Instant::now();
-                paths.sort_by_key(|x| length_from_path_or_max(x));
-
-                info!(
-                    "{} blocks sorted by length in {}",
-                    paths.len(),
-                    display_duration(time.elapsed()),
-                );
-
-                if let Some(blockchain_length) = length_filter {
-                    info!("Applying block filter: blockchain_length < {blockchain_length}");
-                    let filtered_paths: Vec<PathBuf> = paths
-                        .iter()
-                        .map_while(|path| {
-                            if length_from_path_or_max(path) < blockchain_length {
-                                Some(path.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    paths = filtered_paths;
-                }
-
-                // keep track of:
-                // - diffs between blocks of successive lengths (to find gaps)
-                // - starting index for each collection of blocks of a fixed length
-                // - length of the current path under investigation
-                let mut length_start_indices_and_diffs = vec![];
-                let mut curr_length = length_from_path(paths.first().unwrap()).unwrap();
-
-                info!("Searching for canonical chain in startup blocks");
-
-                for (idx, path) in paths.iter().enumerate() {
-                    let length = length_from_path_or_max(path);
-                    if length > curr_length || idx == 0 {
-                        length_start_indices_and_diffs.push((idx, length - curr_length));
-                        curr_length = length;
-                    } else {
-                        continue;
-                    }
-                }
-
-                // check that there are enough contiguous blocks for a canonical chain
-                let last_contiguous_first_noncontiguous_start_idx =
-                    last_contiguous_first_noncontiguous_start_idx(&length_start_indices_and_diffs);
-                let last_contiguous_start_idx = last_contiguous_first_noncontiguous_start_idx
-                    .map(|i| i.0)
-                    .unwrap_or(length_start_indices_and_diffs.last().unwrap().0);
-                let last_contiguous_idx = last_contiguous_first_noncontiguous_start_idx
-                    .map(|i| i.1.saturating_sub(1))
-                    .unwrap_or(paths.len() - 1);
-                let canonical_tip_opt = find_canonical_tip(
-                    &paths,
-                    &length_start_indices_and_diffs,
-                    length_start_indices_and_diffs
-                        .iter()
-                        .position(|x| x.0 == last_contiguous_start_idx)
-                        .unwrap_or(0),
-                    last_contiguous_idx,
-                    canonical_threshold,
-                );
-
-                if canonical_tip_opt.is_none()
-                    || max_num_canonical_blocks(
-                        &length_start_indices_and_diffs,
-                        last_contiguous_start_idx,
-                    ) < canonical_threshold
-                {
-                    info!("No canoncial blocks can be confidently found. Adding all blocks to the witness tree.");
-                    return Ok(Self {
-                        num_canonical: 0,
-                        total_num_blocks: paths.len() as u32,
-                        blocks_dir,
-                        canonical_paths: vec![].into_iter(),
-                        successive_paths: paths.into_iter(),
-                    });
-                }
-
-                // backtrack `MAINNET_CANONICAL_THRESHOLD` blocks from
-                // the `last_contiguous_idx` to find the canonical tip
-                let time = Instant::now();
-                let (mut curr_length_idx, mut curr_start_idx) = canonical_tip_opt.unwrap();
-                let mut curr_path = &paths[curr_length_idx];
-
-                info!(
-                    "Found canonical tip with length {} and hash {} in {}",
-                    length_from_path(curr_path).unwrap_or(0),
-                    hash_from_path(curr_path),
-                    display_duration(time.elapsed()),
-                );
-
-                // handle all blocks that are higher than the canonical tip
-                if let Some(successive_start_idx) = next_length_start_index(&paths, curr_length_idx)
-                {
-                    debug!("Handle successive blocks");
-                    if successive_start_idx < length_start_indices_and_diffs.len() {
-                        for path in paths[successive_start_idx..]
-                            .iter()
-                            .filter(|p| length_from_path(p).is_some())
-                        {
-                            successive_paths.push(path.clone());
-                        }
-                    }
-                }
-
-                // collect the canonical blocks
-                canonical_paths.push(curr_path.clone());
-
-                if canonical_paths.len() < BLOCK_REPORTING_FREQ_NUM as usize {
-                    info!("Walking the canonical chain back to the beginning.");
-                } else {
-                    info!("Walking the canonical chain back to the beginning, reporting every {BLOCK_REPORTING_FREQ_NUM} blocks.");
-                }
-
-                let time = Instant::now();
-                let mut count = 1;
-
-                // descend from the canonical tip to the lowest block in the dir,
-                // segment by segment, searching for ancestors
-                while curr_start_idx > 0 {
-                    if count % BLOCK_REPORTING_FREQ_NUM == 0 {
-                        info!(
-                            "Found {count} canonical blocks in {}",
-                            display_duration(time.elapsed())
-                        );
-                    }
-
-                    // search for parent in previous segment's blocks
-                    let mut parent_found = false;
-                    let prev_length_idx = length_start_indices_and_diffs[curr_start_idx - 1].0;
-                    let parent_hash = extract_parent_hash_from_path(curr_path)?;
-
-                    for path in paths[prev_length_idx..curr_length_idx].iter() {
-                        if parent_hash == hash_from_path(path) {
-                            canonical_paths.push(path.clone());
-                            curr_path = path;
-                            curr_length_idx = prev_length_idx;
-                            count += 1;
-                            curr_start_idx -= 1;
-                            parent_found = true;
-                            continue;
-                        }
-                    }
-
-                    // handle case where we fail to find parent
-                    if !parent_found {
-                        info!(
-                            "Unable to locate parent block: mainnet-{}-{parent_hash}.json",
-                            length_from_path_or_max(curr_path) - 1,
-                        );
-                        return Ok(Self {
-                            num_canonical: 0,
-                            total_num_blocks: paths.len() as u32,
-                            blocks_dir,
-                            canonical_paths: vec![].into_iter(),
-                            successive_paths: paths.into_iter(),
-                        });
-                    }
-                }
-
-                // push the lowest canonical block
-                for path in paths[..curr_length_idx].iter() {
-                    if extract_parent_hash_from_path(curr_path)? == hash_from_path(path) {
-                        canonical_paths.push(path.clone());
-                        break;
-                    }
-                }
-
-                info!("Canonical chain discovery finished!");
-                info!(
-                    "Found {} blocks in the canonical chain in {}",
-                    canonical_paths.len(),
-                    display_duration(time.elapsed()),
-                );
-
-                // sort lowest to highest
-                canonical_paths.reverse();
+            if let Ok((canonical_paths, successive_paths)) = canonical_chain_discovery::discovery(
+                length_filter,
+                canonical_threshold,
+                paths.iter().collect(),
+            ) {
+                Ok(Self {
+                    num_canonical: canonical_paths.len() as u32,
+                    total_num_blocks: (canonical_paths.len() + successive_paths.len()) as u32,
+                    blocks_dir,
+                    canonical_paths: canonical_paths.into_iter(),
+                    successive_paths: successive_paths.into_iter(),
+                })
+            } else {
+                Ok(Self::empty(&blocks_dir, &paths))
             }
-
-            Ok(Self {
-                num_canonical: canonical_paths.len() as u32,
-                total_num_blocks: (canonical_paths.len() + successive_paths.len()) as u32,
-                blocks_dir,
-                canonical_paths: canonical_paths.into_iter(),
-                successive_paths: successive_paths.into_iter(),
-            })
         } else {
             Err(anyhow!("blocks_dir: {blocks_dir:?}, does not exist!"))
         }
@@ -308,154 +116,24 @@ impl BlockParser {
 
         Ok(next_block)
     }
-}
 
-/// Gets the parent hash from the contents of the block's JSON file.
-/// This function depends on the current JSON layout for precomputed blocks
-/// and should be modified to use a custom `prev_state_hash` field deserializer.
-fn extract_parent_hash_from_path(path: &Path) -> anyhow::Result<String> {
-    let mut parent_hash_offset = 75;
-    let mut parent_hash = read_parent_hash(path, parent_hash_offset)?;
-
-    while !parent_hash.starts_with("3N") {
-        parent_hash_offset += 1;
-        parent_hash = read_parent_hash(path, parent_hash_offset)?;
-    }
-    Ok(parent_hash)
-}
-
-fn read_parent_hash(path: &Path, parent_hash_offset: u64) -> anyhow::Result<String> {
-    let parent_hash_length = 52;
-    let mut f = File::open(path)?;
-    let mut buf = vec![0; parent_hash_length];
-
-    f.seek(SeekFrom::Start(parent_hash_offset))?;
-    f.read_exact(&mut buf)?;
-    drop(f);
-    String::from_utf8(buf).map_err(anyhow::Error::from)
-}
-
-/// Checks if the block at `curr_path` is the _parent_ of the block at `path`.
-fn is_parent(path: &Path, curr_path: &Path) -> bool {
-    extract_parent_hash_from_path(curr_path).unwrap() == hash_from_path(path)
-}
-
-/// Returns the start index of the paths with next higher length.
-fn next_length_start_index(paths: &[PathBuf], path_idx: usize) -> Option<usize> {
-    let length = length_from_path_or_max(&paths[path_idx]);
-    for (n, path) in paths[path_idx..].iter().enumerate() {
-        if length_from_path_or_max(path) > length {
-            return Some(path_idx + n);
+    fn empty(blocks_dir: &Path, paths: &Vec<PathBuf>) -> Self {
+        Self {
+            num_canonical: 0,
+            total_num_blocks: paths.len() as u32,
+            blocks_dir: blocks_dir.to_path_buf(),
+            canonical_paths: vec![].into_iter(),
+            successive_paths: paths.clone().into_iter(),
         }
     }
-    None
 }
 
-/// Finds the _canonical tip_, i.e. the _highest_ block in the
-/// _lowest contiguous chain_ with `canonical_threshold` ancestors.
-/// Unfortunately, the existence of this value does not necessarily imply
-/// the existence of a canonical chain within the collection of blocks.
-///
-/// Returns the index of the caonical tip in `paths` and the start index of the first successive block.
-fn find_canonical_tip(
-    paths: &[PathBuf],
-    length_start_indices_and_diffs: &[(usize, u32)],
-    mut curr_start_idx: usize,
-    mut curr_length_idx: usize,
-    canonical_threshold: u32,
-) -> Option<(usize, usize)> {
-    if length_start_indices_and_diffs.len() <= canonical_threshold as usize {
-        None
-    } else {
-        let mut curr_path = &paths[curr_length_idx];
-
-        for n in 1..=canonical_threshold {
-            let mut parent_found = false;
-            let prev_length_start_idx = if curr_start_idx > 0 {
-                length_start_indices_and_diffs[curr_start_idx - 1].0
-            } else {
-                0
-            };
-
-            for path in paths[prev_length_start_idx..curr_length_idx].iter() {
-                // if the parent is found, check that it has a parent, etc
-                if is_parent(path, curr_path) {
-                    curr_path = path;
-                    curr_length_idx = prev_length_start_idx;
-                    curr_start_idx = curr_start_idx.saturating_sub(1);
-                    parent_found = true;
-                    continue;
-                }
-            }
-
-            // if a parent was not found
-            if !parent_found {
-                // begin the search again at the previous length
-                if curr_start_idx > canonical_threshold as usize {
-                    return find_canonical_tip(
-                        paths,
-                        length_start_indices_and_diffs,
-                        curr_start_idx.saturating_sub(1),
-                        prev_length_start_idx,
-                        canonical_threshold,
-                    );
-                } else {
-                    // canonical tip cannot be found
-                    return None;
-                }
-            }
-
-            // canonical tip found
-            if n == canonical_threshold && parent_found {
-                break;
-            }
-        }
-        Some((curr_length_idx, curr_start_idx))
-    }
-}
-
-/// Finds the index of the _highest possible block in the lowest contiguous chain_
-/// and the starting index of the next higher blocks.
-fn last_contiguous_first_noncontiguous_start_idx(
-    length_start_indices_and_diffs: &[(usize, u32)],
-) -> Option<(usize, usize)> {
-    let mut prev = 0;
-    for (idx, diff) in length_start_indices_and_diffs.iter() {
-        if *diff > 1 {
-            return Some((prev, *idx));
-        } else {
-            prev = *idx;
-        }
-    }
-    None
-}
-
-fn max_num_canonical_blocks(
-    length_start_indices_and_diffs: &[(usize, u32)],
-    last_contiguous_start_idx: usize,
-) -> u32 {
-    length_start_indices_and_diffs
-        .iter()
-        .position(|x| x.0 == last_contiguous_start_idx)
-        .unwrap_or(0) as u32
-        + 1
-}
-
-// path helpers
 fn length_from_path(path: &Path) -> Option<u32> {
     if is_valid_block_file(path) {
         get_blockchain_length(path.file_name()?)
     } else {
         None
     }
-}
-
-fn length_from_path_or_max(path: &Path) -> u32 {
-    length_from_path(path).unwrap_or(u32::MAX)
-}
-
-fn hash_from_path(path: &Path) -> String {
-    get_state_hash(path.file_name().unwrap()).unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
DONE:
- creates a separate module for canonical chain discovery
- abstracts block parsing over canonical chain discovery
- address flakiness of block receiver tests
- update `zerocopy` and `serde_yaml` deps

TODO:
- completely separate concerns

Fixes (https://github.com/Granola-Team/mina-indexer/issues/318)