### PR TITLE
Add Nix warning about broken versions

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,7 @@ build:
 
 clean:
   cargo clean
+  rm -rf result
 
 test: test-unit test-regression
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ To build the mina-indexer binaries, run the following command:
 nix build '.?submodules=1'
 ```
 
+**Note:** There is an issue with versions of nix `2.19.x` where it
+doesn't correctly build the binary. Use versions `2.18.x` or
+below. Otherwise, here is a workaround command if you're unable to
+downgrade to a supported version:
+
+```bash
+nix build "git+file://$(pwd)?submodules=1"
+```
+
 This will compile the binaries and place them in `./result/bin`.
 
 ### Running Tests


### PR DESCRIPTION
Clean our results directory on `just clean`

Fixes: https://github.com/Granola-Team/mina-indexer/issues/354, https://github.com/Granola-Team/mina-indexer/issues/356