### PR TITLE
In-memory ledger and regression tests

### DIFF
--- a/download_blocks
+++ b/download_blocks
@@ -11,13 +11,14 @@ download_blocks_cleanup() {
 trap download_blocks_cleanup EXIT
 
 BUCKET=$1
-MAX_SLOT=$2
-NETWORK=$3
-OUT_DIR=$4
+MIN_LENGTH=$2
+MAX_LENGTH=$3
+NETWORK=$4
+OUT_DIR=$5
 
-for SLOT in `seq 2 $MAX_SLOT`
+for LENGTH in `seq $MIN_LENGTH $MAX_LENGTH`
 do
-    echo "gs://${BUCKET}/${NETWORK}-${SLOT}-*.json" >> "$BLOCKS_DIR"/block_urls
+    echo "gs://${BUCKET}/${NETWORK}-${LENGTH}-*.json" >> "$BLOCKS_DIR"/block_urls
 done 2>/dev/null
 
 gsutil -m cp -I "$OUT_DIR" < "$BLOCKS_DIR"/block_urls

--- a/src/bin/mainnet-test.rs
+++ b/src/bin/mainnet-test.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 use mina_indexer::{
     block::parser::BlockParser,
     constants::{
-        CANONICAL_UPDATE_THRESHOLD, MAINNET_CANONICAL_THRESHOLD, MAINNET_TRANSITION_FRONTIER_K,
-        PRUNE_INTERVAL_DEFAULT,
+        CANONICAL_UPDATE_THRESHOLD, LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD,
+        MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT,
     },
     ledger::genesis,
     state::IndexerState,
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,
         CANONICAL_UPDATE_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/src/bin/mainnet-test.rs
+++ b/src/bin/mainnet-test.rs
@@ -24,10 +24,10 @@ use tracing_subscriber::prelude::*;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Startup blocks directory path
-    #[arg(short, long, default_value = concat!(env!("HOME"), ".mina-indexer/startup-blocks"))]
+    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/startup-blocks"))]
     blocks_dir: PathBuf,
     /// Watch blocks directory path
-    #[arg(short, long, default_value = concat!(env!("HOME"), ".mina-indexer/watch-blocks"))]
+    #[arg(short, long, default_value = concat!(env!("HOME"), "/.mina-indexer/watch-blocks"))]
     watch_dir: PathBuf,
     /// Max blockchain_length of blocks to parse
     #[arg(short = 'l', long, default_value_t = 10_000)]

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -103,7 +103,7 @@ pub async fn main() -> anyhow::Result<()> {
             };
             let database_dir = args.database_dir.clone();
             if let Ok(dir) = std::fs::read_dir(database_dir.clone()) {
-                if dir.count() != 0 {
+                if matches!(mode, InitializationMode::New) && dir.count() != 0 {
                     // sync from existing db
                     mode = InitializationMode::Sync;
                 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -133,10 +133,7 @@ pub struct UserCommandWithStatus(pub UserCommandWithStatusV1);
 
 impl UserCommandWithStatus {
     pub fn is_applied(&self) -> bool {
-        if let CommandStatusData::Applied { .. } = self.status_data() {
-            return true;
-        }
-        false
+        self.status_data().is_applied()
     }
 
     pub fn status_data(&self) -> CommandStatusData {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -57,28 +57,74 @@ pub struct Delegation {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum CommandStatusData {
     Applied {
-        balance_data: mina_rs::TransactionStatusBalanceData,
+        auxiliary_data: Box<mina_rs::TransactionStatusAuxiliaryData>,
+        balance_data: Box<mina_rs::TransactionStatusBalanceData>,
     },
     Failed,
 }
 
 impl CommandStatusData {
-    pub fn fee_payer_balance(data: &mina_rs::TransactionStatusBalanceData) -> Option<u64> {
-        data.fee_payer_balance.as_ref().map(|balance| balance.t.t.t)
+    pub fn is_applied(&self) -> bool {
+        matches!(self, Self::Applied { .. })
     }
 
-    pub fn receiver_balance(balance_data: &mina_rs::TransactionStatusBalanceData) -> Option<u64> {
-        balance_data
-            .receiver_balance
-            .as_ref()
-            .map(|balance| balance.t.t.t)
+    fn balance_data(&self) -> Option<&mina_rs::TransactionStatusBalanceData> {
+        if let Self::Applied { balance_data, .. } = self {
+            return Some(balance_data);
+        }
+        None
     }
 
-    pub fn source_balance(balance_data: &mina_rs::TransactionStatusBalanceData) -> Option<u64> {
-        balance_data
-            .source_balance
-            .as_ref()
-            .map(|balance| balance.t.t.t)
+    fn auxiliary_data(&self) -> Option<&mina_rs::TransactionStatusAuxiliaryData> {
+        if let Self::Applied { auxiliary_data, .. } = self {
+            return Some(auxiliary_data);
+        }
+        None
+    }
+
+    pub fn fee_payer_balance(&self) -> Option<u64> {
+        self.balance_data()
+            .and_then(|b| b.fee_payer_balance.as_ref().map(|b| b.t.t.t))
+    }
+
+    pub fn receiver_balance(&self) -> Option<u64> {
+        self.balance_data()
+            .and_then(|b| b.receiver_balance.as_ref().map(|b| b.t.t.t))
+    }
+
+    pub fn source_balance(&self) -> Option<u64> {
+        self.balance_data()
+            .and_then(|b| b.source_balance.as_ref().map(|b| b.t.t.t))
+    }
+
+    pub fn fee_payer_account_creation_fee_paid(&self) -> Option<u64> {
+        self.auxiliary_data().and_then(|b| {
+            b.fee_payer_account_creation_fee_paid
+                .as_ref()
+                .map(|b| b.t.t)
+        })
+    }
+
+    pub fn receiver_account_creation_fee_paid(&self) -> Option<u64> {
+        self.auxiliary_data()
+            .and_then(|b| b.receiver_account_creation_fee_paid.as_ref().map(|b| b.t.t))
+    }
+
+    pub fn created_token(&self) -> Option<u64> {
+        self.auxiliary_data()
+            .and_then(|b| b.created_token.as_ref().map(|b| b.t.t.t))
+    }
+
+    pub fn from_transaction_status(data: &mina_rs::TransactionStatus) -> Self {
+        use mina_rs::TransactionStatus as TS;
+
+        match data {
+            TS::Applied(auxiliary_data, balance_data) => Self::Applied {
+                auxiliary_data: Box::new(auxiliary_data.clone().inner()),
+                balance_data: Box::new(balance_data.clone().inner()),
+            },
+            _ => Self::Failed,
+        }
     }
 }
 
@@ -96,10 +142,11 @@ impl UserCommandWithStatus {
     pub fn status_data(&self) -> CommandStatusData {
         match self.0.t.status.t.clone() {
             mina_serialization_types::staged_ledger_diff::TransactionStatus::Applied(
-                _,
+                auxiliary_data,
                 balance_data,
             ) => CommandStatusData::Applied {
-                balance_data: balance_data.inner(),
+                auxiliary_data: Box::new(auxiliary_data.inner()),
+                balance_data: Box::new(balance_data.inner()),
             },
             mina_serialization_types::staged_ledger_diff::TransactionStatus::Failed(_, _) => {
                 CommandStatusData::Failed
@@ -230,6 +277,12 @@ impl StakeDelegation {
     pub fn new_delegate(&self) -> PublicKey {
         let mina_rs::StakeDelegation::SetDelegate { new_delegate, .. } = self.0.clone().inner();
         new_delegate.into()
+    }
+}
+
+impl From<mina_rs::TransactionStatus> for CommandStatusData {
+    fn from(value: mina_rs::TransactionStatus) -> Self {
+        Self::from_transaction_status(&value)
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 use crate::ledger::account::Amount;
 
-pub const BLOCK_REPORTING_FREQ_NUM: u32 = 5000;
+pub const BLOCK_REPORTING_FREQ_NUM: u32 = 100;
 pub const BLOCK_REPORTING_FREQ_SEC: u64 = 180;
 pub const LEDGER_CADENCE: u32 = 100;
 pub const CANONICAL_UPDATE_THRESHOLD: u32 = PRUNE_INTERVAL_DEFAULT / 5;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,7 @@ use crate::ledger::account::Amount;
 
 pub const BLOCK_REPORTING_FREQ_NUM: u32 = 5000;
 pub const BLOCK_REPORTING_FREQ_SEC: u64 = 180;
+pub const LEDGER_CADENCE: u32 = 100;
 pub const CANONICAL_UPDATE_THRESHOLD: u32 = PRUNE_INTERVAL_DEFAULT / 5;
 pub const MAINNET_CANONICAL_THRESHOLD: u32 = 10;
 pub const MAINNET_GENESIS_HASH: &str = "3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ";

--- a/src/ledger/coinbase.rs
+++ b/src/ledger/coinbase.rs
@@ -71,7 +71,11 @@ impl Coinbase {
         !matches!(self.kind, CoinbaseKind::Zero)
     }
 
-    pub fn as_account_diff(self) -> AccountDiff {
-        AccountDiff::from_coinbase(self.receiver, self.supercharge)
+    // only apply if "coinbase" =/= [ "Zero" ]
+    pub fn as_account_diff(self) -> Option<AccountDiff> {
+        if self.is_coinbase_applied() {
+            return Some(AccountDiff::from_coinbase(self.receiver, self.supercharge));
+        }
+        None
     }
 }

--- a/src/ledger/diff/mod.rs
+++ b/src/ledger/diff/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct LedgerDiff {
     pub public_keys_seen: Vec<PublicKey>,
     pub account_diffs: Vec<AccountDiff>,

--- a/src/ledger/diff/mod.rs
+++ b/src/ledger/diff/mod.rs
@@ -31,9 +31,7 @@ impl LedgerDiff {
         account_diffs.append(&mut account_diff_transactions);
 
         // apply coinbase last
-        // only apply if "coinbase" =/= [ "Zero" ]
-        let coinbase_update = coinbase.clone().as_account_diff();
-        if coinbase.is_coinbase_applied() {
+        if let Some(coinbase_update) = coinbase.as_account_diff() {
             account_diffs.push(coinbase_update);
         }
 
@@ -45,7 +43,9 @@ impl LedgerDiff {
 
     pub fn append(&mut self, other: Self) {
         other.public_keys_seen.into_iter().for_each(|account| {
-            self.public_keys_seen.push(account);
+            if !self.public_keys_seen.contains(&account) {
+                self.public_keys_seen.push(account);
+            }
         });
 
         other.account_diffs.into_iter().for_each(|update| {

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -321,41 +321,6 @@ impl std::fmt::Debug for Ledger {
     }
 }
 
-pub trait ExtendWithLedgerDiff {
-    fn extend_with_diff(self, ledger_diff: LedgerDiff) -> Self;
-    fn from_diff(ledger_diff: LedgerDiff) -> Self;
-}
-
-impl ExtendWithLedgerDiff for Ledger {
-    fn extend_with_diff(self, ledger_diff: LedgerDiff) -> Self {
-        let mut ledger = self;
-        ledger
-            ._apply_diff(&ledger_diff)
-            .expect("diff applied successfully");
-        ledger
-    }
-
-    fn from_diff(ledger_diff: LedgerDiff) -> Self {
-        let mut ledger = Ledger::new();
-        ledger
-            ._apply_diff(&ledger_diff)
-            .expect("diff applied successfully");
-        ledger
-    }
-}
-
-impl ExtendWithLedgerDiff for LedgerDiff {
-    fn extend_with_diff(self, ledger_diff: LedgerDiff) -> Self {
-        let mut to_extend = self;
-        to_extend.append(ledger_diff);
-        to_extend
-    }
-
-    fn from_diff(ledger_diff: LedgerDiff) -> Self {
-        ledger_diff
-    }
-}
-
 impl std::fmt::Display for LedgerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/ledger/post_balances.rs
+++ b/src/ledger/post_balances.rs
@@ -23,69 +23,63 @@ pub struct PostBalance {
 impl PostBalanceUpdate {
     /// Compute a post balance update from the givien block
     pub fn from_precomputed(precomputed_block: &PrecomputedBlock) -> Vec<Self> {
-        let mut updates = vec![];
-        // TODO fee transfers
-        // fee_payer -> coinbase_receiver
-        // InternalCommand::from_precomputed(precomputed_block)
-
         // user commands updates
         let mut commands: Vec<Self> = precomputed_block
             .commands()
             .iter()
             .flat_map(|command| {
+                let status = command.status_data();
                 let signed_command = SignedCommand::from_user_command(command.clone());
                 let source_nonce = signed_command.source_nonce();
+                let fee_payer = signed_command.fee_payer_pk();
+                let source = signed_command.source_pk();
+                let receiver = signed_command.receiver_pk();
+                let fee_payer_balance = CommandStatusData::fee_payer_balance(&status);
+                let receiver_balance = CommandStatusData::receiver_balance(&status);
+                let source_balance = CommandStatusData::source_balance(&status);
 
-                if let CommandStatusData::Applied { balance_data } = command.status_data() {
-                    let fee_payer = signed_command.fee_payer_pk();
-                    let source = signed_command.source_pk();
-                    let receiver = signed_command.receiver_pk();
-                    let fee_payer_balance = CommandStatusData::fee_payer_balance(&balance_data);
-                    let receiver_balance = CommandStatusData::receiver_balance(&balance_data);
-                    let source_balance = CommandStatusData::source_balance(&balance_data);
+                if let (Some(fee_payer_balance), Some(receiver_balance), Some(source_balance)) =
+                    (fee_payer_balance, receiver_balance, source_balance)
+                {
+                    let user_command_type = if signed_command.is_delegation() {
+                        CommandType::Delegation
+                    } else {
+                        CommandType::Payment
+                    };
 
-                    if let (Some(fee_payer_balance), Some(receiver_balance), Some(source_balance)) =
-                        (fee_payer_balance, receiver_balance, source_balance)
-                    {
-                        let user_command_type = if signed_command.is_delegation() {
-                            CommandType::Delegation
-                        } else {
-                            CommandType::Payment
-                        };
-
-                        return Some(PostBalanceUpdate::User(CommandUpdate {
-                            source_nonce,
-                            command_type: user_command_type,
-                            fee_payer: PostBalance {
-                                public_key: fee_payer,
-                                balance: fee_payer_balance,
-                            },
-                            source: PostBalance {
-                                public_key: source,
-                                balance: source_balance,
-                            },
-                            receiver: PostBalance {
-                                public_key: receiver,
-                                balance: receiver_balance,
-                            },
-                        }));
-                    }
+                    return Some(PostBalanceUpdate::User(CommandUpdate {
+                        source_nonce,
+                        command_type: user_command_type,
+                        fee_payer: PostBalance {
+                            public_key: fee_payer,
+                            balance: fee_payer_balance,
+                        },
+                        source: PostBalance {
+                            public_key: source,
+                            balance: source_balance,
+                        },
+                        receiver: PostBalance {
+                            public_key: receiver,
+                            balance: receiver_balance,
+                        },
+                    }));
                 }
 
                 None
             })
             .collect();
 
-        let balance = if Coinbase::from_precomputed(precomputed_block).is_coinbase_applied() {
-            precomputed_block.coinbase_receiver_balance().unwrap_or(0)
-        } else {
-            0
-        };
-        updates.push(PostBalanceUpdate::Coinbase(PostBalance {
-            public_key: precomputed_block.coinbase_receiver(),
-            balance,
-        }));
-        commands.append(&mut updates);
+        // coinbase update
+        if let Some(balance) = precomputed_block
+            .coinbase_receiver_balance()
+            .filter(|_| Coinbase::from_precomputed(precomputed_block).is_coinbase_applied())
+        {
+            commands.push(PostBalanceUpdate::Coinbase(PostBalance {
+                public_key: precomputed_block.coinbase_receiver(),
+                balance,
+            }));
+        }
+
         commands
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -176,6 +176,7 @@ pub async fn initialize(
                 info!("Replaying indexer events from db at {}", db_path.display());
                 IndexerState::new_without_genesis_events(
                     &root_hash,
+                    ledger.ledger.clone(),
                     store,
                     MAINNET_TRANSITION_FRONTIER_K,
                     prune_interval,
@@ -186,6 +187,7 @@ pub async fn initialize(
                 info!("Syncing indexer state from db at {}", db_path.display());
                 IndexerState::new_without_genesis_events(
                     &root_hash,
+                    ledger.ledger.clone(),
                     store,
                     MAINNET_TRANSITION_FRONTIER_K,
                     prune_interval,

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,7 @@ pub struct IndexerConfiguration {
     pub canonical_threshold: u32,
     pub canonical_update_threshold: u32,
     pub initialization_mode: InitializationMode,
+    pub ledger_cadence: u32,
 }
 
 pub enum MinaIndexerQuery {
@@ -152,6 +153,7 @@ pub async fn initialize(
         canonical_threshold,
         canonical_update_threshold,
         initialization_mode,
+        ledger_cadence,
     } = config;
 
     fs::create_dir_all(startup_dir.clone()).expect("startup_dir created");
@@ -170,6 +172,7 @@ pub async fn initialize(
                     MAINNET_TRANSITION_FRONTIER_K,
                     prune_interval,
                     canonical_update_threshold,
+                    ledger_cadence,
                 )?
             }
             InitializationMode::Replay => {
@@ -181,6 +184,7 @@ pub async fn initialize(
                     MAINNET_TRANSITION_FRONTIER_K,
                     prune_interval,
                     canonical_update_threshold,
+                    ledger_cadence,
                 )?
             }
             InitializationMode::Sync => {
@@ -192,6 +196,7 @@ pub async fn initialize(
                     MAINNET_TRANSITION_FRONTIER_K,
                     prune_interval,
                     canonical_update_threshold,
+                    ledger_cadence,
                 )?
             }
         };

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -890,11 +890,11 @@ impl IndexerState {
                     },
                     DbEvent::Ledger(ledger_event) => match ledger_event {
                         DbLedgerEvent::AlreadySeenLedger(hash) => {
-                            info!("replay already seen db ledger with hash {hash}");
+                            info!("Replay already seen db ledger with hash {hash}");
                             Ok(())
                         }
                         DbLedgerEvent::NewLedger { hash } => {
-                            info!("replay new db ledger hash {hash}");
+                            info!("Replay new db ledger hash {hash}");
                             Ok(())
                         }
                     },
@@ -903,14 +903,14 @@ impl IndexerState {
                             blockchain_length,
                             state_hash,
                         } => {
-                            info!("replay new canonical block (height: {blockchain_length}, hash: {state_hash})");
+                            info!("Replay new canonical block (height: {blockchain_length}, hash: {state_hash})");
                             Ok(())
                         }
                     },
                 }
             }
             IndexerEvent::WitnessTree(WitnessTreeEvent::UpdateCanonicalChain(blocks)) => {
-                info!("replay update canonical chain {:?}", blocks);
+                info!("Replay update canonical chain {:?}", blocks);
                 Ok(())
             }
         }

--- a/test
+++ b/test
@@ -580,15 +580,16 @@ test_transactions() {
 # Indexer server correctly creates a db checkpoint
 test_checkpoint() {
     test=test_checkpoint
-    setup
 
+    setup
     dl_mainnet 13 ./blocks
+
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # pre-checkpoint results
     canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -611,7 +612,7 @@ test_checkpoint() {
         --watch-dir ./blocks \
         --database-dir ./checkpoint \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # post-checkpoint reults
     canonical_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -628,6 +629,48 @@ test_checkpoint() {
 
     idxr_pid=$(pgrep -c mina-indexer)
     rm -rf ./checkpoint
+    teardown
+}
+
+# Indexer server starts with many blocks
+test_many_blocks() {
+    test=test_many_blocks
+
+    setup
+    # dl_mainnet 1000 ./blocks
+
+    idxr server cli \
+        --startup-dir $HOME/Documents/granola/indexer/mainnet_blocks \
+        --watch-dir $HOME/Documents/granola/indexer/mainnet_blocks \
+        --database-dir ./database \
+        --log-dir ./logs \
+        --ledger-cadence 100 \
+        --log-level-stdout debug &
+    sleep 300
+
+    # results
+    best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+
+    assert '1000' $best_length
+    assert '990' $canonical_length
+    assert '3NK9aySQJBEgAUKcWGrpbZhA4M8wL2N3cjipq3mEb4HPTuUkowEF' $canonical_hash
+    assert '3NKrnCRmvomXqor8pnqrUsLv4XcofJBu8VWqAsWRirGNPszo1a66' $best_hash
+
+    pk='B62qpJ4Q5J4LoBXgQBfq6gbXTyevFPhwMNYZEBdTSixmFq4UrdNadSN'
+
+    # check ledgers are present
+    # mainnet-100-3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4.json
+    balance=$(idxr ledger --hash 3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4 | jq -r .${pk}.balance)
+    assert '502777775000000' $balance
+
+    # mainnet-900-3NLHqp2mkmWbf4o69J4hg5cftRAAvZ5Edy7uqvJUUVvZWtD1xRrh.json
+    balance=$(idxr ledger --hash 3NLHqp2mkmWbf4o69J4hg5cftRAAvZ5Edy7uqvJUUVvZWtD1xRrh | jq -r .${pk}.balance)
+    assert '502777775000000' $balance
+
+    idxr_pid=$(pgrep -c mina-indexer)
     teardown
 }
 
@@ -648,6 +691,7 @@ if [ "$#" -eq 0 ]; then
     test_replay
     test_transactions
     test_checkpoint
+    test_many_blocks
 else
     # Run only specified tests
     for test_name in "$@"; do
@@ -666,6 +710,7 @@ else
             "test_replay") test_replay ;;
             "test_transactions") test_transactions ;;
             "test_checkpoint") test_checkpoint ;;
+            "test_many_blocks") test_many_blocks ;;
             *) echo "Unknown test: $test_name" ;;
         esac
     done

--- a/test
+++ b/test
@@ -331,7 +331,7 @@ test_best_chain() {
     result=$(idxr best-chain -v | jq -r .[0].state_hash)
     assert '3NKkJDmNZGYdKVDDJkkamGdvNzASia2SXxKpu18imps7KqbNXENY' $result
 
-    # with bounds
+    # best chain with bounds
     bounds=$(idxr best-chain \
         --start-state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R \
         --end-state-hash 3NKQUoBfi9vkbuqtDJmSEYBQrcSo4GjwG8bPCiii4yqM8AxEQvtY \
@@ -399,12 +399,27 @@ test_ledgers() {
     assert '607904750000000' $best_result
     assert '607904750000000' $hash_result
 
-    # write ledger to file
-    file=./ledgers/$best_hash.json
+    # write ledgers to file
+    file=./ledgers/best-$best_height-$best_hash.json
+    idxr best-ledger -p $file
+    
+    file_result=$(cat $file | jq -r .${pk}.balance)
+    assert '607904750000000' $file_result
+    rm -f $file
+
+    file=./ledgers/ledger-$best_height-$best_hash.json
     idxr ledger --hash $best_hash -p $file
     
     file_result=$(cat $file | jq -r .${pk}.balance)
     assert '607904750000000' $file_result
+    rm -f $file
+
+    file=./ledgers/height-$canonical_height-$best_hash.json
+    idxr ledger-at-height --height $canonical_height -p $file
+    
+    file_result=$(cat $file | jq -r .${pk}.balance)
+    assert '607904750000000' $file_result
+    rm -f $file
 
     idxr_pid=$(pgrep -c mina-indexer)
     rm -rf ledgers

--- a/test
+++ b/test
@@ -27,7 +27,15 @@ idxr() {
 }
 
 dl_mainnet() {
-    "$BLOCKS_FETCHER" mina_network_block_data "$1" mainnet "$2"
+    "$BLOCKS_FETCHER" mina_network_block_data 2 "$1" mainnet "$2"
+}
+
+dl_mainnet_single() {
+    "$BLOCKS_FETCHER" mina_network_block_data "$1" "$1" mainnet "$2"
+}
+
+dl_mainnet_range() {
+    "$BLOCKS_FETCHER" mina_network_block_data "$1" "$2" mainnet "$3"
 }
 
 assert() {
@@ -39,6 +47,17 @@ assert() {
         exit 1
     else
         echo "Test Passed!"
+    fi
+}
+
+assert_directory_exists() {
+    directory="$1"
+
+    if [ ! -d "$directory" ]; then
+        echo "Test Failed: Expected directory $directory to exist, but it does not."
+        exit 1
+    else
+        echo "Test Passed: Directory $directory exists."
     fi
 }
 
@@ -100,21 +119,6 @@ test_indexer_cli_reports() {
         grep -iq "Usage: mina-indexer transactions"
 }
 
-# Indexer server config passes cli with minimal args
-test_indexer_basic_start() {
-    test=test_indexer_basic_start
-
-    setup
-    idxr server cli \
-        --startup-dir ./blocks \
-        --watch-dir ./blocks \
-        --database-dir ./database \
-        --log-dir ./logs &
-    sleep 1
-    idxr_pid=$(pgrep -c mina-indexer)
-    teardown
-}
-
 # Indexer server starts up without any precomputed blocks
 test_server_startup() {
     test=test_server_startup
@@ -125,10 +129,11 @@ test_server_startup() {
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 10
+    sleep 5
 
     result=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
     assert '3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ' $result
+
     idxr_pid=$(pgrep -c mina-indexer)
     teardown
 }
@@ -154,62 +159,17 @@ test_ipc_is_available_immediately() {
     teardown
 }
 
-# Indexer server reports correct balance for Genesis Ledger Account
-test_account_balance_cli() {
-    test=test_account_balance_cli
-
-    setup
-    idxr server cli \
-        --startup-dir ./blocks \
-        --watch-dir ./blocks \
-        --database-dir ./database \
-        --log-dir ./logs &
-    sleep 10
-
-    result=$(idxr account -j --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .balance)
-    assert '148837200000000' $result
-    idxr_pid=$(pgrep -c mina-indexer)
-    teardown
-}
-
-# Indexer server returns the correct account
-test_account_public_key_json() {
-    test=test_account_public_key_json
-    setup
-
-    idxr server cli \
-        --startup-dir ./blocks \
-        --watch-dir ./blocks \
-        --database-dir ./database \
-        --log-dir ./logs &
-    sleep 5
-    result=$(idxr account -j --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .public_key)
-    assert 'B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk' $result
-    idxr_pid=$(pgrep -c mina-indexer)
-    teardown
-}
-
-assert_directory_exists() {
-    directory="$1"
-
-    if [ ! -d "$directory" ]; then
-        echo "Test Failed: Expected directory $directory to exist, but it does not."
-        exit 1
-    else
-        echo "Test Passed: Directory $directory exists."
-    fi
-}
-
+# Indexer server starts and creates directories with minimal args
 test_startup_dirs_get_created() {
     test=test_startup_dirs_get_created
-    setup
 
+    setup
     idxr server cli \
         --startup-dir ./startup-blocks \
         --watch-dir ./watch-blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 5
+    sleep 1
 
     assert_directory_exists "./startup-blocks"
     assert_directory_exists "./watch-blocks"
@@ -220,18 +180,57 @@ test_startup_dirs_get_created() {
     teardown
 }
 
-# Indexer server returns the correct canonical tip
-test_canonical_tip() {
-    test=test_canonical_tip
-    setup
+# Indexer server reports correct balance for Genesis Ledger Account
+test_account_balance_cli() {
+    test=test_account_balance_cli
 
-    dl_mainnet 15 ./blocks
+    setup
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
+
+    result=$(idxr account -j --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .balance)
+    assert '148837200000000' $result
+
+    idxr_pid=$(pgrep -c mina-indexer)
+    teardown
+}
+
+# Indexer server returns the correct account
+test_account_public_key_json() {
+    test=test_account_public_key_json
+
+    setup
+    idxr server cli \
+        --startup-dir ./blocks \
+        --watch-dir ./blocks \
+        --database-dir ./database \
+        --log-dir ./logs &
+    sleep 5
+
+    result=$(idxr account -j --public-key B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk | jq -r .public_key)
+    assert 'B62qqDJCQsfDoHJvJCh1hgTpiVbmgBg8SbNKLMXsjuVsX5pxCELDyFk' $result
+
+    idxr_pid=$(pgrep -c mina-indexer)
+    teardown
+}
+
+# Indexer server returns the correct canonical tip
+test_canonical_tip() {
+    test=test_canonical_tip
+
+    setup
+    dl_mainnet 15 ./blocks
+
+    idxr server cli \
+        --startup-dir ./blocks \
+        --watch-dir ./blocks \
+        --database-dir ./database \
+        --log-dir ./logs &
+    sleep 5
     
     state_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
     blockchain_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
@@ -243,19 +242,88 @@ test_canonical_tip() {
     teardown
 }
 
-# Indexer server returns the correct best chain
-test_best_chain() {
-    test=test_best_chain
-    setup
-    mkdir best_chain
+# Indexer handles missing blocks correctly
+test_missing_blocks() {
+    test=test_missing_blocks
 
-    dl_mainnet 12 ./blocks
-    RUST_BACKTRACE=1 idxr server cli \
+    setup
+    dl_mainnet 10 ./blocks
+    dl_mainnet_range 12 20 ./blocks # missing 11
+    dl_mainnet_range 22 30 ./blocks # missing 21
+
+    idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
+
+    # start out missing block 11 & 21
+    num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
+    best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+
+    assert 2 $num_dangling
+    assert 10 $best_length
+    assert 1 $canonical_length
+    assert '3NKGgTk7en3347KH81yDra876GPAUSoSePrfVKPmwR1KHfMpvJC5' $best_hash
+    assert '3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ' $canonical_hash
+
+    # add missing block which connects the dangling branches
+    dl_mainnet_single 21 ./blocks
+    sleep 1
+
+    # dangling branches combine
+    # no new canonical blocks
+    num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
+    best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+
+    assert 1 $num_dangling
+    assert 10 $best_length
+    assert 1 $canonical_length
+    assert '3NKGgTk7en3347KH81yDra876GPAUSoSePrfVKPmwR1KHfMpvJC5' $best_hash
+    assert '3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ' $canonical_hash
+
+    # add remaining missing block
+    dl_mainnet_single 11 ./blocks
+    sleep 1
+
+    # dangling branches move into the root branch
+    num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
+    best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+
+    assert 0 $num_dangling
+    assert 30 $best_length
+    assert 20 $canonical_length
+    assert '3NLsuVoPLnRzdzjrdFKWmkqNzqNEQxrfa7iQMwu1WxcstZjmorUs' $best_hash
+    assert '3NLPpt5SyVnD1U5uJAqR3DL1Cqj5dG26SuWutRQ6AQpbQtQUWSYA' $canonical_hash
+
+    idxr_pid=$(pgrep -c mina-indexer)
+    teardown
+}
+
+# Indexer server returns the correct best chain
+test_best_chain() {
+    test=test_best_chain
+
+    setup
+    mkdir best_chain
+    dl_mainnet 12 ./blocks
+
+    idxr server cli \
+        --startup-dir ./blocks \
+        --watch-dir ./blocks \
+        --database-dir ./database \
+        --log-dir ./logs &
+    sleep 5
 
     result=$(idxr best-chain -n 1 | jq -r .[0].state_hash)
     assert '3NKkJDmNZGYdKVDDJkkamGdvNzASia2SXxKpu18imps7KqbNXENY' $result
@@ -299,16 +367,17 @@ test_best_chain() {
 # Indexer server returns correct ledgers
 test_ledgers() {
     test=test_ledgers
+
     setup
     mkdir ledgers
-
     dl_mainnet 15 ./blocks
+
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     pk='B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR'
 
@@ -345,15 +414,16 @@ test_ledgers() {
 # Indexer server syncs with existing rocksdb
 test_sync() {
     test=test_sync
-    setup
 
+    setup
     dl_mainnet 15 ./blocks
+
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # pre-sync results
     canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -372,7 +442,7 @@ test_sync() {
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # post-sync reults
     canonical_hash_sync=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -392,15 +462,16 @@ test_sync() {
 # Indexer server replays events
 test_replay() {
     test=test_replay
-    setup
 
+    setup
     dl_mainnet 15 ./blocks
+
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # pre-replay results
     canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -420,7 +491,7 @@ test_replay() {
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 20
+    sleep 5
 
     # post-replay reults
     canonical_hash_replay=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
@@ -435,7 +506,7 @@ test_replay() {
     assert '15' $best_length
     assert $best_length $best_length_replay
     assert '15' $num_blocks
-    assert '15' $num_blocks_replay
+    assert $num_blocks $num_blocks_replay
 
     idxr_pid=$(pgrep -c mina-indexer)
     teardown
@@ -444,16 +515,17 @@ test_replay() {
 # Indexer server returns correct transactions
 test_transactions() {
     test=test_transactions
+
     setup
     mkdir transactions
-
     dl_mainnet 13 ./blocks
+
     idxr server cli \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs &
-    sleep 15
+    sleep 5
 
     # basic transaction queries
     transactions=$(idxr transactions --public-key B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR -j | jq -r .)
@@ -548,13 +620,13 @@ test_checkpoint() {
 if [ "$#" -eq 0 ]; then
     # No arguments provided, run all tests
     test_indexer_cli_reports
-    test_indexer_basic_start
     test_server_startup
     test_ipc_is_available_immediately
+    test_startup_dirs_get_created
     test_account_balance_cli
     test_account_public_key_json
-    test_startup_dirs_get_created
     test_canonical_tip
+    test_missing_blocks
     test_best_chain
     test_ledgers
     test_sync
@@ -566,13 +638,13 @@ else
     for test_name in "$@"; do
         case $test_name in
             "test_indexer_cli_reports") test_indexer_cli_reports ;;
-            "test_indexer_basic_start") test_indexer_basic_start ;;
             "test_server_startup") test_server_startup ;;
             "test_ipc_is_available_immediately") test_ipc_is_available_immediately ;;
+            "test_startup_dirs_get_created") test_startup_dirs_get_created ;;
             "test_account_balance_cli") test_account_balance_cli ;;
             "test_account_public_key_json") test_account_public_key_json ;;
-            "test_startup_dirs_get_created") test_startup_dirs_get_created ;;
             "test_canonical_tip") test_canonical_tip ;;
+            "test_missing_blocks") test_missing_blocks ;;
             "test_best_chain") test_best_chain ;;
             "test_ledgers") test_ledgers ;;
             "test_sync") test_sync ;;

--- a/test
+++ b/test
@@ -423,18 +423,19 @@ test_replay() {
     sleep 20
 
     # post-replay reults
-    canonical_hash_sync=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length_sync=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
-    best_hash_sync=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
-    best_length_sync=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    num_blocks_sync=$(idxr summary -j | jq -r .blocks_processed)
+    canonical_hash_replay=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length_replay=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    best_hash_replay=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length_replay=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    num_blocks_replay=$(idxr summary -j | jq -r .blocks_processed)
 
-    assert $canonical_hash $canonical_hash_sync
-    assert $canonical_length $canonical_length_sync
-    assert $best_hash $best_hash_sync
-    assert $best_length $best_length_sync
+    assert $canonical_hash $canonical_hash_replay
+    assert $canonical_length $canonical_length_replay
+    assert $best_hash $best_hash_replay
+    assert '15' $best_length
+    assert $best_length $best_length_replay
     assert '15' $num_blocks
-    assert $num_blocks $num_blocks_sync
+    assert '15' $num_blocks_replay
 
     idxr_pid=$(pgrep -c mina-indexer)
     teardown

--- a/tests/block/store/genesis.rs
+++ b/tests/block/store/genesis.rs
@@ -1,8 +1,8 @@
 use mina_indexer::{
     block::{genesis::GenesisBlock, store::BlockStore},
     constants::{
-        CANONICAL_UPDATE_THRESHOLD, MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K,
-        PRUNE_INTERVAL_DEFAULT,
+        CANONICAL_UPDATE_THRESHOLD, LEDGER_CADENCE, MAINNET_GENESIS_HASH,
+        MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT,
     },
     ledger::genesis::parse_file,
     state::IndexerState,
@@ -26,6 +26,7 @@ async fn block_added() {
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,
         CANONICAL_UPDATE_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/canonicity/blocks.rs
+++ b/tests/canonicity/blocks.rs
@@ -2,7 +2,9 @@ use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
     block::{parser::BlockParser, BlockHash},
     canonicity::{store::CanonicityStore, Canonicity},
-    constants::{MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT},
+    constants::{
+        LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT,
+    },
     ledger::genesis::GenesisRoot,
     state::IndexerState,
     store::IndexerStore,
@@ -26,6 +28,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/canonicity/ledgers.rs
+++ b/tests/canonicity/ledgers.rs
@@ -2,7 +2,9 @@ use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
     block::{parser::BlockParser, store::BlockStore},
     canonicity::store::CanonicityStore,
-    constants::{MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT},
+    constants::{
+        LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT,
+    },
     ledger::{diff::LedgerDiff, genesis::GenesisRoot, public_key::PublicKey, store::LedgerStore},
     state::IndexerState,
     store::IndexerStore,
@@ -26,6 +28,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/canonicity/ledgers.rs
+++ b/tests/canonicity/ledgers.rs
@@ -48,7 +48,7 @@ async fn test() {
 
         ledger_post.apply_post_balances(&block);
         ledger_diff
-            .apply_diff(&LedgerDiff::from_precomputed(&block))
+            ._apply_diff(&LedgerDiff::from_precomputed(&block))
             .unwrap();
 
         if ledger != ledger_post || ledger != ledger_diff {

--- a/tests/command/store.rs
+++ b/tests/command/store.rs
@@ -3,8 +3,8 @@ use mina_indexer::{
     block::parser::BlockParser,
     command::{signed::SignedCommand, store::CommandStore},
     constants::{
-        CANONICAL_UPDATE_THRESHOLD, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH,
-        MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT,
+        CANONICAL_UPDATE_THRESHOLD, LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD,
+        MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT,
     },
     ledger::genesis::parse_file,
     state::IndexerState,
@@ -27,6 +27,7 @@ async fn add_and_get() {
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,
         CANONICAL_UPDATE_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/event/log.rs
+++ b/tests/event/log.rs
@@ -2,7 +2,9 @@ use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
     block::{parser::BlockParser, store::BlockStore},
     canonicity::store::CanonicityStore,
-    constants::{MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT},
+    constants::{
+        LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT,
+    },
     event::{store::EventStore, witness_tree::WitnessTreeEvent},
     ledger::genesis::GenesisRoot,
     state::IndexerState,
@@ -35,6 +37,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
     let mut state1 = IndexerState::new(
@@ -44,6 +47,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/event/replay.rs
+++ b/tests/event/replay.rs
@@ -20,7 +20,7 @@ async fn test() {
         .ledger;
     let mut state = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.clone(),
         indexer_store.clone(),
         10,
         PRUNE_INTERVAL_DEFAULT,
@@ -34,6 +34,7 @@ async fn test() {
     // fresh state to replay events on top of
     let mut new_state = IndexerState::new_without_genesis_events(
         &MAINNET_GENESIS_HASH.into(),
+        genesis_ledger,
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/event/replay.rs
+++ b/tests/event/replay.rs
@@ -1,7 +1,9 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
     block::parser::BlockParser,
-    constants::{MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT},
+    constants::{
+        LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT,
+    },
     ledger::genesis::GenesisRoot,
     state::IndexerState,
     store::IndexerStore,
@@ -25,6 +27,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 
@@ -39,6 +42,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/event/sync.rs
+++ b/tests/event/sync.rs
@@ -1,7 +1,9 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
     block::{parser::BlockParser, BlockWithoutHeight},
-    constants::{MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT},
+    constants::{
+        LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD, MAINNET_GENESIS_HASH, PRUNE_INTERVAL_DEFAULT,
+    },
     ledger::genesis::GenesisRoot,
     state::IndexerState,
     store::IndexerStore,
@@ -25,6 +27,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 
@@ -39,6 +42,7 @@ async fn test() {
         10,
         PRUNE_INTERVAL_DEFAULT,
         MAINNET_CANONICAL_THRESHOLD,
+        LEDGER_CADENCE,
     )
     .unwrap();
 

--- a/tests/event/sync.rs
+++ b/tests/event/sync.rs
@@ -34,6 +34,7 @@ async fn test() {
     // fresh state to sync events with no genesis events
     let mut state_sync = IndexerState::new_without_genesis_events(
         &MAINNET_GENESIS_HASH.into(),
+        genesis_ledger,
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -12,7 +12,8 @@ async fn extension() {
 
     let mut n = 0;
     if let Some(precomputed_block) = block_parser.next_block().unwrap() {
-        let mut state = IndexerState::new_testing(&precomputed_block, None, None, None).unwrap();
+        let mut state =
+            IndexerState::new_testing(&precomputed_block, None, None, None, None).unwrap();
         n += 1;
 
         while let Some(precomputed_block) = block_parser.next_block().unwrap() {

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -65,7 +65,7 @@ async fn extension() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // --------
     // add leaf

--- a/tests/state/dangling_branches/complex/multiple_branches.rs
+++ b/tests/state/dangling_branches/complex/multiple_branches.rs
@@ -76,7 +76,7 @@ async fn merge() {
     // initialize state
     // ----------------
 
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // ---------
     // add leaf0

--- a/tests/state/dangling_branches/complex/multiple_gaps.rs
+++ b/tests/state/dangling_branches/complex/multiple_gaps.rs
@@ -68,7 +68,7 @@ async fn extension() {
     // ----------
 
     // root in branch branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // other in dangling branch 0
     let (extension_type, _) = state.add_block_to_witness_tree(&other_block).unwrap();

--- a/tests/state/dangling_branches/simple/basic_multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/basic_multiple_branch.rs
@@ -51,7 +51,7 @@ async fn extensions() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new_testing(&root0_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root0_block, None, None, None, None).unwrap();
 
     // Root branch
     // - len = 1

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -33,7 +33,7 @@ async fn extension() {
         "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
     );
 
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // root branch
     // - len = 1

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -84,7 +84,7 @@ async fn extensions() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // ----------
     // add root 0

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -39,7 +39,7 @@ async fn extension() {
     // initialize state
     // ----------------
 
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // add dangling_root_block
     let (extension, _) = state

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -55,7 +55,7 @@ async fn extension() {
     // ----------------
 
     // root_block is the root of the root branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None).unwrap();
+    let mut state = IndexerState::new_testing(&root_block, None, None, None, None).unwrap();
 
     // old_dangling_root_block is originally the root of the 0th dangling branch
     let (extension_type, _) = state

--- a/tests/state/ledger/apply_diff.rs
+++ b/tests/state/ledger/apply_diff.rs
@@ -17,7 +17,7 @@ async fn account_diffs() {
         .unwrap();
     let diff = LedgerDiff::from_precomputed(&block);
 
-    let mut ledger = Ledger::from(vec![
+    let ledger = Ledger::from(vec![
         (
             "B62qrRvo5wngd5WA1dgXkQpCdQMRDndusmjfWXWT1LgsSFFdBS9RCsV",
             1000000000000,
@@ -72,7 +72,7 @@ async fn account_diffs() {
     println!("=== Initial ===");
     println!("{:?}", ledger);
 
-    ledger.apply_diff(&diff).unwrap();
+    let ledger = ledger.apply_diff(&diff).unwrap();
 
     let expected = Ledger::from(vec![
         (


### PR DESCRIPTION
- add in-memory ledger to `state`
- add `--ledger-cadence` server flag to customize how often ledgers are persisted
- add file writing regression tests
- add many blocks regression test

Fixes https://github.com/Granola-Team/mina-indexer/issues/382 and https://github.com/Granola-Team/mina-indexer/issues/381