### PR TITLE
Persist commands in an array

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -31,6 +31,9 @@ test-unit: build
 test-regression: build
   ./test
 
+test-release: build
+  ./test test_release
+
 disallow-unused-cargo-deps:
   cargo machete Cargo.toml
 

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -35,11 +35,11 @@ enum IndexerCommand {
 
 #[derive(Subcommand, Debug)]
 enum ServerCommand {
-    /// Start the mina indexer by passing in arguments manually on the command line
-    Cli(ServerArgs),
-    /// Replay the events from an existing db to start the indexer
+    /// Start a new mina indexer by passing arguments on the command line
+    Start(ServerArgs),
+    /// Start a mina indexer by replaying events from an existing indexer store
     Replay(ServerArgs),
-    /// Sync from events in an existing db to start the indexer
+    /// Start a mina indexer by syncing from events in an existing indexer store
     Sync(ServerArgs),
 }
 
@@ -97,7 +97,7 @@ pub async fn main() -> anyhow::Result<()> {
         IndexerCommand::Client(args) => client::run(&args).await,
         IndexerCommand::Server { server_command } => {
             let (args, mut mode) = match server_command {
-                ServerCommand::Cli(args) => (args, InitializationMode::New),
+                ServerCommand::Start(args) => (args, InitializationMode::New),
                 ServerCommand::Sync(args) => (args, InitializationMode::Sync),
                 ServerCommand::Replay(args) => (args, InitializationMode::Replay),
             };

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,20 +24,15 @@ pub enum ClientCli {
     Account(AccountArgs),
     /// Display the best chain
     BestChain(ChainArgs),
-    /// Dump the best ledger to a file
-    BestLedger(BestLedgerArgs),
     /// Create a checkpoint of the indexer store Speedb
     Checkpoint(CheckpointArgs),
-    /// Dump the ledger at a specified state hash
+    #[clap(flatten)]
     Ledger(LedgerArgs),
-    /// Dump the ledger at a specified height (blockchain length)
-    LedgerAtHeight(LedgerAtHeightArgs),
     /// Show summary of the state
     Summary(SummaryArgs),
     /// Shutdown the server
     Shutdown,
     #[clap(flatten)]
-    /// Get transactions for an account
     Transactions(TransactionArgs),
 }
 
@@ -105,9 +100,20 @@ pub struct LedgerAtHeightArgs {
     json: bool,
 }
 
+#[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(author, version, about, long_about = None)]
+pub enum LedgerArgs {
+    /// Query the best ledger
+    BestLedger(BestLedgerArgs),
+    /// Query ledger by state hash
+    Ledger(LedgerStateHashArgs),
+    /// Query ledger at height
+    LedgerAtHeight(LedgerAtHeightArgs),
+}
+
 #[derive(Args, Debug, Serialize, Deserialize)]
 #[command(author, version, about, long_about = None)]
-pub struct LedgerArgs {
+pub struct LedgerStateHashArgs {
     /// Path to write the ledger [default: stdout]
     #[arg(short, long)]
     path: Option<PathBuf>,
@@ -264,7 +270,7 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
                 stdout().write_all(&buffer).await?;
             }
         }
-        ClientCli::BestLedger(best_ledger_args) => {
+        ClientCli::Ledger(LedgerArgs::BestLedger(best_ledger_args)) => {
             let command = match &best_ledger_args.path {
                 None => "best_ledger \0".to_string(),
                 Some(path) => format!("best_ledger {}\0", path.display()),
@@ -283,7 +289,7 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
             let msg = String::from_utf8(buffer)?;
             println!("{msg}");
         }
-        ClientCli::Ledger(ledger_args) => {
+        ClientCli::Ledger(LedgerArgs::Ledger(ledger_args)) => {
             let command = match &ledger_args.path {
                 None => format!("ledger {}\0", ledger_args.hash),
                 Some(path) => format!("ledger {} {}\0", ledger_args.hash, path.display()),
@@ -294,7 +300,7 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
             let msg = String::from_utf8(buffer)?;
             println!("{msg}");
         }
-        ClientCli::LedgerAtHeight(ledger_at_height_args) => {
+        ClientCli::Ledger(LedgerArgs::LedgerAtHeight(ledger_at_height_args)) => {
             let command = match &ledger_at_height_args.path {
                 None => format!("ledger_at_height {}\0", ledger_at_height_args.height),
                 Some(path) => format!(
@@ -332,20 +338,14 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
             let command = "shutdown \0".to_string();
             writer.write_all(command.as_bytes()).await?;
             reader.read_to_end(&mut buffer).await?;
-
-            let msg: String = serde_json::from_slice(&buffer)?;
-            println!("{msg}");
         }
         ClientCli::Transactions(transaction_args) => {
             let command = match transaction_args {
                 TransactionArgs::TxHash(args) => {
-                    format!(
-                        "transactions-hash {} {} {} \0",
-                        args.tx_hash, args.verbose, args.json
-                    )
+                    format!("tx-hash {} {} {}\0", args.tx_hash, args.verbose, args.json)
                 }
                 TransactionArgs::TxPublicKey(pk_args) => format!(
-                    "transactions-pk {} {} {} {} {} {}\0",
+                    "tx-pk {} {} {} {} {} {}\0",
                     pk_args.public_key,
                     pk_args.verbose,
                     pk_args.num.unwrap_or(0),
@@ -355,7 +355,7 @@ pub async fn run(command: &ClientCli) -> Result<(), anyhow::Error> {
                 ),
                 TransactionArgs::TxStateHash(args) => {
                     format!(
-                        "transactions-state-hash {} {} {} \0",
+                        "tx-state-hash {} {} {}\0",
                         args.state_hash, args.verbose, args.json
                     )
                 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,13 +4,10 @@ pub mod store;
 
 use crate::{
     block::{precomputed::PrecomputedBlock, BlockHash},
-    command::signed::SignedCommand,
+    command::signed::{SignedCommand, SignedCommandWithKind},
     ledger::{account::Amount, post_balances::PostBalance, public_key::PublicKey},
 };
-use mina_serialization_types::{
-    staged_ledger_diff as mina_rs,
-    v1::{PaymentPayloadV1, StakeDelegationV1, UserCommandWithStatusV1},
-};
+use mina_serialization_types::{staged_ledger_diff as mina_rs, v1 as mina_v1};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 
@@ -23,7 +20,7 @@ pub enum CommandType {
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Command {
     Payment(Payment),
-    #[serde(alias = "StakeDelegation")]
+    #[serde(rename = "Stake_delegation")]
     Delegation(Delegation),
 }
 
@@ -57,10 +54,13 @@ pub struct Delegation {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum CommandStatusData {
     Applied {
-        auxiliary_data: Box<mina_rs::TransactionStatusAuxiliaryData>,
-        balance_data: Box<mina_rs::TransactionStatusBalanceData>,
+        auxiliary_data: mina_rs::TransactionStatusAuxiliaryData,
+        balance_data: mina_rs::TransactionStatusBalanceData,
     },
-    Failed,
+    Failed(
+        Vec<mina_rs::TransactionStatusFailedType>,
+        mina_rs::TransactionStatusBalanceData,
+    ),
 }
 
 impl CommandStatusData {
@@ -120,16 +120,19 @@ impl CommandStatusData {
 
         match data {
             TS::Applied(auxiliary_data, balance_data) => Self::Applied {
-                auxiliary_data: Box::new(auxiliary_data.clone().inner()),
-                balance_data: Box::new(balance_data.clone().inner()),
+                auxiliary_data: auxiliary_data.clone().inner(),
+                balance_data: balance_data.clone().inner(),
             },
-            _ => Self::Failed,
+            TS::Failed(fails, balance_data) => Self::Failed(
+                fails.iter().map(|reason| reason.clone().inner()).collect(),
+                balance_data.clone().inner(),
+            ),
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct UserCommandWithStatus(pub UserCommandWithStatusV1);
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct UserCommandWithStatus(pub mina_v1::UserCommandWithStatusV1);
 
 impl UserCommandWithStatus {
     pub fn is_applied(&self) -> bool {
@@ -138,17 +141,22 @@ impl UserCommandWithStatus {
 
     pub fn status_data(&self) -> CommandStatusData {
         match self.0.t.status.t.clone() {
-            mina_serialization_types::staged_ledger_diff::TransactionStatus::Applied(
-                auxiliary_data,
-                balance_data,
-            ) => CommandStatusData::Applied {
-                auxiliary_data: Box::new(auxiliary_data.inner()),
-                balance_data: Box::new(balance_data.inner()),
-            },
-            mina_serialization_types::staged_ledger_diff::TransactionStatus::Failed(_, _) => {
-                CommandStatusData::Failed
+            mina_rs::TransactionStatus::Applied(auxiliary_data, balance_data) => {
+                CommandStatusData::Applied {
+                    auxiliary_data: auxiliary_data.inner(),
+                    balance_data: balance_data.inner(),
+                }
             }
+            mina_rs::TransactionStatus::Failed(reason, balance_data) => CommandStatusData::Failed(
+                reason.iter().map(|r| r.clone().inner()).collect(),
+                balance_data.inner(),
+            ),
         }
+    }
+
+    pub fn contains_public_key(&self, pk: &PublicKey) -> bool {
+        let signed = SignedCommand::from(self.clone());
+        signed.all_public_keys().contains(pk)
     }
 
     pub fn data(&self) -> mina_rs::UserCommand {
@@ -196,10 +204,10 @@ impl UserCommandWithStatus {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct PaymentPayload(pub PaymentPayloadV1);
+pub struct PaymentPayload(pub mina_v1::PaymentPayloadV1);
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct StakeDelegation(pub StakeDelegationV1);
+pub struct StakeDelegation(pub mina_v1::StakeDelegationV1);
 
 impl Command {
     /// Get the list of commands from the precomputed block
@@ -277,6 +285,12 @@ impl StakeDelegation {
     }
 }
 
+impl CommandUpdate {
+    pub fn is_delegation(&self) -> bool {
+        matches!(self.command_type, CommandType::Delegation)
+    }
+}
+
 impl From<mina_rs::TransactionStatus> for CommandStatusData {
     fn from(value: mina_rs::TransactionStatus) -> Self {
         Self::from_transaction_status(&value)
@@ -317,13 +331,44 @@ impl From<UserCommandWithStatus> for CommandStatusData {
     }
 }
 
-impl std::fmt::Debug for Command {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl From<CommandStatusData> for serde_json::Value {
+    fn from(value: CommandStatusData) -> Self {
+        use serde_json::*;
+
+        match value {
+            CommandStatusData::Applied {
+                auxiliary_data,
+                balance_data,
+            } => {
+                let status = Value::String("Applied".into());
+                let aux_json = to_auxiliary_json(&auxiliary_data);
+                let balance_json = to_balance_json(&balance_data);
+                Value::Array(vec![status, aux_json, balance_json])
+            }
+            CommandStatusData::Failed(reason, balance_data) => {
+                let status = Value::String("Failed".into());
+                let reason_json = Value::Array(
+                    reason
+                        .iter()
+                        .map(|r| {
+                            Value::String(serde_json::to_string(&r).expect("serialize reason"))
+                        })
+                        .collect(),
+                );
+                let balance_json = to_balance_json(&balance_data);
+                Value::Array(vec![status, reason_json, balance_json])
+            }
+        }
+    }
+}
+
+impl From<Command> for serde_json::Value {
+    fn from(value: Command) -> Self {
         use serde_json::*;
 
         let mut json = Map::new();
-        match self {
-            Self::Payment(Payment {
+        match value {
+            Command::Payment(Payment {
                 source,
                 receiver,
                 amount,
@@ -334,30 +379,59 @@ impl std::fmt::Debug for Command {
                 payment.insert("amount".into(), Value::Number(Number::from(amount.0)));
                 json.insert("Payment".into(), Value::Object(payment));
             }
-            Self::Delegation(Delegation {
+            Command::Delegation(Delegation {
                 delegate,
                 delegator,
             }) => {
                 let mut delegation = Map::new();
                 delegation.insert("delegate".into(), Value::String(delegate.to_address()));
                 delegation.insert("delegator".into(), Value::String(delegator.to_address()));
-                json.insert("StakeDelegation".into(), Value::Object(delegation));
+                json.insert("Stake_delegation".into(), Value::Object(delegation));
             }
         };
+        Value::Object(json)
+    }
+}
+
+impl std::fmt::Debug for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use serde_json::*;
+
+        let json: Value = self.clone().into();
         write!(f, "{}", to_string(&json).unwrap())
     }
 }
 
-impl CommandUpdate {
-    pub fn is_delegation(&self) -> bool {
-        matches!(self.command_type, CommandType::Delegation)
+impl From<UserCommandWithStatus> for serde_json::Value {
+    fn from(value: UserCommandWithStatus) -> Self {
+        use serde_json::*;
+
+        let mut object = Map::new();
+        let user_cmd: UserCommandWithStatus = value.0.inner().into();
+        let status: CommandStatusData = user_cmd.clone().into();
+        let data: SignedCommandWithKind = user_cmd.into();
+
+        object.insert("data".into(), data.into());
+        object.insert("status".into(), status.into());
+        Value::Object(object)
+    }
+}
+
+impl std::fmt::Debug for UserCommandWithStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use serde_json::*;
+
+        let json: Value = self.clone().into();
+        write!(f, "{}", to_string(&json).unwrap())
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::{Command, Delegation, Payment};
-    use crate::{block::parser::BlockParser, constants::MAINNET_CANONICAL_THRESHOLD};
+    use crate::{
+        block::parser::BlockParser, command::stringify, constants::MAINNET_CANONICAL_THRESHOLD,
+    };
     use std::path::PathBuf;
 
     #[tokio::test]
@@ -504,5 +578,98 @@ mod test {
                     .collect::<Vec<(String, String)>>()
             );
         }
+    }
+
+    ///
+    #[test]
+    fn user_command_with_status_json() -> anyhow::Result<()> {
+        use crate::block::precomputed::PrecomputedBlock;
+        use serde_json::*;
+
+        let path: PathBuf = "./tests/data/non_sequential_blocks/mainnet-220897-3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw.json".into();
+        let contents = std::fs::read(path.clone())?;
+        let user_cmd_with_status_json: Value =
+            from_slice::<Value>(&contents)?["staged_ledger_diff"]["diff"][0]["commands"][0].clone();
+        let block = PrecomputedBlock::parse_file(&path)?;
+        let user_cmd_with_status = block.commands()[0].clone();
+        let user_cmd_with_status: Value = user_cmd_with_status.into();
+
+        assert_eq!(user_cmd_with_status_json, stringify(user_cmd_with_status));
+        Ok(())
+    }
+}
+
+fn to_auxiliary_json(
+    auxiliary_data: &mina_rs::TransactionStatusAuxiliaryData,
+) -> serde_json::Value {
+    use serde_json::*;
+
+    let mut auxiliary_obj = Map::new();
+    let fee_payer_account_creation_fee_paid = auxiliary_data
+        .fee_payer_account_creation_fee_paid
+        .clone()
+        .map(|amt| Value::Number(Number::from(amt.inner().inner())))
+        .unwrap_or(Value::Null);
+    let receiver_account_creation_fee_paid = auxiliary_data
+        .receiver_account_creation_fee_paid
+        .clone()
+        .map(|amt| Value::Number(Number::from(amt.inner().inner())))
+        .unwrap_or(Value::Null);
+    let created_token = auxiliary_data
+        .created_token
+        .clone()
+        .map(|id| Value::Number(Number::from(id.inner().inner().inner())))
+        .unwrap_or(Value::Null);
+
+    auxiliary_obj.insert(
+        "fee_payer_account_creation_fee_paid".into(),
+        fee_payer_account_creation_fee_paid,
+    );
+    auxiliary_obj.insert(
+        "receiver_account_creation_fee_paid".into(),
+        receiver_account_creation_fee_paid,
+    );
+    auxiliary_obj.insert("created_token".into(), created_token);
+    Value::Object(auxiliary_obj)
+}
+
+fn to_balance_json(balance_data: &mina_rs::TransactionStatusBalanceData) -> serde_json::Value {
+    use serde_json::*;
+
+    let mut balance_obj = Map::new();
+    let fee_payer_balance = balance_data
+        .fee_payer_balance
+        .clone()
+        .map(|amt| Value::Number(Number::from(amt.inner().inner().inner())))
+        .unwrap_or(Value::Null);
+    let receiver_balance = balance_data
+        .receiver_balance
+        .clone()
+        .map(|amt| Value::Number(Number::from(amt.inner().inner().inner())))
+        .unwrap_or(Value::Null);
+    let source_balance = balance_data
+        .source_balance
+        .clone()
+        .map(|amt| Value::Number(Number::from(amt.inner().inner().inner())))
+        .unwrap_or(Value::Null);
+
+    balance_obj.insert("fee_payer_balance".into(), fee_payer_balance);
+    balance_obj.insert("receiver_balance".into(), receiver_balance);
+    balance_obj.insert("source_balance".into(), source_balance);
+    Value::Object(balance_obj)
+}
+
+#[allow(dead_code)]
+fn stringify(value: serde_json::Value) -> serde_json::Value {
+    use serde_json::*;
+
+    match value {
+        Value::Number(n) => Value::String(n.to_string()),
+        Value::Object(mut obj) => {
+            obj.iter_mut().for_each(|(_, x)| *x = stringify(x.clone()));
+            Value::Object(obj)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(stringify).collect()),
+        x => x,
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -682,11 +682,8 @@ mod test {
         let user_cmd_with_status = block.commands()[0].clone();
         let user_cmd_with_status: Value = user_cmd_with_status.into();
 
-        println!("{:#?}", convert(mina_json.clone()));
-        println!("{:#?}", to_mina_json(user_cmd_with_status.clone()));
-
         assert_eq!(convert(mina_json), to_mina_json(user_cmd_with_status));
-        panic!()
+        Ok(())
     }
 }
 

--- a/src/command/signed.rs
+++ b/src/command/signed.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use blake2::digest::VariableOutput;
 use mina_serialization_types::staged_ledger_diff as mina_rs;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::io::Write;
 use versioned::Versioned;
 
@@ -236,101 +236,15 @@ impl From<SignedCommand> for serde_json::Value {
     fn from(value: SignedCommand) -> Self {
         use serde_json::*;
 
-        let mut json = Map::new();
-        let mina_rs::SignedCommand { payload, .. } = value.0.inner().inner();
+        let mut object = Map::new();
+        let payload = payload_json(value.0.clone());
+        let signer = signer(value.0.clone());
+        let signature = signature(value.0);
 
-        let mut common = Map::new();
-        let mina_rs::SignedCommandPayloadCommon {
-            fee,
-            fee_token,
-            fee_payer_pk,
-            nonce,
-            valid_until,
-            memo,
-        } = payload
-            .clone()
-            .inner()
-            .inner()
-            .common
-            .inner()
-            .inner()
-            .inner();
-        common.insert(
-            "fee".into(),
-            Value::Number(Number::from(fee.inner().inner())),
-        );
-        common.insert(
-            "fee_token".into(),
-            Value::Number(Number::from(fee_token.inner().inner().inner())),
-        );
-        common.insert(
-            "fee_payer_pk".into(),
-            Value::String(PublicKey::from(fee_payer_pk).to_address()),
-        );
-        common.insert(
-            "nonce".into(),
-            Value::Number(Number::from(nonce.inner().inner())),
-        );
-        common.insert(
-            "valid_until".into(),
-            Value::Number(Number::from(valid_until.inner().inner() as u64)),
-        );
-        common.insert(
-            "memo".into(),
-            Value::String(String::from_utf8_lossy(&memo.inner().0).to_string()),
-        );
-
-        let mut body = Map::new();
-        match payload.inner().inner().body.inner().inner() {
-            mina_rs::SignedCommandPayloadBody::PaymentPayload(payment_payload) => {
-                let mina_rs::PaymentPayload {
-                    source_pk,
-                    receiver_pk,
-                    token_id,
-                    amount,
-                } = payment_payload.inner().inner();
-
-                let mut payment = Map::new();
-                payment.insert(
-                    "source_pk".into(),
-                    Value::String(PublicKey::from(source_pk).to_address()),
-                );
-                payment.insert(
-                    "receiver_pk".into(),
-                    Value::String(PublicKey::from(receiver_pk).to_address()),
-                );
-                payment.insert(
-                    "token_id".into(),
-                    Value::Number(Number::from(token_id.inner().inner().inner())),
-                );
-                payment.insert(
-                    "amount".into(),
-                    Value::Number(Number::from(amount.inner().inner())),
-                );
-                body.insert("Payment".into(), Value::Object(payment));
-            }
-            mina_rs::SignedCommandPayloadBody::StakeDelegation(stake_delegation) => {
-                let mina_rs::StakeDelegation::SetDelegate {
-                    delegator,
-                    new_delegate,
-                } = stake_delegation.inner();
-
-                let mut stake_delegation = Map::new();
-                stake_delegation.insert(
-                    "delegator".into(),
-                    Value::String(PublicKey::from(delegator).to_address()),
-                );
-                stake_delegation.insert(
-                    "new_delegate".into(),
-                    Value::String(PublicKey::from(new_delegate).to_address()),
-                );
-                body.insert("Stake_delegation".into(), Value::Object(stake_delegation));
-            }
-        };
-
-        json.insert("common".into(), Value::Object(common));
-        json.insert("body".into(), Value::Object(body));
-        Value::Object(json)
+        object.insert("payload".into(), payload);
+        object.insert("signer".into(), signer);
+        object.insert("signature".into(), signature);
+        Value::Object(object)
     }
 }
 
@@ -404,6 +318,123 @@ impl std::fmt::Debug for SignedCommandWithStateHash {
         );
         write!(f, "{}", to_string(&json).unwrap())
     }
+}
+
+fn signer(value: mina_rs::SignedCommandV1) -> serde_json::Value {
+    use serde_json::*;
+
+    Value::String(PublicKey::from_v1(value.inner().inner().signer.0.inner()).to_address())
+}
+
+fn signature(_value: mina_rs::SignedCommandV1) -> serde_json::Value {
+    use serde_json::*;
+
+    Value::String("signature".into())
+}
+
+fn payload_json(value: mina_rs::SignedCommandV1) -> serde_json::Value {
+    use serde_json::*;
+
+    let mut payload_obj = Map::new();
+    let mina_rs::SignedCommand { payload, .. } = value.inner().inner();
+
+    let mut common = Map::new();
+    let mina_rs::SignedCommandPayloadCommon {
+        fee,
+        fee_token,
+        fee_payer_pk,
+        nonce,
+        valid_until,
+        memo,
+    } = payload
+        .clone()
+        .inner()
+        .inner()
+        .common
+        .inner()
+        .inner()
+        .inner();
+    common.insert(
+        "fee".into(),
+        Value::Number(Number::from(fee.inner().inner())),
+    );
+    common.insert(
+        "fee_token".into(),
+        Value::Number(Number::from(fee_token.inner().inner().inner())),
+    );
+    common.insert(
+        "fee_payer_pk".into(),
+        Value::String(PublicKey::from(fee_payer_pk).to_address()),
+    );
+    common.insert(
+        "nonce".into(),
+        Value::Number(Number::from(nonce.inner().inner())),
+    );
+    common.insert(
+        "valid_until".into(),
+        Value::Number(Number::from(valid_until.inner().inner() as u32)),
+    );
+    common.insert(
+        "memo".into(),
+        Value::String(String::from_utf8_lossy(&memo.inner().0).to_string()),
+    );
+
+    let body = match payload.inner().inner().body.inner().inner() {
+        mina_rs::SignedCommandPayloadBody::PaymentPayload(payment_payload) => {
+            let mina_rs::PaymentPayload {
+                source_pk,
+                receiver_pk,
+                token_id,
+                amount,
+            } = payment_payload.inner().inner();
+
+            let mut payment = Map::new();
+            payment.insert(
+                "source_pk".into(),
+                Value::String(PublicKey::from(source_pk).to_address()),
+            );
+            payment.insert(
+                "receiver_pk".into(),
+                Value::String(PublicKey::from(receiver_pk).to_address()),
+            );
+            payment.insert(
+                "token_id".into(),
+                Value::Number(Number::from(token_id.inner().inner().inner())),
+            );
+            payment.insert(
+                "amount".into(),
+                Value::Number(Number::from(amount.inner().inner())),
+            );
+            Value::Array(vec![
+                Value::String("Payment".into()),
+                Value::Object(payment),
+            ])
+        }
+        mina_rs::SignedCommandPayloadBody::StakeDelegation(stake_delegation) => {
+            let mina_rs::StakeDelegation::SetDelegate {
+                delegator,
+                new_delegate,
+            } = stake_delegation.inner();
+
+            let mut stake_delegation = Map::new();
+            stake_delegation.insert(
+                "delegator".into(),
+                Value::String(PublicKey::from(delegator).to_address()),
+            );
+            stake_delegation.insert(
+                "new_delegate".into(),
+                Value::String(PublicKey::from(new_delegate).to_address()),
+            );
+            Value::Array(vec![
+                Value::String("Stake_delegation".into()),
+                Value::Object(stake_delegation),
+            ])
+        }
+    };
+
+    payload_obj.insert("common".into(), Value::Object(common));
+    payload_obj.insert("body".into(), body);
+    Value::Object(payload_obj)
 }
 
 #[cfg(test)]

--- a/src/command/signed.rs
+++ b/src/command/signed.rs
@@ -23,6 +23,7 @@ pub struct SignedCommandWithData {
     pub command: SignedCommand,
     pub state_hash: BlockHash,
     pub status: CommandStatusData,
+    pub tx_hash: String,
 }
 
 impl SignedCommand {
@@ -140,6 +141,20 @@ impl SignedCommandWithStateHash {
     }
 }
 
+impl SignedCommandWithData {
+    pub fn from(user_cmd: &UserCommandWithStatus, state_hash: &str) -> Self {
+        let command = SignedCommand::from(user_cmd.clone());
+        Self {
+            state_hash: state_hash.into(),
+            status: user_cmd.status_data(),
+            tx_hash: command
+                .hash_signed_command()
+                .expect("valid transaction hash"),
+            command,
+        }
+    }
+}
+
 impl From<mina_rs::UserCommand> for SignedCommand {
     fn from(value: mina_rs::UserCommand) -> Self {
         let mina_rs::UserCommand::SignedCommand(v1) = value;
@@ -217,12 +232,12 @@ impl From<Versioned<Versioned<mina_rs::SignedCommand, 1>, 1>> for SignedCommand 
     }
 }
 
-impl std::fmt::Debug for SignedCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl From<SignedCommand> for serde_json::Value {
+    fn from(value: SignedCommand) -> Self {
         use serde_json::*;
 
         let mut json = Map::new();
-        let mina_rs::SignedCommand { payload, .. } = self.0.clone().inner().inner();
+        let mina_rs::SignedCommand { payload, .. } = value.0.inner().inner();
 
         let mut common = Map::new();
         let mina_rs::SignedCommandPayloadCommon {
@@ -258,7 +273,7 @@ impl std::fmt::Debug for SignedCommand {
         );
         common.insert(
             "valid_until".into(),
-            Value::Number(Number::from(valid_until.inner().inner())),
+            Value::Number(Number::from(valid_until.inner().inner() as u64)),
         );
         common.insert(
             "memo".into(),
@@ -309,12 +324,84 @@ impl std::fmt::Debug for SignedCommand {
                     "new_delegate".into(),
                     Value::String(PublicKey::from(new_delegate).to_address()),
                 );
-                body.insert("StakeDelegation".into(), Value::Object(stake_delegation));
+                body.insert("Stake_delegation".into(), Value::Object(stake_delegation));
             }
         };
 
         json.insert("common".into(), Value::Object(common));
         json.insert("body".into(), Value::Object(body));
+        Value::Object(json)
+    }
+}
+
+pub struct SignedCommandWithKind(SignedCommand);
+
+impl From<UserCommandWithStatus> for SignedCommandWithKind {
+    fn from(value: UserCommandWithStatus) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<SignedCommandWithKind> for serde_json::Value {
+    fn from(value: SignedCommandWithKind) -> Self {
+        use serde_json::*;
+
+        Value::Array(vec![Value::String("Signed_command".into()), value.0.into()])
+    }
+}
+
+impl From<SignedCommandWithData> for serde_json::Value {
+    fn from(value: SignedCommandWithData) -> Self {
+        use serde_json::*;
+
+        let mut obj = Map::new();
+        let tx_hash = Value::String(value.tx_hash);
+        let state_hash = Value::String(value.state_hash.0);
+        let command = value.command.into();
+        let status = value.status.into();
+
+        obj.insert("tx_hash".into(), tx_hash);
+        obj.insert("command".into(), command);
+        obj.insert("status".into(), status);
+        obj.insert("state_hash".into(), state_hash);
+        Value::Object(obj)
+    }
+}
+
+impl From<SignedCommandWithData> for SignedCommand {
+    fn from(value: SignedCommandWithData) -> Self {
+        value.command
+    }
+}
+
+impl std::fmt::Debug for SignedCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use serde_json::*;
+
+        let json: Value = self.clone().into();
+        write!(f, "{}", to_string(&json).unwrap())
+    }
+}
+
+impl std::fmt::Debug for SignedCommandWithData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use serde_json::*;
+
+        let json: Value = self.clone().into();
+        write!(f, "{}", to_string(&json).unwrap())
+    }
+}
+
+impl std::fmt::Debug for SignedCommandWithStateHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use serde_json::*;
+
+        let mut json = Map::new();
+        json.insert("command".to_string(), self.command.clone().into());
+        json.insert(
+            "state_hash".to_string(),
+            Value::String(self.state_hash.0.clone()),
+        );
         write!(f, "{}", to_string(&json).unwrap())
     }
 }

--- a/src/command/signed.rs
+++ b/src/command/signed.rs
@@ -24,6 +24,7 @@ pub struct SignedCommandWithData {
     pub state_hash: BlockHash,
     pub status: CommandStatusData,
     pub tx_hash: String,
+    pub blockchain_length: u32,
 }
 
 impl SignedCommand {
@@ -142,7 +143,11 @@ impl SignedCommandWithStateHash {
 }
 
 impl SignedCommandWithData {
-    pub fn from(user_cmd: &UserCommandWithStatus, state_hash: &str) -> Self {
+    pub fn from(
+        user_cmd: &UserCommandWithStatus,
+        state_hash: &str,
+        blockchain_length: u32,
+    ) -> Self {
         let command = SignedCommand::from(user_cmd.clone());
         Self {
             state_hash: state_hash.into(),
@@ -151,6 +156,7 @@ impl SignedCommandWithData {
                 .hash_signed_command()
                 .expect("valid transaction hash"),
             command,
+            blockchain_length,
         }
     }
 }
@@ -273,11 +279,13 @@ impl From<SignedCommandWithData> for serde_json::Value {
         let state_hash = Value::String(value.state_hash.0);
         let command = value.command.into();
         let status = value.status.into();
+        let blockchain_length = value.blockchain_length.into();
 
         obj.insert("tx_hash".into(), tx_hash);
         obj.insert("command".into(), command);
         obj.insert("status".into(), status);
         obj.insert("state_hash".into(), state_hash);
+        obj.insert("blockchain_length".into(), blockchain_length);
         Value::Object(obj)
     }
 }

--- a/src/command/store.rs
+++ b/src/command/store.rs
@@ -1,6 +1,6 @@
 use crate::{
     block::{precomputed::PrecomputedBlock, BlockHash},
-    command::{signed::SignedCommandWithStateHash, UserCommandWithStatus},
+    command::{signed::SignedCommandWithData, UserCommandWithStatus},
     ledger::public_key::PublicKey,
 };
 
@@ -19,13 +19,13 @@ pub trait CommandStore {
     fn get_command_by_hash(
         &self,
         command_hash: &str,
-    ) -> anyhow::Result<Option<SignedCommandWithStateHash>>;
+    ) -> anyhow::Result<Option<SignedCommandWithData>>;
 
     /// Get commands involving the public key as a sender or receiver
     fn get_commands_for_public_key(
         &self,
         pk: &PublicKey,
-    ) -> anyhow::Result<Option<Vec<SignedCommandWithStateHash>>>;
+    ) -> anyhow::Result<Option<Vec<SignedCommandWithData>>>;
 
     /// Get commands for the public key with number and/or state hash bounds
     fn get_commands_with_bounds(
@@ -33,7 +33,7 @@ pub trait CommandStore {
         pk: &PublicKey,
         start_state_hash: &BlockHash,
         end_state_hash: &BlockHash,
-    ) -> anyhow::Result<Option<Vec<SignedCommandWithStateHash>>>;
+    ) -> anyhow::Result<Option<Vec<SignedCommandWithData>>>;
 
     /// Get number of commands for public key `pk`
     fn get_pk_num_commands(&self, pk: &str) -> anyhow::Result<Option<u32>>;

--- a/src/command/store.rs
+++ b/src/command/store.rs
@@ -1,6 +1,6 @@
 use crate::{
     block::{precomputed::PrecomputedBlock, BlockHash},
-    command::signed::{SignedCommand, SignedCommandWithStateHash},
+    command::{signed::SignedCommandWithStateHash, UserCommandWithStatus},
     ledger::public_key::PublicKey,
 };
 
@@ -13,7 +13,7 @@ pub trait CommandStore {
     fn get_commands_in_block(
         &self,
         state_hash: &BlockHash,
-    ) -> anyhow::Result<Option<Vec<SignedCommand>>>;
+    ) -> anyhow::Result<Option<Vec<UserCommandWithStatus>>>;
 
     /// Get a command by its hash
     fn get_command_by_hash(
@@ -34,4 +34,7 @@ pub trait CommandStore {
         start_state_hash: &BlockHash,
         end_state_hash: &BlockHash,
     ) -> anyhow::Result<Option<Vec<SignedCommandWithStateHash>>>;
+
+    /// Get number of commands for public key `pk`
+    fn get_pk_num_commands(&self, pk: &str) -> anyhow::Result<Option<u32>>;
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 use crate::ledger::account::Amount;
 
-pub const BLOCK_REPORTING_FREQ_NUM: u32 = 100;
+pub const BLOCK_REPORTING_FREQ_NUM: u32 = 5000;
 pub const BLOCK_REPORTING_FREQ_SEC: u64 = 180;
 pub const LEDGER_CADENCE: u32 = 100;
 pub const CANONICAL_UPDATE_THRESHOLD: u32 = PRUNE_INTERVAL_DEFAULT / 5;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,7 +1,7 @@
 use crate::{
     block::{is_valid_state_hash, store::BlockStore, Block, BlockHash, BlockWithoutHeight},
-    command::{signed::SignedCommand, store::CommandStore, Command},
-    ledger::{self, public_key::PublicKey, store::LedgerStore, Ledger},
+    command::{store::CommandStore, Command},
+    ledger::{self, public_key, store::LedgerStore, Ledger},
     server::{IndexerConfiguration, IpcChannelUpdate},
     state::summary::{SummaryShort, SummaryVerbose},
     store::IndexerStore,
@@ -125,12 +125,16 @@ async fn handle_conn(
     let response_json = match command_string.as_str() {
         "account" => {
             let pk_buffer = buffers.next().unwrap();
-            let pk: PublicKey = String::from_utf8(pk_buffer.to_vec())?
-                .trim_end_matches('\0')
-                .into();
+            let pk = String::from_utf8(pk_buffer.to_vec())?;
+            let pk = pk.trim_end_matches('\0');
+            if public_key::is_valid(pk) {
+                Some(pk.into())
+            } else {
+                Some(format!("Invalid pk: {pk}"))
+            };
             info!("Received account command for {pk}");
 
-            let account = ledger.accounts.get(&pk);
+            let account = ledger.accounts.get(&pk.into());
             if let Some(account) = account {
                 debug!("Writing account {account:?} to client");
                 Some(serde_json::to_string(account)?)
@@ -379,10 +383,9 @@ async fn handle_conn(
             writer
                 .write_all(b"Shutting down the Mina Indexer daemon...")
                 .await?;
-            info!("Shutting down the indexer...");
             process::exit(0);
         }
-        "transactions" => {
+        "tx-pk" => {
             let pk = &String::from_utf8(buffers.next().unwrap().to_vec())?;
             let verbose = String::from_utf8(buffers.next().unwrap().to_vec())?.parse::<bool>()?;
             let num = String::from_utf8(buffers.next().unwrap().to_vec())?.parse::<usize>()?;
@@ -400,7 +403,7 @@ async fn handle_conn(
             let path = String::from_utf8(buffers.next().unwrap().to_vec())?;
             let path = path.trim_end_matches('\0');
 
-            info!("Received transactions command for {pk}");
+            info!("Received transactions command for public key {pk}");
             let transactions = db
                 .get_commands_with_bounds(&pk.clone().into(), &start_state_hash, &end_state_hash)?
                 .unwrap_or(vec![]);
@@ -412,27 +415,22 @@ async fn handle_conn(
                 };
 
                 if verbose {
-                    let txs: Vec<SignedCommand> =
-                        txs.into_iter().map(SignedCommand::from).collect();
                     format!("{txs:?}")
                 } else {
-                    let txs: Vec<Command> = txs.into_iter().map(Command::from).collect();
+                    let txs: Vec<Command> =
+                        txs.into_iter().map(|c| Command::from(c.command)).collect();
                     format!("{txs:?}")
                 }
             };
             if path.is_empty() {
-                // stdout
                 debug!("Writing transactions for {pk} to stdout");
                 Some(transaction_str)
             } else {
-                // write to path
                 let path: PathBuf = path.into();
                 if !path.is_dir() {
                     debug!("Writing transactions for {pk} to {}", path.display());
 
                     tokio::fs::write(&path, transaction_str).await?;
-                    // let s = tokio::fs::read_to_string(path.clone()).await?;
-                    // debug!("File contents: {s}");
                     Some(format!(
                         "Transactions for {pk} written to {}",
                         path.display()
@@ -444,6 +442,38 @@ async fn handle_conn(
                     ))
                 }
             }
+        }
+        "tx-hash" => {
+            let tx_hash = String::from_utf8(buffers.next().unwrap().to_vec())?;
+            let verbose = String::from_utf8(buffers.next().unwrap().to_vec())?
+                .trim_end_matches('\0')
+                .parse()?;
+
+            info!("Received transactions command for tx hash {tx_hash}");
+            db.get_command_by_hash(&tx_hash)?.map(|cmd| {
+                if verbose {
+                    format!("{cmd:?}")
+                } else {
+                    let cmd: Command = cmd.command.into();
+                    format!("{cmd:?}")
+                }
+            })
+        }
+        "tx-state-hash" => {
+            let state_hash = String::from_utf8(buffers.next().unwrap().to_vec())?;
+            let verbose = String::from_utf8(buffers.next().unwrap().to_vec())?
+                .trim_end_matches('\0')
+                .parse()?;
+
+            info!("Received transactions command for state hash {state_hash}");
+            db.get_commands_in_block(&state_hash.into())?.map(|cmds| {
+                if verbose {
+                    format!("{cmds:?}")
+                } else {
+                    let cmd: Vec<Command> = cmds.into_iter().map(Command::from).collect();
+                    format!("{cmd:?}")
+                }
+            })
         }
         bad_request => {
             return Err(anyhow!("Malformed request: {bad_request}"));

--- a/src/ledger/account.rs
+++ b/src/ledger/account.rs
@@ -93,7 +93,7 @@ impl Ord for Account {
 
 const MINA_SCALE: u32 = 9;
 
-fn nanomina_to_mina(num: u64) -> String {
+pub fn nanomina_to_mina(num: u64) -> String {
     let mut dec = Decimal::from(num);
     dec.set_scale(MINA_SCALE).unwrap();
     let mut dec_str = dec.to_string();

--- a/src/ledger/public_key.rs
+++ b/src/ledger/public_key.rs
@@ -26,6 +26,10 @@ impl Ord for PublicKey {
 }
 
 impl PublicKey {
+    pub fn from_v1(v1: PublicKeyV1) -> Self {
+        Self(v1)
+    }
+
     pub fn to_address(&self) -> String {
         CompressedPubKey::from(&self.0).into_address()
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -122,7 +122,7 @@ impl BlockStore for IndexerStore {
         // add block commands
         self.add_commands(block)?;
 
-        // add new block event
+        // add new block db event only after all other data is added
         let db_event = DbEvent::Block(DbBlockEvent::NewBlock {
             state_hash: block.state_hash.clone(),
             blockchain_length: block.blockchain_length,
@@ -462,28 +462,31 @@ impl CommandStore for IndexerStore {
         let value = serde_json::to_vec(&signed_commands)?;
         self.database.put_cf(&commands_cf, key, value)?;
 
-        // add: pk -> signed commands with state hash
+        // add: "pk -> linked list of signed commands with state hash"
         for pk in block.all_public_keys() {
             let pk_str = pk.to_address();
             trace!("Adding command pk {pk}");
-            let key = pk_str.as_bytes();
 
-            let mut block_pk_commands: Vec<SignedCommandWithStateHash> = signed_commands
+            // get pk num commands
+            let n = self.get_pk_num_commands(&pk_str)?.unwrap_or(0);
+            let block_pk_commands: Vec<SignedCommandWithStateHash> = signed_commands
                 .iter()
                 .filter(|cmd| cmd.contains_public_key(&pk))
                 .map(|c| SignedCommandWithStateHash::from(c, &block.state_hash))
                 .collect();
 
-            block_pk_commands.append(
-                &mut self
-                    .database
-                    .get_pinned_cf(&commands_cf, key)?
-                    .map(|bytes| serde_json::from_slice(&bytes).unwrap())
-                    .unwrap_or(vec![]),
-            );
+            if !block_pk_commands.is_empty() {
+                // write these commands to the next key for pk
+                let key = format!("{pk_str}{n}").as_bytes().to_vec();
+                let value = serde_json::to_vec(&block_pk_commands)?;
+                self.database.put_cf(commands_cf, &key, value)?;
 
-            let value = serde_json::to_vec(&block_pk_commands)?;
-            self.database.put_cf(&commands_cf, key, value)?;
+                // update pk's num commands
+                let key = pk_str.as_bytes();
+                let next_n = (n + 1).to_string();
+                let value = next_n.as_bytes();
+                self.database.put_cf(&commands_cf, key, value)?;
+            }
         }
 
         Ok(())
@@ -527,12 +530,34 @@ impl CommandStore for IndexerStore {
         trace!("Getting commands for public key {pk}");
         self.database.try_catch_up_with_primary().unwrap_or(());
 
-        let key = pk.as_bytes();
         let commands_cf = self.commands_cf();
-        if let Some(commands_bytes) = self.database.get_pinned_cf(commands_cf, key)? {
-            return Ok(Some(serde_json::from_slice(&commands_bytes)?));
+        let mut commands = None;
+        fn key_n(pk: String, n: u32) -> Vec<u8> {
+            format!("{pk}{n}").as_bytes().to_vec()
         }
-        Ok(None)
+
+        if let Some(n) = self.get_pk_num_commands(&pk)? {
+            for m in 0..n {
+                if let Some(mut block_m_commands) = self
+                    .database
+                    .get_pinned_cf(commands_cf, key_n(pk.clone(), m))?
+                    .map(|bytes| {
+                        serde_json::from_slice::<Vec<SignedCommandWithStateHash>>(&bytes)
+                            .expect("signed commands with state hash")
+                    })
+                {
+                    let mut cmds = commands.unwrap_or(vec![]);
+                    cmds.append(&mut block_m_commands);
+                    commands = Some(cmds);
+                } else {
+                    commands = None;
+                    break;
+                }
+            }
+        }
+
+        // only returns some if all fetches are successful
+        Ok(commands)
     }
 
     fn get_commands_with_bounds(
@@ -577,6 +602,18 @@ impl CommandStore for IndexerStore {
         }
 
         Ok(None)
+    }
+
+    /// Number of blocks containing `pk` commands
+    fn get_pk_num_commands(&self, pk: &str) -> anyhow::Result<Option<u32>> {
+        let key = pk.as_bytes();
+        Ok(self
+            .database
+            .get_pinned_cf(self.commands_cf(), key)?
+            .map(|bytes| {
+                let s = String::from_utf8(bytes.to_vec()).expect("valid utf8");
+                s.parse().expect("n is u32")
+            }))
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -452,8 +452,11 @@ impl CommandStore for IndexerStore {
             );
 
             let key = hash.as_bytes();
-            let value =
-                serde_json::to_vec(&SignedCommandWithData::from(command, &block.state_hash))?;
+            let value = serde_json::to_vec(&SignedCommandWithData::from(
+                command,
+                &block.state_hash,
+                block.blockchain_length,
+            ))?;
             self.database.put_cf(commands_cf, key, value)?;
         }
 
@@ -472,7 +475,7 @@ impl CommandStore for IndexerStore {
             let block_pk_commands: Vec<SignedCommandWithData> = user_commands
                 .iter()
                 .filter(|cmd| cmd.contains_public_key(&pk))
-                .map(|c| SignedCommandWithData::from(c, &block.state_hash))
+                .map(|c| SignedCommandWithData::from(c, &block.state_hash, block.blockchain_length))
                 .collect();
 
             if !block_pk_commands.is_empty() {

--- a/test
+++ b/test
@@ -2,7 +2,8 @@
 set -ex
 
 # Collect the binaries under test and the test ledger.
-IDXR="$(pwd)"/target/debug/mina-indexer
+IDXR_DEBUG="$(pwd)"/target/debug/mina-indexer
+IDXR_RELEASE="$(pwd)"/target/release/mina-indexer
 LEDGER="$(pwd)"/tests/data/genesis_ledgers/mainnet.json
 BLOCKS_FETCHER="$(pwd)"/download_blocks
 
@@ -23,16 +24,25 @@ test_cleanup() {
 trap test_cleanup EXIT
 
 idxr() {
-    RUST_BACKTRACE=full "$IDXR" "$@"
+    RUST_BACKTRACE=full "$IDXR_DEBUG" "$@"
 }
 
 idxr_server() {
-    RUST_BACKTRACE=full "$IDXR" server "$@" &
+    RUST_BACKTRACE=full "$IDXR_DEBUG" server "$@" &
+    echo $! > idxr_pid
+}
+
+idxr_server_release() {
+    RUST_BACKTRACE=full "$IDXR_RELEASE" server "$@" &
     echo $! > idxr_pid
 }
 
 idxr_server_start() {
     idxr_server start "$@"
+}
+
+idxr_server_release_start() {
+    idxr_server_release start "$@"
 }
 
 dl_mainnet() {
@@ -728,6 +738,46 @@ test_many_blocks() {
     teardown
 }
 
+# Release version is fast
+test_release() {
+    test=test_release
+
+    setup
+    dl_mainnet 5000 ./blocks
+
+    idxr_server_release_start \
+        --startup-dir ./blocks \
+        --watch-dir ./blocks \
+        --database-dir ./database \
+        --log-dir ./logs
+        --log-level-stdout debug &
+    sleep 30
+
+    # results
+    best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
+    best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+
+    assert '5000' $best_length
+    assert '4990' $canonical_length
+    assert '3NKiyxhxfohCGpHkQg7TC1cNxHzAHbcHCUAdSM1aNt2u6dGtVrvC' $canonical_hash
+    assert '3NLn1bsWFjycHNJGGLy3KSxXSW6ixmFrunn1iym5GWjTXxkt6oFi' $best_hash
+
+    pk='B62qpJ4Q5J4LoBXgQBfq6gbXTyevFPhwMNYZEBdTSixmFq4UrdNadSN'
+
+    # check ledgers are present
+    # mainnet-100-3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4.json
+    balance=$(idxr ledger --hash 3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4 | jq -r .${pk}.balance)
+    assert '502777775000000' $balance
+
+    # mainnet-900-3NLHqp2mkmWbf4o69J4hg5cftRAAvZ5Edy7uqvJUUVvZWtD1xRrh.json
+    balance=$(idxr ledger --hash 3NLHqp2mkmWbf4o69J4hg5cftRAAvZ5Edy7uqvJUUVvZWtD1xRrh | jq -r .${pk}.balance)
+    assert '502777775000000' $balance
+
+    teardown
+}
+
 # Check command-line arguments
 if [ "$#" -eq 0 ]; then
     # No arguments provided, run all tests
@@ -765,6 +815,7 @@ else
             "test_transactions") test_transactions ;;
             "test_checkpoint") test_checkpoint ;;
             "test_many_blocks") test_many_blocks ;;
+            "test_release") test_release ;;
             *) echo "Unknown test: $test_name" ;;
         esac
     done

--- a/test
+++ b/test
@@ -265,7 +265,8 @@ test_missing_blocks() {
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
-        --log-dir ./logs
+        --log-dir ./logs \
+        --log-level-stdout debug &
     sleep 5
 
     # start out missing block 11 & 21
@@ -550,7 +551,7 @@ test_transactions() {
     # basic pk transaction queries
     transactions=$(idxr tx-public-key --public-key B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR -j | jq -r .)
     amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j | jq -r .[0].Payment.amount)
-    amount_v=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.body.Payment.amount)
+    amount_v=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.body.Payment.amount)
     state_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].state_hash)
     tx_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].tx_hash)
 
@@ -578,7 +579,7 @@ test_transactions() {
     assert '1000' $amount
 
     # tx hash query - verbose
-    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.body.Payment.amount)
+    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.payload.body.Payment.amount)
     status=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .status | jq -r .[0])
     tx_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .tx_hash)
     state_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .state_hash)
@@ -601,10 +602,10 @@ test_transactions() {
     kind=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[0])
     assert 'Signed_command' $kind
 
-    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.amount)
-    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.source_pk)
-    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.receiver_pk)
-    token=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.token_id)
+    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.amount)
+    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.source_pk)
+    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.receiver_pk)
+    token=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.token_id)
 
     assert '1' $token
     assert '1000' $amount

--- a/test
+++ b/test
@@ -23,11 +23,11 @@ test_cleanup() {
 trap test_cleanup EXIT
 
 idxr() {
-    "$IDXR" "$@"
+    RUST_BACKTRACE=full "$IDXR" "$@"
 }
 
 idxr_server() {
-    "$IDXR" server "$@" &
+    RUST_BACKTRACE=full "$IDXR" server "$@" &
     echo $! > idxr_pid
 }
 

--- a/test
+++ b/test
@@ -31,8 +31,8 @@ idxr_server() {
     echo $! > idxr_pid
 }
 
-idxr_server_cli() {
-    idxr_server cli "$@"
+idxr_server_start() {
+    idxr_server start "$@"
 }
 
 dl_mainnet() {
@@ -125,8 +125,14 @@ test_indexer_cli_reports() {
     idxr shutdown --help 2>&1 |
         grep -iq "Usage: mina-indexer shutdown"
 
-    idxr transactions --help 2>&1 |
-        grep -iq "Usage: mina-indexer transactions"
+    idxr tx-hash --help 2>&1 |
+        grep -iq "Usage: mina-indexer tx-hash"
+
+    idxr tx-public-key --help 2>&1 |
+        grep -iq "Usage: mina-indexer tx-public-key"
+
+    idxr tx-state-hash --help 2>&1 |
+        grep -iq "Usage: mina-indexer tx-state-hash"
 }
 
 # Indexer server starts up without any precomputed blocks
@@ -134,7 +140,7 @@ test_server_startup() {
     test=test_server_startup
     
     setup
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -154,7 +160,7 @@ test_ipc_is_available_immediately() {
     setup
     dl_mainnet 100 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -172,7 +178,7 @@ test_startup_dirs_get_created() {
     test=test_startup_dirs_get_created
 
     setup
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./startup-blocks \
         --watch-dir ./watch-blocks \
         --database-dir ./database \
@@ -192,7 +198,7 @@ test_account_balance_cli() {
     test=test_account_balance_cli
 
     setup
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -210,7 +216,7 @@ test_account_public_key_json() {
     test=test_account_public_key_json
 
     setup
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -230,7 +236,7 @@ test_canonical_tip() {
     setup
     dl_mainnet 15 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -255,7 +261,7 @@ test_missing_blocks() {
     dl_mainnet_range 12 20 ./blocks # missing 11
     dl_mainnet_range 22 30 ./blocks # missing 21
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -321,7 +327,7 @@ test_best_chain() {
     mkdir best_chain
     dl_mainnet 12 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -374,7 +380,7 @@ test_ledgers() {
     mkdir ledgers
     dl_mainnet 15 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -434,7 +440,7 @@ test_sync() {
     setup
     dl_mainnet 15 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -481,7 +487,7 @@ test_replay() {
     setup
     dl_mainnet 15 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -534,39 +540,80 @@ test_transactions() {
     mkdir transactions
     dl_mainnet 13 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs
     sleep 5
 
-    # basic transaction queries
-    transactions=$(idxr transactions --public-key B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR -j | jq -r .)
+    # basic pk transaction queries
+    transactions=$(idxr tx-public-key --public-key B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR -j | jq -r .)
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j | jq -r .[0].Payment.amount)
+    amount_v=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.body.Payment.amount)
+    state_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].state_hash)
+    tx_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].tx_hash)
+
     assert '[]' $transactions
-
-    amount=$(idxr transactions --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
     assert '1000' $amount
+    assert '1000' $amount_v
+    assert '3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R' $state_hash
+    assert 'CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa' $tx_hash
 
-    amount=$(idxr transactions --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j | jq -r .[0].Payment.amount)
-    assert '1000' $amount
-
-    # bounded transaction queries
-    amount=$(idxr transactions -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy \
+    # bounded pk transaction queries
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy \
         --start-state-hash 3NL9qBsNibXPm5Nh8cSg5CCqrbzX5VUVY9gJzAbg7EVCF3hfhazG \
         --end-state-hash 3NKXzc1hAE1bK9BSkJUhBBSznMhwW3ZxUTgdoLoqzW6SvqVFcAw5 \
         | jq -r .[0].Payment.amount)
     assert '1000' $amount
 
-    amount=$(idxr transactions -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy \
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy \
         --start-state-hash 3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH \
         --end-state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R \
         | jq -r .[0].Payment.amount)
     assert '1000' $amount
 
+    # tx hash query
+    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j | jq -r .Payment.amount)
+    assert '1000' $amount
+
+    # tx hash query - verbose
+    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.body.Payment.amount)
+    status=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .status | jq -r .[0])
+    tx_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .tx_hash)
+    state_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .state_hash)
+
+    assert '1000' $amount
+    assert 'Failed' $status
+    assert 'CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa' $tx_hash
+    assert '3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R' $state_hash
+
+    # state hash query
+    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j | jq -r .[0].Payment.amount)
+    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j | jq -r .[0].Payment.source)
+    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j | jq -r .[0].Payment.receiver)
+
+    assert '1000' $amount
+    assert 'B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy' $source
+    assert 'B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM' $receiver
+
+    # state hash query - verbose
+    kind=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[0])
+    assert 'Signed_command' $kind
+
+    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.amount)
+    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.source_pk)
+    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.receiver_pk)
+    token=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].body.Payment.token_id)
+
+    assert '1' $token
+    assert '1000' $amount
+    assert 'B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy' $source
+    assert 'B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM' $receiver
+
     # write transactions to file
     file=./transactions/transactions.json
-    idxr transactions --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -p $file
+    idxr tx-public-key --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -p $file
     
     file_result=$(cat $file | jq -r .[0].Payment.amount)
     assert '1000' $file_result
@@ -582,7 +629,7 @@ test_checkpoint() {
     setup
     dl_mainnet 13 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
@@ -594,7 +641,7 @@ test_checkpoint() {
     canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    amount=$(idxr transactions --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
 
     # create checkpoint in ./checkpoint
     idxr checkpoint -p ./checkpoint
@@ -616,7 +663,7 @@ test_checkpoint() {
     canonical_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
     best_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    amount_checkpoint=$(idxr transactions --public-key B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
+    amount_checkpoint=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
 
     assert $canonical_hash $canonical_hash_checkpoint
     assert $canonical_length $canonical_length_checkpoint
@@ -635,14 +682,14 @@ test_many_blocks() {
     setup
     dl_mainnet 1000 ./blocks
 
-    idxr_server_cli \
+    idxr_server_start \
         --startup-dir ./blocks \
         --watch-dir ./blocks \
         --database-dir ./database \
         --log-dir ./logs \
         --ledger-cadence 100 \
-        --log-level-stdout debug
-    sleep 300
+        --log-level-stdout debug &
+    sleep 60
 
     # results
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)

--- a/test
+++ b/test
@@ -551,13 +551,20 @@ test_transactions() {
     # basic pk transaction queries
     transactions=$(idxr tx-public-key --public-key B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR -j | jq -r .)
     amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j | jq -r .[0].Payment.amount)
-    amount_v=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.body.Payment.amount)
+
+    assert '1000' $amount
+    assert '[]' $transactions
+
+    # basic pk transaction queries - verbose
+    kind=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.body.kind)
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.body.contents.amount)
     state_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].state_hash)
     tx_hash=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].tx_hash)
+    length=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].blockchain_length)
 
-    assert '[]' $transactions
+    assert 3 $length
     assert '1000' $amount
-    assert '1000' $amount_v
+    assert 'Payment' $kind
     assert '3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R' $state_hash
     assert 'CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa' $tx_hash
 
@@ -579,11 +586,15 @@ test_transactions() {
     assert '1000' $amount
 
     # tx hash query - verbose
-    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.payload.body.Payment.amount)
-    status=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .status | jq -r .[0])
+    kind=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.payload.body.kind)
+    amount=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .command.payload.body.contents.amount)
+    status=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .status.kind)
     tx_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .tx_hash)
     state_hash=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .state_hash)
+    length=$(idxr tx-hash --tx-hash CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa -j -v | jq -r .blockchain_length)
 
+    assert 3 $length
+    assert 'Payment' $kind
     assert '1000' $amount
     assert 'Failed' $status
     assert 'CkpZirFuoLVVab6x2ry4j8Ld5gMmQdak7VHW6f5C7VJYE34WAEWqa' $tx_hash
@@ -599,13 +610,13 @@ test_transactions() {
     assert 'B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM' $receiver
 
     # state hash query - verbose
-    kind=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[0])
+    kind=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data.kind)
     assert 'Signed_command' $kind
 
-    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.amount)
-    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.source_pk)
-    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.receiver_pk)
-    token=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data | jq -r .[1].payload.body.Payment.token_id)
+    amount=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data.contents.payload.body.contents.amount)
+    source=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data.contents.payload.body.contents.source_pk)
+    receiver=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data.contents.payload.body.contents.receiver_pk)
+    token=$(idxr tx-state-hash --state-hash 3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R -j -v | jq -r .[0].data.contents.payload.body.contents.token_id)
 
     assert '1' $token
     assert '1000' $amount
@@ -642,7 +653,7 @@ test_checkpoint() {
     canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
+    amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.contents.body.contents.amount)
 
     # create checkpoint in ./checkpoint
     idxr checkpoint -p ./checkpoint
@@ -664,7 +675,7 @@ test_checkpoint() {
     canonical_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
     best_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    amount_checkpoint=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].body.Payment.amount)
+    amount_checkpoint=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -j -v | jq -r .[0].command.payload.contents.body.contents.amount)
 
     assert $canonical_hash $canonical_hash_checkpoint
     assert $canonical_length $canonical_length_checkpoint

--- a/tests/command/store.rs
+++ b/tests/command/store.rs
@@ -34,7 +34,7 @@ async fn add_and_get() {
     let mut bp = BlockParser::new(blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
     let state_hash = "3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw";
     let block = bp.get_precomputed_block(state_hash).await.unwrap();
-    let block_cmds = SignedCommand::from_precomputed(&block);
+    let block_cmds = block.commands();
     let pks = block.all_public_keys();
 
     // add the block to the block store
@@ -53,6 +53,7 @@ async fn add_and_get() {
         let pk_cmds: Vec<SignedCommand> = block_cmds
             .iter()
             .cloned()
+            .map(SignedCommand::from)
             .filter(|x| x.contains_public_key(&pk))
             .collect();
         let result_pk_cmds: Vec<SignedCommand> = indexer_store
@@ -67,7 +68,7 @@ async fn add_and_get() {
     }
 
     // check transaction hash key
-    for cmd in block_cmds {
+    for cmd in SignedCommand::from_precomputed(&block) {
         let result_cmd: SignedCommand = indexer_store
             .get_command_by_hash(&cmd.hash_signed_command().unwrap())
             .unwrap()


### PR DESCRIPTION
- persist commands in an array
- embellish stored command data
- flatten transaction and ledger queries
- change `mina-indexer server cli` to `mina-indexer server start`
- add `RUST_BACKTRACE=full` to regression tests
- introduce json conversion functions

Fixes: https://github.com/Granola-Team/mina-indexer/issues/404
Starts solving: https://github.com/Granola-Team/mina-indexer/issues/342