### PR TITLE
Unit test improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "speedb",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bs58 = { version = "0.5.0", features = ["check"] }
 blake2 = "0.10.6"
 ctrlc = "3.4.0"
 oneshot = "0.1.5"
+tempfile = "3.9.0"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/tests/block/store/add_and_get_blocks.rs
+++ b/tests/block/store/add_and_get_blocks.rs
@@ -4,15 +4,14 @@ use mina_indexer::{
     constants::MAINNET_CANONICAL_THRESHOLD,
     store::IndexerStore,
 };
-use std::{collections::HashMap, fs::remove_dir_all, path::PathBuf};
-use tokio::time::Instant;
+use std::{collections::HashMap, path::PathBuf, time::Instant};
 
-#[tokio::test]
-async fn speedb() {
-    let store_dir = setup_new_db_dir("./block-store-test");
+#[test]
+fn speedb() {
+    let store_dir = setup_new_db_dir("block-store-db").unwrap();
     let log_dir = &PathBuf::from("./tests/data/sequential_blocks");
 
-    let db = IndexerStore::new(&store_dir).unwrap();
+    let db = IndexerStore::new(store_dir.path()).unwrap();
     let mut bp = BlockParser::new(log_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
     let mut blocks = HashMap::new();
@@ -39,6 +38,4 @@ async fn speedb() {
     println!("Number of blocks: {n}");
     println!("To insert all:    {add_time:?}");
     println!("To fetch all:     {:?}\n", fetching.elapsed());
-
-    remove_dir_all(store_dir).unwrap();
 }

--- a/tests/block/store/genesis.rs
+++ b/tests/block/store/genesis.rs
@@ -13,8 +13,8 @@ use std::{path::PathBuf, sync::Arc};
 
 #[test]
 fn block_added() -> anyhow::Result<()> {
-    let store_dir = setup_new_db_dir("genesis-block-test");
-    let indexer_store = Arc::new(IndexerStore::new(&store_dir)?);
+    let store_dir = setup_new_db_dir("block-store-genesis")?;
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path())?);
     let genesis_ledger_path = &PathBuf::from("./tests/data/genesis_ledgers/mainnet.json");
     let genesis_root = parse_file(genesis_ledger_path)?;
 

--- a/tests/canonicity/blocks.rs
+++ b/tests/canonicity/blocks.rs
@@ -9,14 +9,14 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn test() {
-    let db_path = setup_new_db_dir("./test_canonical_blocks_store");
+    let store_dir = setup_new_db_dir("canonicity-blocks").unwrap();
     let log_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
-    let indexer_store = Arc::new(IndexerStore::new(&db_path).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
         .unwrap()
@@ -80,6 +80,4 @@ async fn test() {
                 .unwrap()
         );
     }
-
-    remove_dir_all(db_path).unwrap();
 }

--- a/tests/canonicity/chain_discovery.rs
+++ b/tests/canonicity/chain_discovery.rs
@@ -1,8 +1,8 @@
 use mina_indexer::{block::parser::BlockParser, constants::MAINNET_CANONICAL_THRESHOLD};
 use std::path::PathBuf;
 
-#[tokio::test]
-async fn gaps() {
+#[test]
+fn gaps() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/gaps");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
@@ -18,8 +18,8 @@ async fn gaps() {
     assert_eq!(block_parser.total_num_blocks, 25);
 }
 
-#[tokio::test]
-async fn contiguous() {
+#[test]
+fn contiguous() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
@@ -35,8 +35,8 @@ async fn contiguous() {
     assert_eq!(block_parser.total_num_blocks, 20);
 }
 
-#[tokio::test]
-async fn missing_parent() {
+#[test]
+fn missing_parent() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/missing_parent");
     let mut block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
@@ -57,8 +57,8 @@ async fn missing_parent() {
     assert_eq!(block_parser.total_num_blocks, 35)
 }
 
-#[tokio::test]
-async fn one_block() {
+#[test]
+fn one_block() {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/one_block");
     let block_parser = BlockParser::new(&blocks_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
@@ -66,8 +66,8 @@ async fn one_block() {
     assert_eq!(block_parser.total_num_blocks, 1);
 }
 
-#[tokio::test]
-async fn canonical_threshold() {
+#[test]
+fn canonical_threshold() {
     let canonical_threshold = 2;
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new(&blocks_dir, canonical_threshold).unwrap();

--- a/tests/canonicity/ledgers.rs
+++ b/tests/canonicity/ledgers.rs
@@ -9,14 +9,14 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn test() {
-    let db_path = setup_new_db_dir("./test_canonical_ledgers_store");
+    let store_dir = setup_new_db_dir("./test_canonical_ledgers_store").unwrap();
     let log_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
-    let indexer_store = Arc::new(IndexerStore::new(&db_path).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
         .unwrap()
@@ -126,6 +126,4 @@ async fn test() {
         assert!(ledger == ledger_diff, "Different ledgers (diff)");
         assert!(ledger == ledger_post, "Different ledgers (post)");
     }
-
-    remove_dir_all(db_path).unwrap();
 }

--- a/tests/command/store.rs
+++ b/tests/command/store.rs
@@ -10,14 +10,14 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn add_and_get() {
-    let store_dir = setup_new_db_dir("./command-store-test");
+    let store_dir = setup_new_db_dir("command-store").unwrap();
     let blocks_dir = &PathBuf::from("./tests/data/non_sequential_blocks");
 
-    let indexer_store = Arc::new(IndexerStore::new(&store_dir).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_ledger_path = &PathBuf::from("./tests/data/genesis_ledgers/mainnet.json");
     let genesis_root = parse_file(genesis_ledger_path).unwrap();
     let indexer = IndexerState::new(
@@ -76,6 +76,4 @@ async fn add_and_get() {
             .into();
         assert_eq!(result_cmd, cmd);
     }
-
-    remove_dir_all(store_dir).unwrap();
 }

--- a/tests/event/log.rs
+++ b/tests/event/log.rs
@@ -10,20 +10,20 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn test() {
     let log_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
 
-    let db_path0 = setup_new_db_dir("./test-event-log-store0");
+    let store_dir0 = setup_new_db_dir("event-log-store0").unwrap();
     let mut block_parser0 = BlockParser::new(&log_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    let db_path1 = setup_new_db_dir("./test-event-log-store1");
+    let store_dir1 = setup_new_db_dir("event-log-store1").unwrap();
     let mut block_parser1 = BlockParser::new(&log_dir, MAINNET_CANONICAL_THRESHOLD).unwrap();
 
-    let indexer_store0 = Arc::new(IndexerStore::new(&db_path0).unwrap());
-    let indexer_store1 = Arc::new(IndexerStore::new(&db_path1).unwrap());
+    let indexer_store0 = Arc::new(IndexerStore::new(store_dir0.path()).unwrap());
+    let indexer_store1 = Arc::new(IndexerStore::new(store_dir1.path()).unwrap());
 
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
@@ -101,7 +101,4 @@ async fn test() {
     println!("{:?}", event_log1);
 
     assert_eq!(event_log0, event_log1);
-
-    remove_dir_all(db_path0).unwrap();
-    remove_dir_all(db_path1).unwrap();
 }

--- a/tests/event/replay.rs
+++ b/tests/event/replay.rs
@@ -8,14 +8,14 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn test() {
-    let db_path = setup_new_db_dir("./test-event-replay");
+    let store_dir = setup_new_db_dir("event-replay").unwrap();
     let log_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
-    let indexer_store = Arc::new(IndexerStore::new(&db_path).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
         .unwrap()
@@ -53,6 +53,4 @@ async fn test() {
     assert_eq!(state.best_tip_block(), new_state.best_tip_block());
     assert_eq!(state.canonical_tip_block(), new_state.canonical_tip_block());
     assert_eq!(state.diffs_map, new_state.diffs_map);
-
-    remove_dir_all(db_path).unwrap();
 }

--- a/tests/event/store.rs
+++ b/tests/event/store.rs
@@ -3,12 +3,11 @@ use mina_indexer::{
     event::{block::*, db::*, ledger::*, store::*, witness_tree::*, *},
     store::IndexerStore,
 };
-use std::fs::remove_dir_all;
 
-#[tokio::test]
-async fn add_and_get_events() {
-    let store_dir = setup_new_db_dir("./event-store-test");
-    let db = IndexerStore::new(&store_dir).unwrap();
+#[test]
+fn add_and_get_events() {
+    let store_dir = setup_new_db_dir("event-store").unwrap();
+    let db = IndexerStore::new(store_dir.path()).unwrap();
 
     let event0 = IndexerEvent::BlockWatcher(BlockWatcherEvent::SawBlock {
         state_hash: "block0".into(),
@@ -61,6 +60,4 @@ async fn add_and_get_events() {
         event_log,
         vec![event0, event1, event2, event3, event4, event5, event6, event7, event8]
     );
-
-    remove_dir_all(store_dir).unwrap();
 }

--- a/tests/event/sync.rs
+++ b/tests/event/sync.rs
@@ -8,14 +8,14 @@ use mina_indexer::{
     state::IndexerState,
     store::IndexerStore,
 };
-use std::{fs::remove_dir_all, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
 async fn test() {
-    let db_path = setup_new_db_dir("./test-event-sync");
+    let store_dir = setup_new_db_dir("event-sync").unwrap();
     let log_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
-    let indexer_store = Arc::new(IndexerStore::new(&db_path).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
         .unwrap()
@@ -64,6 +64,4 @@ async fn test() {
             state_sync.diffs_map.get(state_hash)
         );
     }
-
-    remove_dir_all(db_path).unwrap();
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,14 +6,12 @@ mod receiver;
 mod state;
 
 pub mod helpers {
-    /// Removes the dir if it exists, creates a fesh dir
-    pub fn setup_new_db_dir(db_path: &str) -> std::path::PathBuf {
-        let mut store_dir = std::env::temp_dir();
-        store_dir.push(db_path);
-
-        if store_dir.exists() {
-            std::fs::remove_dir_all(store_dir.clone()).unwrap();
+    /// Sets up a new temp dir, deleted when it goes out of scope
+    pub fn setup_new_db_dir(prefix: &str) -> anyhow::Result<tempfile::TempDir> {
+        let store_dir = tempfile::TempDir::with_prefix(prefix)?;
+        if store_dir.path().exists() {
+            std::fs::remove_dir_all(store_dir.path())?;
         }
-        store_dir
+        Ok(store_dir)
     }
 }


### PR DESCRIPTION
- use `tempfile` temp dirs in unit tests
- remove manual resource handling
- remove `async` tests where possible

Solves https://github.com/Granola-Team/mina-indexer/issues/420