### PR TITLE
Parse genesis ledger only once

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,14 +24,16 @@ clean:
   cargo clean
   rm -rf result
 
-test: test-unit test-regression
+test: test-unit
+  ./test
 
-test-ci: lint test-unit test-regression
+test-ci: lint test-unit
+  ./test
 
 test-unit: build
   cargo nextest run
 
-test-regression: build-release
+test-regression: build
   ./test
 
 test-release: build-release

--- a/ops/buildkite-pipeline.yaml
+++ b/ops/buildkite-pipeline.yaml
@@ -6,7 +6,8 @@ steps:
     echo PATH=$PATH
     nix-shell --pure --run just
     nix-shell --pure --run "just prereqs"
-    nix-shell --pure --run "just test-ci"
+    nix-shell --pure --run "just test-ci | tee build.log"
   key: prereqs
+  artifact_paths: "build.log"
   agents:
     os: linux

--- a/src/bin/mainnet-test.rs
+++ b/src/bin/mainnet-test.rs
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     let total_time = Instant::now();
     let mut state = IndexerState::new(
         &GENESIS_HASH.into(),
-        genesis_root.ledger,
+        genesis_root.into(),
         indexer_store,
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,

--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -5,7 +5,7 @@ use mina_indexer::{
         CANONICAL_UPDATE_THRESHOLD, LEDGER_CADENCE, MAINNET_CANONICAL_THRESHOLD,
         MAINNET_GENESIS_HASH, MAINNET_TRANSITION_FRONTIER_K, PRUNE_INTERVAL_DEFAULT,
     },
-    ledger,
+    ledger::{self, genesis::GenesisLedger},
     server::{IndexerConfiguration, InitializationMode, MinaIndexer},
     store::IndexerStore,
 };
@@ -189,8 +189,9 @@ pub fn process_indexer_configuration(
             error!("Unable to parse genesis ledger: {err}");
             std::process::exit(100)
         }
-        Ok(ledger) => {
-            info!("Ledger parsed successfully!");
+        Ok(genesis_root) => {
+            let ledger: GenesisLedger = genesis_root.into();
+            info!("Genesis ledger parsed successfully");
 
             Ok(IndexerConfiguration {
                 ledger,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -10,7 +10,7 @@ use futures_util::{io::BufReader, AsyncBufReadExt, AsyncWriteExt};
 use interprocess::local_socket::tokio::{LocalSocketListener, LocalSocketStream};
 use std::{path::PathBuf, process, sync::Arc};
 use tokio::sync::{mpsc, RwLock};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[derive(Debug)]
 pub struct IpcActor {
@@ -44,7 +44,7 @@ impl IpcActor {
                 blockchain_length: 1,
                 global_slot_since_genesis: 0,
             }),
-            ledger: RwLock::new(config.ledger.ledger.into()),
+            ledger: RwLock::new(config.ledger.into()),
             summary: RwLock::new(None),
             store: RwLock::new(store),
         }
@@ -254,7 +254,7 @@ async fn handle_conn(
             // check if ledger or state hash and use appropriate getter
             if is_valid_state_hash(&hash[..52]) {
                 let hash = &hash[..52];
-                debug!("{hash} is a state hash");
+                trace!("{hash} is a state hash");
 
                 if let Some(ledger) = db.get_ledger_state_hash(&hash.into())? {
                     let ledger = ledger.to_string();
@@ -288,7 +288,7 @@ async fn handle_conn(
                 }
             } else if ledger::is_valid_hash(&hash[..51]) {
                 let hash = &hash[..51];
-                debug!("{hash} is a ledger hash");
+                trace!("{hash} is a ledger hash");
 
                 if let Some(ledger) = db.get_ledger(hash)? {
                     let ledger = ledger.to_string();

--- a/src/server.rs
+++ b/src/server.rs
@@ -222,7 +222,6 @@ pub async fn initialize(
 
         match initialization_mode {
             InitializationMode::New => {
-                info!("Parsing blocks");
                 let mut block_parser = BlockParser::new(&startup_dir, canonical_threshold)?;
                 state
                     .initialize_with_canonical_chain_discovery(&mut block_parser)

--- a/test
+++ b/test
@@ -21,6 +21,7 @@ test_cleanup() {
     fi
     rm -rf "${TEST_DIR}"
 }
+
 trap test_cleanup EXIT
 
 idxr() {

--- a/test
+++ b/test
@@ -178,7 +178,7 @@ test_ipc_is_available_immediately() {
         --log-dir ./logs \
         --genesis-ledger "$LEDGER" \
         --root-hash 3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ
-    sleep 1
+    sleep 2
 
     idxr summary
     teardown
@@ -194,7 +194,7 @@ test_startup_dirs_get_created() {
         --watch-dir ./watch-blocks \
         --database-dir ./database \
         --log-dir ./logs
-    sleep 1
+    sleep 2
 
     assert_directory_exists "./startup-blocks"
     assert_directory_exists "./watch-blocks"

--- a/tests/block/store/genesis.rs
+++ b/tests/block/store/genesis.rs
@@ -20,7 +20,7 @@ fn block_added() -> anyhow::Result<()> {
 
     let indexer = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_root.ledger,
+        genesis_root.into(),
         indexer_store,
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/canonicity/blocks.rs
+++ b/tests/canonicity/blocks.rs
@@ -18,12 +18,10 @@ async fn test() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
     let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
-    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
-        .unwrap()
-        .ledger;
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents).unwrap();
     let mut state = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.into(),
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/canonicity/ledgers.rs
+++ b/tests/canonicity/ledgers.rs
@@ -18,12 +18,10 @@ async fn test() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
     let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
-    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
-        .unwrap()
-        .ledger;
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents).unwrap();
     let mut state = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.into(),
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/command/store.rs
+++ b/tests/command/store.rs
@@ -22,7 +22,7 @@ async fn add_and_get() {
     let genesis_root = parse_file(genesis_ledger_path).unwrap();
     let indexer = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_root.ledger,
+        genesis_root.into(),
         indexer_store.clone(),
         MAINNET_TRANSITION_FRONTIER_K,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/event/log.rs
+++ b/tests/event/log.rs
@@ -26,13 +26,11 @@ async fn test() {
     let indexer_store1 = Arc::new(IndexerStore::new(store_dir1.path()).unwrap());
 
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
-    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
-        .unwrap()
-        .ledger;
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents).unwrap();
 
     let mut state0 = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger.clone(),
+        genesis_ledger.clone().into(),
         indexer_store0,
         10,
         PRUNE_INTERVAL_DEFAULT,
@@ -42,7 +40,7 @@ async fn test() {
     .unwrap();
     let mut state1 = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.into(),
         indexer_store1,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/event/replay.rs
+++ b/tests/event/replay.rs
@@ -17,12 +17,10 @@ async fn test() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
     let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
-    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
-        .unwrap()
-        .ledger;
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents).unwrap();
     let mut state = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger.clone(),
+        genesis_ledger.clone().into(),
         indexer_store.clone(),
         10,
         PRUNE_INTERVAL_DEFAULT,
@@ -37,7 +35,7 @@ async fn test() {
     // fresh state to replay events on top of
     let mut new_state = IndexerState::new_without_genesis_events(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.into(),
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/event/sync.rs
+++ b/tests/event/sync.rs
@@ -17,12 +17,10 @@ async fn test() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
     let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
     let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
-    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)
-        .unwrap()
-        .ledger;
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents).unwrap();
     let mut state = IndexerState::new(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger.clone(),
+        genesis_ledger.clone().into(),
         indexer_store.clone(),
         10,
         PRUNE_INTERVAL_DEFAULT,
@@ -37,7 +35,7 @@ async fn test() {
     // fresh state to sync events with no genesis events
     let mut state_sync = IndexerState::new_without_genesis_events(
         &MAINNET_GENESIS_HASH.into(),
-        genesis_ledger,
+        genesis_ledger.into(),
         indexer_store,
         10,
         PRUNE_INTERVAL_DEFAULT,

--- a/tests/state/ledger/genesis.rs
+++ b/tests/state/ledger/genesis.rs
@@ -1,39 +1,39 @@
 use mina_indexer::ledger::{
-    genesis::{self, GenesisRoot},
+    genesis::{self, GenesisLedger, GenesisRoot},
     Ledger,
 };
 #[test]
-fn test_mainnet_genesis_parser() {
-    let genesis_ledger = genesis::parse_file("./tests/data/genesis_ledgers/mainnet.json").unwrap();
-    let ledger: Ledger = genesis_ledger.clone().into();
+fn test_mainnet_genesis_parser() -> anyhow::Result<()> {
+    let genesis_root = genesis::parse_file("./tests/data/genesis_ledgers/mainnet.json")?;
+    let genesis_ledger: GenesisLedger = genesis_root.clone().into();
+    let ledger: Ledger = genesis_ledger.into();
+
     // Ledger account balances are in nanomina
     let initial_supply = ledger
         .accounts
         .values()
         .fold(0u64, |acc, account| acc + account.balance.0);
+
+    assert_eq!("mainnet", genesis_root.ledger.name, "Network name");
     assert_eq!(
-        "mainnet", genesis_ledger.ledger.name,
-        "The network name should match"
+        "2021-03-17T00:00:00Z", genesis_root.genesis.genesis_state_timestamp,
+        "Genesis timestamp"
     );
-    assert_eq!(
-        "2021-03-17T00:00:00Z", genesis_ledger.genesis.genesis_state_timestamp,
-        "Genesis timestamp should match"
-    );
-    // 1675 total genesis ledger accounts
     assert_eq!(
         1675,
-        genesis_ledger.ledger.accounts.len(),
-        "Total number of genesis accounts should match"
+        genesis_root.ledger.accounts.len(),
+        "Total number of genesis accounts"
     );
     // 805253692.840038233 was manually calculated ignoring the 2 bad accounts balances
     assert_eq!(
         805253692840038233, initial_supply,
-        "Mina inital distribution should match"
+        "Mina inital distribution"
     );
+    Ok(())
 }
 
 #[test]
-fn test_ignore_known_invalid_pks_on_mainnet() {
+fn test_ignore_known_invalid_pks_on_mainnet() -> anyhow::Result<()> {
     let ledger_json = r#"{
         "genesis": {
             "genesis_state_timestamp": "2021-03-17T00:00:00Z"
@@ -47,9 +47,13 @@ fn test_ignore_known_invalid_pks_on_mainnet() {
             ]
         }
     }"#;
-    let root: GenesisRoot =
-        serde_json::from_str(ledger_json).expect("Genesis ledger parses into GenesisRoot");
+
+    let root: GenesisRoot = serde_json::from_str(ledger_json)?;
     assert_eq!(3, root.ledger.accounts.len(), "Should contain 3 accounts");
-    let ledger: Ledger = root.ledger.into();
-    assert_eq!(1, ledger.accounts.len(), "Should only be 1 account")
+
+    let ledger: GenesisLedger = root.into();
+    let ledger: Ledger = ledger.into();
+    assert_eq!(1, ledger.accounts.len(), "Should only be 1 account");
+
+    Ok(())
 }


### PR DESCRIPTION
- introduce `GenesisLedger` for parsed genesis ledgers
- add genesis ledger, then block at startup
- add buildkite artifact

Solves https://github.com/Granola-Team/mina-indexer/issues/383