### PR TITLE
Have rustup manage rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,6 @@
         developmentDependencies = with pkgs;
           [
             rust
-            rust-analyzer
             rnix-lsp
             alejandra
             cargo-nextest

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.70.0"
-components = [ "rust-src" ]
+components = [ "rust-src", "rust-analyzer" ]
 profile = "default"


### PR DESCRIPTION
Remove the explicit dependency on rust-analyzer in flake.nix in favour of using rust-toolchain.toml to manage it. So for those who do not use nix will have the same version of rust-analyzer.