### PR TITLE
Add public key index for blocks

### DIFF
--- a/src/block/precomputed.rs
+++ b/src/block/precomputed.rs
@@ -311,6 +311,16 @@ impl PrecomputedBlock {
         pks
     }
 
+    pub fn all_public_keys(&self) -> Vec<PublicKey> {
+        let mut public_keys: HashSet<PublicKey> =
+            self.all_command_public_keys().into_iter().collect();
+        add_keys(&mut public_keys, self.prover_keys());
+
+        let mut public_keys: Vec<PublicKey> = public_keys.into_iter().collect();
+        public_keys.sort();
+        public_keys
+    }
+
     pub fn global_slot_since_genesis(&self) -> u32 {
         self.protocol_state
             .body

--- a/src/block/store.rs
+++ b/src/block/store.rs
@@ -1,6 +1,7 @@
 use crate::{
     block::{precomputed::PrecomputedBlock, BlockHash},
     event::db::DbEvent,
+    ledger::public_key::PublicKey,
 };
 
 pub trait BlockStore {
@@ -38,4 +39,14 @@ pub trait BlockStore {
 
     /// Add a block at the given global slot since genesis
     fn add_block_at_slot(&self, state_hash: &BlockHash, slot: u32) -> anyhow::Result<()>;
+
+    /// Get number of blocks for the given public key
+    fn get_num_blocks_at_public_key(&self, pk: &PublicKey) -> anyhow::Result<u32>;
+
+    /// Add block to the given public key's collection
+    fn add_block_at_public_key(&self, pk: &PublicKey, state_hash: &BlockHash)
+        -> anyhow::Result<()>;
+
+    /// Get blocks for the given public key
+    fn get_blocks_at_public_key(&self, pk: &PublicKey) -> anyhow::Result<Vec<PrecomputedBlock>>;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,8 @@ pub enum BlockArgs {
     BlocksAtSlot(BlocksAtSlotArgs),
     /// Query blocks by blockchain length
     BlocksAtHeight(BlocksAtHeightArgs),
+    /// Query blocks by public key
+    BlocksAtPublicKey(BlocksAtPublicKeyArgs),
 }
 
 #[derive(Args, Debug, Serialize, Deserialize)]
@@ -98,6 +100,20 @@ pub struct BlocksAtSlotArgs {
     /// Retrieve the blocks in given global slot
     #[arg(short, long)]
     slot: String,
+    /// Path to write the block [default: stdout]
+    #[arg(short, long)]
+    path: Option<PathBuf>,
+    /// Display the entire precomputed block
+    #[arg(short, long, default_value_t = false)]
+    verbose: bool,
+}
+
+#[derive(Args, Debug, Serialize, Deserialize)]
+#[command(author, version, about, long_about = None)]
+pub struct BlocksAtPublicKeyArgs {
+    /// Retrieve the blocks associated with given public key
+    #[arg(short = 'k', long)]
+    public_key: String,
     /// Path to write the block [default: stdout]
     #[arg(short, long)]
     path: Option<PathBuf>,
@@ -346,6 +362,12 @@ pub async fn run(command: &ClientCli) -> anyhow::Result<()> {
                 BlockArgs::BlocksAtSlot(args) => format!(
                     "blocks-at-slot {} {} {}\0",
                     args.slot,
+                    args.verbose,
+                    args.path.clone().unwrap_or("".into()).display()
+                ),
+                BlockArgs::BlocksAtPublicKey(args) => format!(
+                    "blocks-at-public-key {} {} {}\0",
+                    args.public_key,
                     args.verbose,
                     args.path.clone().unwrap_or("".into()).display()
                 ),

--- a/test
+++ b/test
@@ -118,6 +118,9 @@ test_indexer_cli_reports() {
     idxr blocks-at-slot --help 2>&1 |
         grep -iq "Usage: mina-indexer blocks-at-slot"
 
+    idxr blocks-at-public-key --help 2>&1 |
+        grep -iq "Usage: mina-indexer blocks-at-public-key"
+
     idxr checkpoint --help 2>&1 |
         grep -iq "Usage: mina-indexer checkpoint"
 
@@ -378,6 +381,25 @@ test_blocks() {
     assert 'Canonical' $canonicity
     assert 'Canonical' $canonicity_v
 
+    # basic public key query
+    hash=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 | jq -r .[0].state_hash)
+    slot=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 | jq -r .[0].global_slot_since_genesis)
+    length=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 | jq -r .[0].blockchain_length)
+    canonicity=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 | jq -r .[0].canonicity)
+
+    # verbose public key query
+    hash_v=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 -v | jq -r .[0].state_hash)
+    length_v=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 -v | jq -r .[0].blockchain_length)
+    canonicity_v=$(idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 -v | jq -r .[0].canonicity)
+    
+    assert 9 $slot
+    assert $wt_hash $hash
+    assert $wt_hash $hash_v
+    assert $wt_length $length
+    assert $wt_length $length_v
+    assert 'Canonical' $canonicity
+    assert 'Canonical' $canonicity_v
+
     # height 10 = slot 9
     slot=$(idxr blocks-at-slot -s 9 | jq -r .)
     height=$(idxr blocks-at-height -h 10 | jq -r .)
@@ -396,6 +418,16 @@ test_blocks() {
     # write at slot to file
     file=./blocks_at_slot.json
     idxr blocks-at-slot -s 9 -p $file
+
+    height=$(cat $file | jq -r .[0].blockchain_length)
+    slot=$(cat $file | jq -r .[0].global_slot_since_genesis)
+    
+    assert 9 $slot
+    assert 10 $height
+
+    # write at public key to file
+    file=./blocks_at_pk.json
+    idxr blocks-at-public-key -k B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3 -p $file
 
     height=$(cat $file | jq -r .[0].blockchain_length)
     slot=$(cat $file | jq -r .[0].global_slot_since_genesis)


### PR DESCRIPTION
- expose all public keys in precomputed block
- add public key functions to `BlockStore` trait
- add client command and ipc query handler
- add regression test

Fixes https://github.com/Granola-Team/mina-indexer/issues/492