### PR TITLE
Add rustfmt for imports_granularity = "Crate"

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,12 @@ clean:
   cargo clean
   rm -rf result
 
+format:
+  cargo +nightly fmt --all
+
+format-verify:
+  cargo +nightly fmt --all --check
+
 test: test-unit
   ./test
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "One"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 imports_granularity = "Crate"
 group_imports = "One"
 wrap_comments = true
+newline_style = "Unix"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 imports_granularity = "Crate"
 group_imports = "One"
+wrap_comments = true


### PR DESCRIPTION
Implements Granola-Team/mina-indexer#509

Note: I did not actually run the format on the codebase (to not intermix the import changes) 