### PR TITLE
Improve genesis ledger parsing

### DIFF
--- a/src/ledger/genesis.rs
+++ b/src/ledger/genesis.rs
@@ -8,7 +8,6 @@ use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
-use tracing::debug;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenesisTimestamp {
@@ -72,16 +71,6 @@ impl GenesisLedger {
                     .expect("Parsed Genesis Balance has wrong format"),
                 Err(_) => panic!("Unable to parse Genesis Balance"),
             });
-            // Temporary hack to ignore bad PKs in mainnet genesis ledger
-            if genesis_account.pk == "B62qpyhbvLobnd4Mb52vP7LPFAasb2S6Qphq8h5VV8Sq1m7VNK1VZcW"
-                || genesis_account.pk == "B62qqdcf6K9HyBSaxqH5JVFJkc1SUEe1VzDc5kYZFQZXWSQyGHoino1"
-            {
-                debug!(
-                    "Known broken public keys... Ignoring {}",
-                    genesis_account.pk
-                );
-                continue;
-            }
             let public_key = PublicKey::from(genesis_account.pk);
             accounts.insert(
                 public_key.clone(),

--- a/tests/state/ledger/genesis.rs
+++ b/tests/state/ledger/genesis.rs
@@ -26,34 +26,8 @@ fn test_mainnet_genesis_parser() -> anyhow::Result<()> {
     );
     // 805253692.840038233 was manually calculated ignoring the 2 bad accounts balances
     assert_eq!(
-        805253692840038233, initial_supply,
+        805385692840038233, initial_supply,
         "Mina inital distribution"
     );
-    Ok(())
-}
-
-#[test]
-fn test_ignore_known_invalid_pks_on_mainnet() -> anyhow::Result<()> {
-    let ledger_json = r#"{
-        "genesis": {
-            "genesis_state_timestamp": "2021-03-17T00:00:00Z"
-        },
-        "ledger": {
-            "name": "mainnet",
-            "accounts": [
-                {"pk": "B62qqdcf6K9HyBSaxqH5JVFJkc1SUEe1VzDc5kYZFQZXWSQyGHoino1","balance":"0"},
-                {"pk": "B62qpyhbvLobnd4Mb52vP7LPFAasb2S6Qphq8h5VV8Sq1m7VNK1VZcW","balance":"0"},
-                {"pk": "B62qmVHmj3mNhouDf1hyQFCSt3ATuttrxozMunxYMLctMvnk5y7nas1","balance":"0"}
-            ]
-        }
-    }"#;
-
-    let root: GenesisRoot = serde_json::from_str(ledger_json)?;
-    assert_eq!(3, root.ledger.accounts.len(), "Should contain 3 accounts");
-
-    let ledger: GenesisLedger = root.into();
-    let ledger: Ledger = ledger.into();
-    assert_eq!(1, ledger.accounts.len(), "Should only be 1 account");
-
     Ok(())
 }

--- a/tests/state/ledger/genesis.rs
+++ b/tests/state/ledger/genesis.rs
@@ -1,5 +1,5 @@
 use mina_indexer::ledger::{
-    genesis::{self, GenesisLedger, GenesisRoot},
+    genesis::{self, GenesisLedger},
     Ledger,
 };
 #[test]
@@ -24,7 +24,6 @@ fn test_mainnet_genesis_parser() -> anyhow::Result<()> {
         genesis_root.ledger.accounts.len(),
         "Total number of genesis accounts"
     );
-    // 805253692.840038233 was manually calculated ignoring the 2 bad accounts balances
     assert_eq!(
         805385692840038233, initial_supply,
         "Mina inital distribution"


### PR DESCRIPTION
Fixes
* https://github.com/Granola-Team/mina-indexer/issues/512

- Clean up genesis ledger code to remove mina-rs types
- Add back the 2 known bad genesis ledger accounts
