### PR TITLE
Orphan blocks bypass witness and use best block from store

### DIFF
--- a/src/canonicity/store.rs
+++ b/src/canonicity/store.rs
@@ -14,9 +14,5 @@ pub trait CanonicityStore {
     fn get_canonical_hash_at_height(&self, height: u32) -> anyhow::Result<Option<BlockHash>>;
 
     /// Get block canonicity
-    fn get_block_canonicity(
-        &self,
-        state_hash: &BlockHash,
-        best_tip: &BlockHash,
-    ) -> anyhow::Result<Option<Canonicity>>;
+    fn get_block_canonicity(&self, state_hash: &BlockHash) -> anyhow::Result<Option<Canonicity>>;
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -497,15 +497,11 @@ impl CanonicityStore for IndexerStore {
         Ok(())
     }
 
-    fn get_block_canonicity(
-        &self,
-        state_hash: &BlockHash,
-        best_tip: &BlockHash,
-    ) -> anyhow::Result<Option<Canonicity>> {
+    fn get_block_canonicity(&self, state_hash: &BlockHash) -> anyhow::Result<Option<Canonicity>> {
         trace!("Getting canonicity of block with hash {}", state_hash.0);
         self.database.try_catch_up_with_primary().unwrap_or(());
 
-        if let Ok(Some(best_tip)) = self.get_block(best_tip) {
+        if let Ok(Some(best_tip)) = self.get_best_block() {
             if let Some(PrecomputedBlock {
                 blockchain_length, ..
             }) = self.get_block(state_hash)?

--- a/tests/block/parser.rs
+++ b/tests/block/parser.rs
@@ -1,4 +1,4 @@
-use mina_indexer::block::parser::BlockParser;
+use mina_indexer::block::{parser::BlockParser, precomputed::PrecomputedBlock};
 use std::path::PathBuf;
 use tokio::time::Instant;
 
@@ -9,12 +9,13 @@ async fn representative_benches() {
     let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
 
-    while let Some(precomputed_block) = block_parser0
+    while let Some(block) = block_parser0
         .next_block()
         .expect("IO Error on block_parser")
     {
+        let block: PrecomputedBlock = block.into();
         logs_processed += 1;
-        dbg!(precomputed_block.state_hash);
+        dbg!(block.state_hash);
     }
 
     println!("./tests/data/non_sequential_blocks");
@@ -27,12 +28,13 @@ async fn representative_benches() {
     let mut block_parser1 = BlockParser::new_testing(&sample_dir1).unwrap();
 
     logs_processed = 0;
-    while let Some(precomputed_block) = block_parser1
+    while let Some(block) = block_parser1
         .next_block()
         .expect("IO Error on block_parser")
     {
+        let block: PrecomputedBlock = block.into();
         logs_processed += 1;
-        dbg!(precomputed_block.state_hash);
+        dbg!(block.state_hash);
     }
 
     println!("./tests/data/sequential_blocks");
@@ -79,7 +81,7 @@ async fn orphaned_blocks() {
                 "tests/data/sequential_blocks/mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json".into(),
                 "tests/data/sequential_blocks/mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json".into(),
             ],
-            successive_paths: vec![
+            recent_paths: vec![
                 "tests/data/sequential_blocks/mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.json".into(),
                 "tests/data/sequential_blocks/mainnet-105492-3NKTUzjMZ8GD89XKD4qhnKZVXEfUSRGjHTYncZVQTxipZA9mnKZu.json".into(),
                 "tests/data/sequential_blocks/mainnet-105492-3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN.json".into(),

--- a/tests/block/store/blocks.rs
+++ b/tests/block/store/blocks.rs
@@ -1,6 +1,6 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
-    block::{parser::BlockParser, store::BlockStore},
+    block::{parser::BlockParser, precomputed::PrecomputedBlock, store::BlockStore},
     constants::*,
     store::IndexerStore,
 };
@@ -24,7 +24,9 @@ fn add_and_get() {
     let mut n = 0;
     let adding = Instant::now();
     while let Some(block) = bp.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         let state_hash = block.state_hash.clone();
+
         db.add_block(&block).unwrap();
         blocks.insert(state_hash.clone(), block);
         println!("Added {:?}", &state_hash);

--- a/tests/block/store/blocks_at_height.rs
+++ b/tests/block/store/blocks_at_height.rs
@@ -1,6 +1,6 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
-    block::{parser::BlockParser, store::BlockStore},
+    block::{parser::BlockParser, precomputed::PrecomputedBlock, store::BlockStore},
     constants::*,
     store::IndexerStore,
 };
@@ -19,6 +19,7 @@ fn add_and_get() -> anyhow::Result<()> {
     )?;
 
     while let Some(block) = bp.next_block()? {
+        let block: PrecomputedBlock = block.into();
         db.add_block(&block)?;
         println!("{}: {}", block.blockchain_length, block.state_hash);
     }

--- a/tests/block/store/blocks_at_slot.rs
+++ b/tests/block/store/blocks_at_slot.rs
@@ -1,6 +1,6 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
-    block::{parser::BlockParser, store::BlockStore},
+    block::{parser::BlockParser, precomputed::PrecomputedBlock, store::BlockStore},
     constants::*,
     store::IndexerStore,
 };
@@ -19,6 +19,7 @@ fn add_and_get() -> anyhow::Result<()> {
     )?;
 
     while let Some(block) = bp.next_block()? {
+        let block: PrecomputedBlock = block.into();
         db.add_block(&block)?;
     }
 

--- a/tests/canonicity/chain_discovery.rs
+++ b/tests/canonicity/chain_discovery.rs
@@ -1,4 +1,7 @@
-use mina_indexer::{block::parser::BlockParser, constants::*};
+use mina_indexer::{
+    block::{parser::BlockParser, precomputed::PrecomputedBlock},
+    constants::*,
+};
 use std::path::PathBuf;
 
 #[test]
@@ -11,10 +14,11 @@ fn gaps() {
     )
     .unwrap();
 
-    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
+    while let Some(block) = block_parser.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
-            precomputed_block.blockchain_length, precomputed_block.state_hash
+            block.blockchain_length, block.state_hash
         );
     }
 
@@ -33,10 +37,11 @@ fn contiguous() {
     )
     .unwrap();
 
-    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
+    while let Some(block) = block_parser.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
-            precomputed_block.blockchain_length, precomputed_block.state_hash
+            block.blockchain_length, block.state_hash
         );
     }
 
@@ -55,10 +60,11 @@ fn missing_parent() {
     )
     .unwrap();
 
-    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
+    while let Some(block) = block_parser.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
-            precomputed_block.blockchain_length, precomputed_block.state_hash
+            block.blockchain_length, block.state_hash
         );
     }
 
@@ -98,10 +104,11 @@ fn canonical_threshold() {
     )
     .unwrap();
 
-    while let Some(precomputed_block) = block_parser.next_block().unwrap() {
+    while let Some(block) = block_parser.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
-            precomputed_block.blockchain_length, precomputed_block.state_hash
+            block.blockchain_length, block.state_hash
         );
     }
 

--- a/tests/event/log.rs
+++ b/tests/event/log.rs
@@ -1,6 +1,6 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
-    block::{parser::BlockParser, store::BlockStore},
+    block::{parser::BlockParser, precomputed::PrecomputedBlock, store::BlockStore},
     canonicity::store::CanonicityStore,
     constants::*,
     event::{store::EventStore, witness_tree::*},
@@ -58,6 +58,7 @@ async fn test() {
     // - update best tip
     // - update canonicities
     while let Some(block) = block_parser1.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
         if let Some(db_event) = state1
             .indexer_store
             .as_ref()

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -1,4 +1,7 @@
-use mina_indexer::{block::parser::BlockParser, state::IndexerState};
+use mina_indexer::{
+    block::{parser::BlockParser, precomputed::PrecomputedBlock},
+    state::IndexerState,
+};
 use std::path::PathBuf;
 
 /// Parses all blocks in ./tests/data/sequential_blocks
@@ -12,13 +15,14 @@ async fn extension() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     let mut n = 0;
-    if let Some(precomputed_block) = block_parser.next_block().unwrap() {
-        let mut state =
-            IndexerState::new_testing(&precomputed_block, None, None, None, None, None).unwrap();
+    if let Some(block) = block_parser.next_block().unwrap() {
+        let block: PrecomputedBlock = block.into();
+        let mut state = IndexerState::new_testing(&block, None, None, None, None, None).unwrap();
         n += 1;
 
-        while let Some(precomputed_block) = block_parser.next_block().unwrap() {
-            state.add_block_to_witness_tree(&precomputed_block).unwrap();
+        while let Some(block) = block_parser.next_block().unwrap() {
+            let block: PrecomputedBlock = block.into();
+            state.add_block_to_witness_tree(&block).unwrap();
             n += 1;
         }
 

--- a/tests/state/mod.rs
+++ b/tests/state/mod.rs
@@ -1,3 +1,4 @@
 mod dangling_branches;
 mod ledger;
+mod orphaned_blocks;
 mod root_branch;

--- a/tests/state/orphaned_blocks.rs
+++ b/tests/state/orphaned_blocks.rs
@@ -1,0 +1,51 @@
+use crate::helpers::setup_new_db_dir;
+use mina_indexer::{
+    block::{parser::BlockParser, store::BlockStore},
+    ledger::genesis::GenesisRoot,
+    state::IndexerState,
+    store::IndexerStore,
+};
+use std::{path::PathBuf, sync::Arc};
+
+#[tokio::test]
+async fn not_added_to_witness_tree() -> anyhow::Result<()> {
+    let store_dir = setup_new_db_dir("orphaned-blocks")?;
+    let log_dir = PathBuf::from("./tests/data/sequential_blocks");
+    let mut block_parser = BlockParser::new_with_canonical_chain_discovery(&log_dir, 10, 10)?;
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path())?);
+    let genesis_contents = include_str!("../data/genesis_ledgers/mainnet.json");
+    let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)?;
+    let mut state = IndexerState::new(genesis_ledger.clone().into(), indexer_store.clone(), 10)?;
+
+    // add all blocks to the state
+    state.add_blocks(&mut block_parser).await?;
+
+    // This block is deep canonical:
+    // 0: mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
+    // It is included in the witness tree's diff map and the block store
+    let state_hash0 = "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".into();
+    assert!(state.diffs_map.contains_key(&state_hash0));
+    assert_eq!(
+        indexer_store.get_block(&state_hash0)?.unwrap().state_hash,
+        state_hash0.0
+    );
+
+    // These two blocks are orphaned:
+    // 1: mainnet-105489-3NLFXtdzaFW2WX6KgrxMjL4enE4pCa9hAsVUPm47PT6337SXgBGh.json
+    // 2: mainnet-105489-3NLUfaHDcyt9KsYxi1xsSdYE369GAduLxVgRUDE7RuFgSXQBphDK.json
+    let state_hash1 = "3NLFXtdzaFW2WX6KgrxMjL4enE4pCa9hAsVUPm47PT6337SXgBGh".into();
+    assert!(!state.diffs_map.contains_key(&state_hash1));
+    assert_eq!(
+        indexer_store.get_block(&state_hash1)?.unwrap().state_hash,
+        state_hash1.0
+    );
+
+    let state_hash2 = "3NLUfaHDcyt9KsYxi1xsSdYE369GAduLxVgRUDE7RuFgSXQBphDK".into();
+    assert!(!state.diffs_map.contains_key(&state_hash2));
+    assert_eq!(
+        indexer_store.get_block(&state_hash2)?.unwrap().state_hash,
+        state_hash2.0
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
- adds `ParsedBlock` wrapper to block parser for passing orphaned block info to the witness tree
- bypasses orphaned blocks in the witness tree
- removes `best_tip` field from `IpcChannelUpdate`
- adds unit test

Fixes https://github.com/Granola-Team/mina-indexer/issues/488
Fixes https://github.com/Granola-Team/mina-indexer/issues/566