### PR TITLE
Fix accidental deletion of the primary database by the IPCActor

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -77,8 +77,10 @@ impl IpcActor {
                                     },
                                     Ok(_) => { info!("handled connection"); },
                                 };
-                                debug!("Removing readonly instance at {}", store.db_path.clone().display());
-                                tokio::fs::remove_dir_all(&store.db_path).await.ok();
+                                if !store.is_primary {
+                                    debug!("Removing readonly instance at {}", store.db_path.clone().display());
+                                    tokio::fs::remove_dir_all(&store.db_path).await.ok();
+                                }
                             });
                         }
                     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,6 +22,7 @@ use tracing::{trace, warn};
 pub struct IndexerStore {
     pub db_path: PathBuf,
     pub database: DB,
+    pub is_primary: bool,
 }
 
 impl IndexerStore {
@@ -45,6 +46,7 @@ impl IndexerStore {
         Ok(Self {
             db_path: PathBuf::from(secondary),
             database,
+            is_primary: false,
         })
     }
 
@@ -73,6 +75,7 @@ impl IndexerStore {
         Ok(Self {
             db_path: PathBuf::from(path),
             database,
+            is_primary: true,
         })
     }
 


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/577
* https://github.com/Granola-Team/mina-indexer/issues/577

The IPC removes the db_path dir to remove the secondary droppings but this shouldn't happen on a primary database. Only remove non-primary stores when handling Unix Domain handle_conn calls.