### PR TITLE
Ensure rustfmt works in all environments

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,12 @@
 # The command 'just' will give usage information.
 # See https://github.com/casey/just for more.
 
+# Ensure rustfmt works in all environments
+# Nix environment has rustfmt nightly and won't work with +nightly
+# Non-Nix environment needs nightly toolchain installed and requires +nightly
+is_rustfmt_nightly := `rustfmt --version | grep stable || echo "true"`
+nightly_if_required := if is_rustfmt_nightly == "true" { "" } else { "+nightly" }
+
 default:
   @just --list --justfile {{justfile()}}
 
@@ -22,7 +28,7 @@ clean:
   rm -rf result
 
 format:
-  cargo fmt --all
+  cargo {{nightly_if_required}} fmt --all
 
 test: test-unit
   ./test
@@ -46,7 +52,7 @@ audit:
   cargo audit
 
 lint: && audit disallow-unused-cargo-deps
-  cargo fmt --all --check
+  cargo {{nightly_if_required}} fmt --all --check
   cargo clippy --all-targets --all-features -- -D warnings
 
 images:


### PR DESCRIPTION
Fixes Granola-Team/mina-indexer#574

Nix environment has `rustfmt` nightly and won't work with `+nightly`. Non-Nix environment needs nightly toolchain installed and requires `+nightly`.

I ended up checking the `rustfmt` version (`stable` or `nightly`) instead of checking to see if we are inside the Nix environment. However, I'm leaving related reading about how to determine if inside a Nix environment: https://github.com/NixOS/nix/issues/6677