### PR TITLE
Low hanging fruit

### DIFF
--- a/src/bin/mina-indexer.rs
+++ b/src/bin/mina-indexer.rs
@@ -94,7 +94,7 @@ pub struct ServerArgs {
     /// Threshold for determining the canonicity of a block
     #[arg(long, default_value_t = MAINNET_CANONICAL_THRESHOLD)]
     canonical_threshold: u32,
-    /// Threshold for updating the canonical tip/ledger
+    /// Threshold for updating the canonical root/ledger
     #[arg(long, default_value_t = CANONICAL_UPDATE_THRESHOLD)]
     canonical_update_threshold: u32,
     /// Web server hostname for REST and GraphQL

--- a/src/block/genesis.rs
+++ b/src/block/genesis.rs
@@ -1,13 +1,16 @@
 use crate::block::precomputed::PrecomputedBlock;
 use std::path::PathBuf;
 
-pub struct GenesisBlock(pub PrecomputedBlock);
+pub struct GenesisBlock(pub PrecomputedBlock, pub u64);
 
 impl GenesisBlock {
     /// Creates the mainnet genesis block as a PCB
     pub fn new() -> anyhow::Result<Self> {
         let genesis_block_path: PathBuf = concat!(env!("PWD"), "/tests/data/genesis_blocks/mainnet-1-3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ.json").into();
-        Ok(Self(PrecomputedBlock::parse_file(&genesis_block_path)?))
+        Ok(Self(
+            PrecomputedBlock::parse_file(&genesis_block_path)?,
+            genesis_block_path.metadata().unwrap().len(),
+        ))
     }
 }
 

--- a/src/canonicity/canonical_chain_discovery.rs
+++ b/src/canonicity/canonical_chain_discovery.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info};
 
 /// Separate blocks into 3 length-sorted lists:
 /// - canonical chain
-/// - blocks following the canonical tip
+/// - blocks following the canonical root
 /// - orphaned blocks
 pub fn discovery(
     min_len_filter: Option<u32>,
@@ -75,7 +75,7 @@ pub fn discovery(
         let last_contiguous_idx = last_contiguous_first_noncontiguous_start_idx
             .map(|i| i.1.saturating_sub(1))
             .unwrap_or(paths.len() - 1);
-        let canonical_tip_opt = find_canonical_tip(
+        let canonical_root_opt = find_canonical_root(
             paths.as_slice(),
             &length_start_indices_and_diffs,
             length_start_indices_and_diffs
@@ -86,7 +86,7 @@ pub fn discovery(
             canonical_threshold,
         );
 
-        if canonical_tip_opt.is_none()
+        if canonical_root_opt.is_none()
             || max_num_canonical_blocks(&length_start_indices_and_diffs, last_contiguous_start_idx)
                 < canonical_threshold
         {
@@ -95,17 +95,17 @@ pub fn discovery(
         }
 
         // backtrack `MAINNET_CANONICAL_THRESHOLD` blocks from
-        // the `last_contiguous_idx` to find the canonical tip
-        let (mut curr_length_idx, mut curr_start_idx) = canonical_tip_opt.unwrap();
+        // the `last_contiguous_idx` to find the canonical root
+        let (mut curr_length_idx, mut curr_start_idx) = canonical_root_opt.unwrap();
         let mut curr_path = paths[curr_length_idx];
 
         info!(
-            "Found canonical tip (length {}): {}",
+            "Found canonical root (length {}): {}",
             extract_block_height(curr_path).unwrap_or(0),
             extract_state_hash(curr_path),
         );
 
-        // handle all blocks that are higher than the canonical tip
+        // handle all blocks that are higher than the canonical root
         if let Some(successive_start_idx) =
             next_length_start_index(paths.as_slice(), curr_length_idx)
         {
@@ -132,7 +132,7 @@ pub fn discovery(
         let time = Instant::now();
         let mut count = 1;
 
-        // descend from the canonical tip to the lowest block in the dir,
+        // descend from the canonical root to the lowest block in the dir,
         // segment by segment, searching for ancestors
         while curr_start_idx > 0 {
             if count % reporting_freq == 0 {
@@ -232,14 +232,14 @@ fn next_length_start_index(paths: &[&PathBuf], path_idx: usize) -> Option<usize>
     None
 }
 
-/// Finds the _canonical tip_, i.e. the _highest_ block in the
+/// Finds the _canonical root_, i.e. the _highest_ block in the
 /// _lowest contiguous chain_ with `canonical_threshold` ancestors.
 /// Unfortunately, the existence of this value does not necessarily imply
 /// the existence of a canonical chain within the collection of blocks.
 ///
 /// Returns the index of the caonical tip in `paths` and the start index of the
 /// first successive block.
-fn find_canonical_tip(
+fn find_canonical_root(
     paths: &[&PathBuf],
     length_start_indices_and_diffs: &[(usize, u32)],
     mut curr_start_idx: usize,
@@ -274,7 +274,7 @@ fn find_canonical_tip(
             if !parent_found {
                 // begin the search again at the previous length
                 if curr_start_idx > canonical_threshold as usize {
-                    return find_canonical_tip(
+                    return find_canonical_root(
                         paths,
                         length_start_indices_and_diffs,
                         curr_start_idx.saturating_sub(1),
@@ -282,12 +282,12 @@ fn find_canonical_tip(
                         canonical_threshold,
                     );
                 } else {
-                    // canonical tip cannot be found
+                    // canonical root cannot be found
                     return None;
                 }
             }
 
-            // canonical tip found
+            // canonical root found
             if n == canonical_threshold && parent_found {
                 break;
             }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -529,7 +529,7 @@ mod test {
             BLOCK_REPORTING_FREQ_NUM,
         )
         .unwrap();
-        let block = bp
+        let (block, _) = bp
             .get_precomputed_block("3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw")
             .await
             .unwrap();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 use crate::ledger::account::Amount;
 
-pub const BLOCK_REPORTING_FREQ_NUM: u32 = 5000;
+pub const BLOCK_REPORTING_FREQ_NUM: u32 = 1000;
 pub const BLOCK_REPORTING_FREQ_SEC: u64 = 180;
 pub const LEDGER_CADENCE: u32 = 100;
 pub const CANONICAL_UPDATE_THRESHOLD: u32 = PRUNE_INTERVAL_DEFAULT / 5;

--- a/src/ledger/mod.rs
+++ b/src/ledger/mod.rs
@@ -248,7 +248,12 @@ impl From<u64> for Amount {
 }
 
 pub fn is_valid_ledger_hash(input: &str) -> bool {
-    input.starts_with("jx") && input.len() == 51
+    let mut chars = input.chars();
+    let c0 = chars.next();
+    let c1 = chars.next();
+    input.len() == 51
+        && c0 == Some('j')
+        && (c1 == Some('w') || c1 == Some('x') || c1 == Some('y') || c1 == Some('z'))
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -165,80 +165,73 @@ pub async fn initialize(
         ledger_cadence,
         reporting_freq,
     };
-    let state = {
-        let mut state = match initialization_mode {
-            InitializationMode::New => {
-                info!(
-                    "Initializing indexer state from blocks in {} and staking ledgers in {}",
-                    block_startup_dir.display(),
-                    ledger_startup_dir.display(),
-                );
-                IndexerState::new_from_config(state_config)?
-            }
-            InitializationMode::Replay => {
-                info!("Replaying indexer events from db at {}", db_path.display());
-                IndexerState::new_without_genesis_events(state_config)?
-            }
-            InitializationMode::Sync => {
-                info!("Syncing indexer state from db at {}", db_path.display());
-                IndexerState::new_without_genesis_events(state_config)?
-            }
-        };
-
-        let summary = Box::new(state.summary_verbose());
-        let store = Arc::new(state.spawn_secondary_database()?);
-
-        debug!("Updating IPC state");
-        ipc_update_sender
-            .send(IpcChannelUpdate { summary, store })
-            .await?;
-
-        match initialization_mode {
-            InitializationMode::New => {
-                let mut block_parser = match BlockParser::new_with_canonical_chain_discovery(
-                    &block_startup_dir,
-                    canonical_threshold,
-                    reporting_freq,
-                ) {
-                    Ok(block_parser) => block_parser,
-                    Err(e) => {
-                        panic!("Obtaining block parser failed: {e}");
-                    }
-                };
-                info!("Initializing indexer state");
-                state
-                    .initialize_with_canonical_chain_discovery(&mut block_parser)
-                    .await?;
-                state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
-            }
-            InitializationMode::Replay => {
-                let min_length_filter = state.replay_events()?;
-                let mut block_parser = BlockParser::new_glob_min_length_filtered(
-                    &block_startup_dir,
-                    min_length_filter,
-                )?;
-                state.add_blocks(&mut block_parser).await?;
-                state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
-            }
-            InitializationMode::Sync => {
-                let min_length_filter = state.sync_from_db()?;
-                let mut block_parser = BlockParser::new_glob_min_length_filtered(
-                    &block_startup_dir,
-                    min_length_filter,
-                )?;
-                state.add_blocks(&mut block_parser).await?;
-                state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
-            }
+    let mut state = match initialization_mode {
+        InitializationMode::New => {
+            info!(
+                "Initializing indexer state from blocks in {} and staking ledgers in {}",
+                block_startup_dir.display(),
+                ledger_startup_dir.display(),
+            );
+            IndexerState::new_from_config(state_config)?
         }
-
-        ipc_update_sender
-            .send(IpcChannelUpdate {
-                summary: Box::new(state.summary_verbose()),
-                store: Arc::new(state.spawn_secondary_database()?),
-            })
-            .await?;
-        state
+        InitializationMode::Replay => {
+            info!("Replaying indexer events from db at {}", db_path.display());
+            IndexerState::new_without_genesis_events(state_config)?
+        }
+        InitializationMode::Sync => {
+            info!("Syncing indexer state from db at {}", db_path.display());
+            IndexerState::new_without_genesis_events(state_config)?
+        }
     };
+
+    let summary = Box::new(state.summary_verbose());
+    let store = Arc::new(state.spawn_secondary_database()?);
+
+    debug!("Updating IPC state");
+    ipc_update_sender
+        .send(IpcChannelUpdate { summary, store })
+        .await?;
+
+    match initialization_mode {
+        InitializationMode::New => {
+            let mut block_parser = match BlockParser::new_with_canonical_chain_discovery(
+                &block_startup_dir,
+                canonical_threshold,
+                reporting_freq,
+            ) {
+                Ok(block_parser) => block_parser,
+                Err(e) => {
+                    panic!("Obtaining block parser failed: {e}");
+                }
+            };
+            info!("Initializing indexer state");
+            state
+                .initialize_with_canonical_chain_discovery(&mut block_parser)
+                .await?;
+            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+        }
+        InitializationMode::Replay => {
+            let min_length_filter = state.replay_events()?;
+            let mut block_parser =
+                BlockParser::new_length_sorted_min_filtered(&block_startup_dir, min_length_filter)?;
+            state.add_blocks(&mut block_parser).await?;
+            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+        }
+        InitializationMode::Sync => {
+            let min_length_filter = state.sync_from_db()?;
+            let mut block_parser =
+                BlockParser::new_length_sorted_min_filtered(&block_startup_dir, min_length_filter)?;
+            state.add_blocks(&mut block_parser).await?;
+            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+        }
+    }
+
+    ipc_update_sender
+        .send(IpcChannelUpdate {
+            summary: Box::new(state.summary_verbose()),
+            store: Arc::new(state.spawn_secondary_database()?),
+        })
+        .await?;
 
     Ok(state)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -208,21 +208,21 @@ pub async fn initialize(
             state
                 .initialize_with_canonical_chain_discovery(&mut block_parser)
                 .await?;
-            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+            state.add_startup_staking_ledgers_to_store(&ledger_startup_dir)?;
         }
         InitializationMode::Replay => {
             let min_length_filter = state.replay_events()?;
             let mut block_parser =
                 BlockParser::new_length_sorted_min_filtered(&block_startup_dir, min_length_filter)?;
             state.add_blocks(&mut block_parser).await?;
-            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+            state.add_startup_staking_ledgers_to_store(&ledger_startup_dir)?;
         }
         InitializationMode::Sync => {
             let min_length_filter = state.sync_from_db()?;
             let mut block_parser =
                 BlockParser::new_length_sorted_min_filtered(&block_startup_dir, min_length_filter)?;
             state.add_blocks(&mut block_parser).await?;
-            state.add_staking_ledgers_to_store(&ledger_startup_dir)?;
+            state.add_startup_staking_ledgers_to_store(&ledger_startup_dir)?;
         }
     }
 

--- a/src/state/branch.rs
+++ b/src/state/branch.rs
@@ -96,8 +96,8 @@ impl Branch {
     }
 
     #[instrument(skip(self))]
-    /// Returns the node id of the canonical tip, if it exists
-    pub fn canonical_tip_id(&self) -> Option<NodeId> {
+    /// Returns the node id of the canonical root, if it exists
+    pub fn canonical_root_id(&self) -> Option<NodeId> {
         for (n, ancestor_id) in self
             .branches
             .ancestor_ids(&self.best_tip_id())

--- a/src/state/summary.rs
+++ b/src/state/summary.rs
@@ -7,8 +7,8 @@ pub trait Summary {
     fn blocks_processed(&self) -> u32;
     fn best_tip_length(&self) -> u32;
     fn best_tip_hash(&self) -> String;
-    fn canonical_tip_length(&self) -> u32;
-    fn canonical_tip_hash(&self) -> String;
+    fn canonical_root_length(&self) -> u32;
+    fn canonical_root_hash(&self) -> String;
     fn root_hash(&self) -> String;
     fn root_height(&self) -> u32;
     fn root_length(&self) -> u32;
@@ -39,8 +39,8 @@ pub struct SummaryVerbose {
 pub struct WitnessTreeSummaryShort {
     pub best_tip_length: u32,
     pub best_tip_hash: String,
-    pub canonical_tip_length: u32,
-    pub canonical_tip_hash: String,
+    pub canonical_root_length: u32,
+    pub canonical_root_hash: String,
     pub root_hash: String,
     pub root_height: u32,
     pub root_length: u32,
@@ -54,8 +54,8 @@ pub struct WitnessTreeSummaryShort {
 pub struct WitnessTreeSummaryVerbose {
     pub best_tip_length: u32,
     pub best_tip_hash: String,
-    pub canonical_tip_length: u32,
-    pub canonical_tip_hash: String,
+    pub canonical_root_length: u32,
+    pub canonical_root_hash: String,
     pub root_hash: String,
     pub root_height: u32,
     pub root_length: u32,
@@ -109,8 +109,8 @@ impl From<WitnessTreeSummaryVerbose> for WitnessTreeSummaryShort {
         Self {
             best_tip_length: value.best_tip_length,
             best_tip_hash: value.best_tip_hash,
-            canonical_tip_length: value.canonical_tip_length,
-            canonical_tip_hash: value.canonical_tip_hash,
+            canonical_root_length: value.canonical_root_length,
+            canonical_root_hash: value.canonical_root_hash,
             root_hash: value.root_hash,
             root_height: value.root_height,
             root_length: value.root_length,
@@ -128,18 +128,22 @@ fn summary_short(state: &impl Summary, f: &mut std::fmt::Formatter<'_>) -> std::
     writeln!(f, "  Blocks added: {}", state.blocks_processed())?;
 
     writeln!(f, "\n=== Root branch ===")?;
-    writeln!(f, "  Height:               {}", state.root_height())?;
-    writeln!(f, "  Length:               {}", state.root_length())?;
-    writeln!(f, "  Num leaves:           {}", state.num_leaves())?;
-    writeln!(f, "  Root hash:            {}", state.root_hash())?;
-    writeln!(f, "  Best tip length:      {}", state.best_tip_length())?;
-    writeln!(f, "  Best tip hash:        {}", state.best_tip_hash())?;
+    writeln!(f, "  Height:                {}", state.root_height())?;
+    writeln!(f, "  Length:                {}", state.root_length())?;
+    writeln!(f, "  Num leaves:            {}", state.num_leaves())?;
+    writeln!(f, "  Root hash:             {}", state.root_hash())?;
+    writeln!(f, "  Best tip length:       {}", state.best_tip_length())?;
+    writeln!(f, "  Best tip hash:         {}", state.best_tip_hash())?;
     writeln!(
         f,
-        "  Canonical tip length: {}",
-        state.canonical_tip_length()
+        "  Canonical root length: {}",
+        state.canonical_root_length()
     )?;
-    writeln!(f, "  Canonical tip hash:   {}", state.canonical_tip_hash())?;
+    writeln!(
+        f,
+        "  Canonical root hash:   {}",
+        state.canonical_root_hash()
+    )?;
 
     if state.num_dangling() > 0 {
         writeln!(f, "\n=== Dangling branches ===")?;
@@ -179,12 +183,12 @@ impl Summary for SummaryShort {
         self.blocks_processed
     }
 
-    fn canonical_tip_hash(&self) -> String {
-        self.witness_tree.canonical_tip_hash.clone()
+    fn canonical_root_hash(&self) -> String {
+        self.witness_tree.canonical_root_hash.clone()
     }
 
-    fn canonical_tip_length(&self) -> u32 {
-        self.witness_tree.canonical_tip_length
+    fn canonical_root_length(&self) -> u32 {
+        self.witness_tree.canonical_root_length
     }
 
     fn db_stats(&self) -> DbStats {
@@ -237,12 +241,12 @@ impl Summary for SummaryVerbose {
         self.blocks_processed
     }
 
-    fn canonical_tip_hash(&self) -> String {
-        self.witness_tree.canonical_tip_hash.clone()
+    fn canonical_root_hash(&self) -> String {
+        self.witness_tree.canonical_root_hash.clone()
     }
 
-    fn canonical_tip_length(&self) -> u32 {
-        self.witness_tree.canonical_tip_length
+    fn canonical_root_length(&self) -> u32 {
+        self.witness_tree.canonical_root_length
     }
 
     fn db_stats(&self) -> DbStats {

--- a/test
+++ b/test
@@ -182,7 +182,7 @@ test_server_startup() {
         --log-dir ./logs
     sleep 5
 
-    result=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
+    result=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
     assert '3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ' $result
 
     teardown
@@ -273,9 +273,9 @@ test_account_public_key_json() {
     teardown
 }
 
-# Indexer summary returns the correct canonical tip
-test_canonical_tip() {
-    test=test_canonical_tip
+# Indexer summary returns the correct canonical root
+test_canonical_root() {
+    test=test_canonical_root
 
     setup
     dl_mainnet 15 ./blocks
@@ -286,8 +286,8 @@ test_canonical_tip() {
         --log-dir ./logs
     sleep 5
     
-    hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
     
     assert 5 $length
     assert '3NKQUoBfi9vkbuqtDJmSEYBQrcSo4GjwG8bPCiii4yqM8AxEQvtY' $hash
@@ -312,8 +312,8 @@ test_canonical_threshold() {
         --canonical-threshold $canonical_threshold
     sleep 5
 
-    hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert $(expr $num_seq_blocks - $canonical_threshold) $length
     assert '3NKXzc1hAE1bK9BSkJUhBBSznMhwW3ZxUTgdoLoqzW6SvqVFcAw5' $hash
@@ -482,8 +482,8 @@ test_block_copy() {
     # start without block 11
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert 10 $best_length
     assert 1 $canonical_length
@@ -498,8 +498,8 @@ test_block_copy() {
     # check
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert 11 $best_length
     assert 1 $canonical_length
@@ -529,8 +529,8 @@ test_missing_blocks() {
     num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert 2 $num_dangling
     assert 10 $best_length
@@ -547,8 +547,8 @@ test_missing_blocks() {
     num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert 1 $num_dangling
     assert 10 $best_length
@@ -564,8 +564,8 @@ test_missing_blocks() {
     num_dangling=$(idxr summary -j | jq -r .witness_tree.num_dangling)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert 0 $num_dangling
     assert 30 $best_length
@@ -645,8 +645,8 @@ test_ledgers() {
     pk='B62qp1RJRL7x249Z6sHCjKm1dbkpUWHRdiQbcDaz1nWUGa9rx48tYkR'
 
     # canonical ledgers match
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_height=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_height=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     hash_balance=$(idxr ledger --hash $canonical_hash | jq -r .${pk}.balance)
     height_balance=$(idxr ledger-at-height --height $canonical_height | jq -r .${pk}.balance)
@@ -720,8 +720,8 @@ test_sync() {
     sleep 5
 
     # post-sync results
-    canonical_hash_sync=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length_sync=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash_sync=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length_sync=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
     best_hash_sync=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length_sync=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
 
@@ -763,8 +763,8 @@ test_replay() {
     sleep 5
 
     # post-replay results
-    canonical_hash_replay=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length_replay=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash_replay=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length_replay=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
     best_hash_replay=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length_replay=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
     num_blocks_replay=$(idxr summary -j | jq -r .blocks_processed)
@@ -949,8 +949,8 @@ test_checkpoint() {
     sleep 5
 
     # pre-checkpoint results
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
     amount=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -v | jq -r .[0].command.payload.body.amount)
@@ -970,8 +970,8 @@ test_checkpoint() {
     sleep 5
 
     # post-checkpoint reults
-    canonical_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
     best_hash_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length_checkpoint=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
     amount_checkpoint=$(idxr tx-public-key -k B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy -v | jq -r .[0].command.payload.body.amount)
@@ -1004,8 +1004,8 @@ test_many_blocks() {
     # results
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert '1000' $best_length
     assert '990' $canonical_length
@@ -1118,8 +1118,8 @@ test_release() {
     # results
     best_hash=$(idxr summary -j | jq -r .witness_tree.best_tip_hash)
     best_length=$(idxr summary -j | jq -r .witness_tree.best_tip_length)
-    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_tip_hash)
-    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_tip_length)
+    canonical_hash=$(idxr summary -j | jq -r .witness_tree.canonical_root_hash)
+    canonical_length=$(idxr summary -j | jq -r .witness_tree.canonical_root_length)
 
     assert '5000' $best_length
     assert '4990' $canonical_length
@@ -1305,7 +1305,7 @@ if [ "$#" -eq 0 ]; then
     test_startup_dirs_get_created
     test_account_balance_cli
     test_account_public_key_json
-    test_canonical_tip
+    test_canonical_root
     test_canonical_threshold
     test_best_tip
     test_blocks
@@ -1334,7 +1334,7 @@ else
             "test_startup_dirs_get_created") test_startup_dirs_get_created ;;
             "test_account_balance_cli") test_account_balance_cli ;;
             "test_account_public_key_json") test_account_public_key_json ;;
-            "test_canonical_tip") test_canonical_tip ;;
+            "test_canonical_root") test_canonical_root ;;
             "test_canonical_threshold") test_canonical_threshold ;;
             "test_best_tip") test_best_tip ;;
             "test_blocks") test_blocks ;;

--- a/tests/block/store/blocks.rs
+++ b/tests/block/store/blocks.rs
@@ -7,27 +7,26 @@ use mina_indexer::{
 use std::{collections::HashMap, path::PathBuf, time::Instant};
 
 #[test]
-fn add_and_get() {
-    let store_dir = setup_new_db_dir("block-store-db").unwrap();
-    let log_dir = &PathBuf::from("./tests/data/sequential_blocks");
+fn add_and_get() -> anyhow::Result<()> {
+    let store_dir = setup_new_db_dir("block-store-db")?;
+    let blocks_dir = &PathBuf::from("./tests/data/sequential_blocks");
 
-    let db = IndexerStore::new(store_dir.path()).unwrap();
+    let db = IndexerStore::new(store_dir.path())?;
     let mut bp = BlockParser::new_with_canonical_chain_discovery(
-        log_dir,
+        blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
     let mut blocks = HashMap::new();
 
     let mut n = 0;
     let adding = Instant::now();
-    while let Some(block) = bp.next_block().unwrap() {
+    while let Some((block, _)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         let state_hash = block.state_hash.clone();
 
-        db.add_block(&block).unwrap();
+        db.add_block(&block)?;
         blocks.insert(state_hash.clone(), block);
         println!("Added {:?}", &state_hash);
         n += 1;
@@ -45,4 +44,5 @@ fn add_and_get() {
     println!("Number of blocks: {n}");
     println!("To insert all:    {add_time:?}");
     println!("To fetch all:     {:?}\n", fetching.elapsed());
+    Ok(())
 }

--- a/tests/block/store/blocks_at_height.rs
+++ b/tests/block/store/blocks_at_height.rs
@@ -18,14 +18,14 @@ fn add_and_get() -> anyhow::Result<()> {
         BLOCK_REPORTING_FREQ_NUM,
     )?;
 
-    while let Some(block) = bp.next_block()? {
+    while let Some((block, _)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         db.add_block(&block)?;
-        println!("{}: {}", block.blockchain_length, block.state_hash);
+        println!("{}", block.summary());
     }
 
     for block in db.get_blocks_at_height(105489)? {
-        println!("{}: {}", block.blockchain_length, block.state_hash);
+        println!("{}", block.summary());
     }
 
     assert_eq!(db.get_blocks_at_height(105489)?.len(), 3);

--- a/tests/block/store/blocks_at_slot.rs
+++ b/tests/block/store/blocks_at_slot.rs
@@ -18,7 +18,7 @@ fn add_and_get() -> anyhow::Result<()> {
         BLOCK_REPORTING_FREQ_NUM,
     )?;
 
-    while let Some(block) = bp.next_block()? {
+    while let Some((block, _)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         db.add_block(&block)?;
     }

--- a/tests/canonicity/blocks.rs
+++ b/tests/canonicity/blocks.rs
@@ -26,8 +26,8 @@ async fn test() {
 
     state.add_blocks(&mut block_parser).await.unwrap();
 
-    println!("CANONICAL TIP: {:?}", state.canonical_tip_block());
-    println!("BEST TIP:      {:?}", state.best_tip_block());
+    println!("CANONICAL ROOT: {:?}", state.canonical_root_block());
+    println!("BEST TIP:       {:?}", state.best_tip_block());
     println!("{state}");
 
     assert_eq!(block_parser.total_num_blocks, 20);

--- a/tests/canonicity/chain_discovery.rs
+++ b/tests/canonicity/chain_discovery.rs
@@ -66,8 +66,8 @@ fn missing_parent() -> anyhow::Result<()> {
 
     // mainnet-105500-3NKvv2iBAPhZ8SRCxQEuGTgqTYuFXd2WVANXW6pcsR8pdzLuUj7C.json
     // which should be present in the canonical chain, is absent from the
-    // collection. Therefore we can't determine the canonical tip from either
-    // block with length 105501. Thus, the highest canonical tip we can find is
+    // collection. Therefore we can't determine the canonical root from either
+    // block with length 105501. Thus, the highest canonical root we can find is
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
     // and the best canonical consists of blocks with lengths 105487, 105488,
     // 105489, 105490.

--- a/tests/canonicity/chain_discovery.rs
+++ b/tests/canonicity/chain_discovery.rs
@@ -5,39 +5,35 @@ use mina_indexer::{
 use std::path::PathBuf;
 
 #[test]
-fn gaps() {
+fn gaps() -> anyhow::Result<()> {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/gaps");
     let mut block_parser = BlockParser::new_with_canonical_chain_discovery(
         &blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
-    while let Some(block) = block_parser.next_block().unwrap() {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
-        println!(
-            "length: {}, hash: {}",
-            block.blockchain_length, block.state_hash
-        );
+        println!("{}", block.summary());
     }
 
     // only length 2 is known to be canonical
-    assert_eq!(block_parser.num_canonical, 1);
     assert_eq!(block_parser.total_num_blocks, 25);
+    assert_eq!(block_parser.num_deep_canonical_blocks, 1);
+    Ok(())
 }
 
 #[test]
-fn contiguous() {
+fn contiguous() -> anyhow::Result<()> {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_with_canonical_chain_discovery(
         &blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
-    while let Some(block) = block_parser.next_block().unwrap() {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
@@ -46,21 +42,21 @@ fn contiguous() {
     }
 
     // lengths 2..11 are known to be canonical
-    assert_eq!(block_parser.num_canonical, 10);
     assert_eq!(block_parser.total_num_blocks, 20);
+    assert_eq!(block_parser.num_deep_canonical_blocks, 10);
+    Ok(())
 }
 
 #[test]
-fn missing_parent() {
+fn missing_parent() -> anyhow::Result<()> {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/missing_parent");
     let mut block_parser = BlockParser::new_with_canonical_chain_discovery(
         &blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
-    while let Some(block) = block_parser.next_block().unwrap() {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!(
             "length: {}, hash: {}",
@@ -75,47 +71,45 @@ fn missing_parent() {
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
     // and the best canonical consists of blocks with lengths 105487, 105488,
     // 105489, 105490.
-    assert_eq!(block_parser.num_canonical, 4);
-    assert_eq!(block_parser.total_num_blocks, 35)
+    assert_eq!(block_parser.total_num_blocks, 35);
+    assert_eq!(block_parser.num_deep_canonical_blocks, 4);
+    Ok(())
 }
 
 #[test]
-fn one_block() {
+fn one_block() -> anyhow::Result<()> {
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/one_block");
     let block_parser = BlockParser::new_with_canonical_chain_discovery(
         &blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
-    assert_eq!(block_parser.num_canonical, 0);
     assert_eq!(block_parser.total_num_blocks, 1);
+    assert_eq!(block_parser.num_deep_canonical_blocks, 0);
+    Ok(())
 }
 
 #[test]
-fn canonical_threshold() {
+fn canonical_threshold() -> anyhow::Result<()> {
     let canonical_threshold = 2;
     let blocks_dir = PathBuf::from("./tests/data/canonical_chain_discovery/contiguous");
     let mut block_parser = BlockParser::new_with_canonical_chain_discovery(
         &blocks_dir,
         canonical_threshold,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
 
-    while let Some(block) = block_parser.next_block().unwrap() {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
-        println!(
-            "length: {}, hash: {}",
-            block.blockchain_length, block.state_hash
-        );
+        println!("{}", block.summary());
     }
 
     // lengths 2..19 are known to be canonical
     assert_eq!(
-        block_parser.num_canonical,
+        block_parser.num_deep_canonical_blocks,
         block_parser.total_num_blocks - canonical_threshold
     );
     assert_eq!(block_parser.total_num_blocks, 20);
+    Ok(())
 }

--- a/tests/command/store.rs
+++ b/tests/command/store.rs
@@ -31,7 +31,7 @@ async fn add_and_get() {
     )
     .unwrap();
     let state_hash = "3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw";
-    let block = bp.get_precomputed_block(state_hash).await.unwrap();
+    let (block, _) = bp.get_precomputed_block(state_hash).await.unwrap();
     let block_cmds = block.commands();
     let pks = block.all_command_public_keys();
 

--- a/tests/event/log.rs
+++ b/tests/event/log.rs
@@ -57,7 +57,7 @@ async fn test() {
     // - add block to witness tree
     // - update best tip
     // - update canonicities
-    while let Some(block) = block_parser1.next_block().unwrap() {
+    while let Some((block, _)) = block_parser1.next_block().unwrap() {
         let block: PrecomputedBlock = block.into();
         if let Some(db_event) = state1
             .indexer_store

--- a/tests/event/replay.rs
+++ b/tests/event/replay.rs
@@ -30,6 +30,9 @@ async fn test() {
 
     // witness trees match
     assert_eq!(state.best_tip_block(), new_state.best_tip_block());
-    assert_eq!(state.canonical_tip_block(), new_state.canonical_tip_block());
+    assert_eq!(
+        state.canonical_root_block(),
+        new_state.canonical_root_block()
+    );
     assert_eq!(state.diffs_map, new_state.diffs_map);
 }

--- a/tests/event/sync.rs
+++ b/tests/event/sync.rs
@@ -30,12 +30,12 @@ async fn test() {
 
     // witness trees are functionally equal
     let best_tip: BlockWithoutHeight = state.best_tip_block().clone().into();
-    let canonical_tip: BlockWithoutHeight = state.canonical_tip_block().clone().into();
+    let canonical_root: BlockWithoutHeight = state.canonical_root_block().clone().into();
     let best_tip_sync: BlockWithoutHeight = state_sync.best_tip_block().clone().into();
-    let canonical_tip_sync: BlockWithoutHeight = state_sync.canonical_tip_block().clone().into();
+    let canonical_root_sync: BlockWithoutHeight = state_sync.canonical_root_block().clone().into();
 
     assert_eq!(best_tip, best_tip_sync);
-    assert_eq!(canonical_tip, canonical_tip_sync);
+    assert_eq!(canonical_root, canonical_root_sync);
 
     for state_hash in state_sync.diffs_map.keys() {
         assert_eq!(

--- a/tests/snark_work/mod.rs
+++ b/tests/snark_work/mod.rs
@@ -31,7 +31,7 @@ async fn store() {
     )
     .unwrap();
     let state_hash = "3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw";
-    let block = bp.get_precomputed_block(state_hash).await.unwrap();
+    let (block, _) = bp.get_precomputed_block(state_hash).await.unwrap();
     let block_snarks = SnarkWorkSummary::from_precomputed(&block);
     let block_snarks_state_hash = SnarkWorkSummaryWithStateHash::from_precomputed(&block);
 

--- a/tests/state/dangling_branches/add_all_blocks.rs
+++ b/tests/state/dangling_branches/add_all_blocks.rs
@@ -10,19 +10,20 @@ use std::path::PathBuf;
 /// `leaves` and the underlying tree's leaf blocks Verifies the length of the
 /// longest chain
 #[tokio::test]
-async fn extension() {
-    let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
+async fn extension() -> anyhow::Result<()> {
+    let blocks_dir = PathBuf::from("./tests/data/sequential_blocks");
+    let mut block_parser = BlockParser::new_testing(&blocks_dir)?;
 
     let mut n = 0;
-    if let Some(block) = block_parser.next_block().unwrap() {
+    if let Some((block, block_bytes)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
-        let mut state = IndexerState::new_testing(&block, None, None, None, None, None).unwrap();
+        let mut state =
+            IndexerState::new_testing(&block, block_bytes, None, None, None, None, None)?;
         n += 1;
 
-        while let Some(block) = block_parser.next_block().unwrap() {
+        while let Some((block, _)) = block_parser.next_block()? {
             let block: PrecomputedBlock = block.into();
-            state.add_block_to_witness_tree(&block).unwrap();
+            state.add_block_to_witness_tree(&block)?;
             n += 1;
         }
 
@@ -110,4 +111,6 @@ async fn extension() {
         // ten blocks in the longest chain
         assert_eq!(longest_chain.len(), 13);
     }
+
+    Ok(())
 }

--- a/tests/state/dangling_branches/complex/basic.rs
+++ b/tests/state/dangling_branches/complex/basic.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 /// Merges two dangling branches
 #[tokio::test]
-async fn extension() {
+async fn extension() -> anyhow::Result<()> {
     // -----------------------------
     //          Root branch
     // -----------------------------
@@ -27,15 +27,14 @@ async fn extension() {
     //      leaf    =>     .
     // -----------------------------
 
-    let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
+    let blocks_dir = PathBuf::from("./tests/data/sequential_blocks");
+    let mut block_parser = BlockParser::new_testing(&blocks_dir)?;
 
     // root_block =
     // mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root_block = block_parser
+    let (root_block, root_block_bytes) = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         root_block.state_hash,
         "3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_owned()
@@ -43,10 +42,9 @@ async fn extension() {
 
     // middle_block =
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
-    let middle_block = block_parser
+    let (middle_block, _) = block_parser
         .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         middle_block.state_hash,
         "3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC".to_owned()
@@ -54,10 +52,9 @@ async fn extension() {
 
     // leaf_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let leaf_block = block_parser
+    let (leaf_block, _) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         leaf_block.state_hash,
         "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
@@ -68,13 +65,14 @@ async fn extension() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None, None, None).unwrap();
+    let mut state =
+        IndexerState::new_testing(&root_block, root_block_bytes, None, None, None, None, None)?;
 
     // --------
     // add leaf
     // --------
 
-    let (extension_type, _) = state.add_block_to_witness_tree(&leaf_block).unwrap();
+    let (extension_type, _) = state.add_block_to_witness_tree(&leaf_block)?;
     assert_eq!(extension_type, ExtensionType::DanglingNew);
 
     println!("=== Before Root Branch ===");
@@ -83,8 +81,7 @@ async fn extension() {
         .root_branch
         .clone()
         .branches
-        .write_formatted(&mut tree)
-        .unwrap();
+        .write_formatted(&mut tree)?;
     println!("{tree}");
 
     println!("=== Before Dangling Branch 0 ===");
@@ -94,8 +91,7 @@ async fn extension() {
         .first()
         .unwrap()
         .branches
-        .write_formatted(&mut tree)
-        .unwrap();
+        .write_formatted(&mut tree)?;
     println!("{tree}");
 
     // 1 dangling branch
@@ -125,12 +121,11 @@ async fn extension() {
         .root_branch
         .clone()
         .branches
-        .write_formatted(&mut tree)
-        .unwrap();
+        .write_formatted(&mut tree)?;
     println!("{tree}");
 
     // dangling branch rebases on top of root_branch
-    let (extension_type, _) = state.add_block_to_witness_tree(&middle_block).unwrap();
+    let (extension_type, _) = state.add_block_to_witness_tree(&middle_block)?;
     assert!(matches!(extension_type, ExtensionType::RootComplex(_)));
 
     // no more dangling branches
@@ -158,4 +153,6 @@ async fn extension() {
 
     // branch root should match the tree's root
     assert_eq!(root, branch_root);
+
+    Ok(())
 }

--- a/tests/state/dangling_branches/simple/improper_forward.rs
+++ b/tests/state/dangling_branches/simple/improper_forward.rs
@@ -25,7 +25,7 @@ async fn extension() {
 
     // root_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let root_block = block_parser
+    let (root_block, root_block_bytes) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
         .await
         .unwrap();
@@ -34,7 +34,9 @@ async fn extension() {
         "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
     );
 
-    let mut state = IndexerState::new_testing(&root_block, None, None, None, None, None).unwrap();
+    let mut state =
+        IndexerState::new_testing(&root_block, root_block_bytes, None, None, None, None, None)
+            .unwrap();
 
     // root branch
     // - len = 1
@@ -53,7 +55,7 @@ async fn extension() {
 
     // child1 = mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.
     // json
-    let child1 = block_parser
+    let (child1, _) = block_parser
         .get_precomputed_block("3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk")
         .await
         .unwrap();
@@ -88,7 +90,7 @@ async fn extension() {
 
     // child2 = mainnet-105492-3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN.
     // json
-    let child2 = block_parser
+    let (child2, _) = block_parser
         .get_precomputed_block("3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN")
         .await
         .unwrap();

--- a/tests/state/dangling_branches/simple/multiple_branch.rs
+++ b/tests/state/dangling_branches/simple/multiple_branch.rs
@@ -21,7 +21,7 @@ async fn extensions() {
 
     // root_block =
     // mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root_block = block_parser
+    let (root_block, root_block_bytes) = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
@@ -32,7 +32,7 @@ async fn extensions() {
 
     // root0_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let root0_block = block_parser
+    let (root0_block, _) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
         .await
         .unwrap();
@@ -43,7 +43,7 @@ async fn extensions() {
 
     // child0_block =
     // mainnet-105492-3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ.json
-    let child0_block = block_parser
+    let (child0_block, _) = block_parser
         .get_precomputed_block("3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ")
         .await
         .unwrap();
@@ -54,7 +54,7 @@ async fn extensions() {
 
     // root1_block =
     // mainnet-105495-3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9.json
-    let root1_block = block_parser
+    let (root1_block, _) = block_parser
         .get_precomputed_block("3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9")
         .await
         .unwrap();
@@ -65,7 +65,7 @@ async fn extensions() {
 
     // child10_block =
     // mainnet-105496-3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL.json
-    let child10_block = block_parser
+    let (child10_block, _) = block_parser
         .get_precomputed_block("3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL")
         .await
         .expect("WTF");
@@ -76,7 +76,7 @@ async fn extensions() {
 
     // child11_block =
     // mainnet-105496-3NKE1aiFviFWrYMN5feKm3L7C4Zqp3czkwAtcXj1tdbaGDZ47L1k.json
-    let child11_block = block_parser
+    let (child11_block, _) = block_parser
         .get_precomputed_block("3NKE1aiFviFWrYMN5feKm3L7C4Zqp3czkwAtcXj1tdbaGDZ47L1k")
         .await
         .unwrap();
@@ -90,7 +90,9 @@ async fn extensions() {
     // ----------------
 
     // root0_block will the be the root of the 0th dangling_branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None, None, None).unwrap();
+    let mut state =
+        IndexerState::new_testing(&root_block, root_block_bytes, None, None, None, None, None)
+            .unwrap();
 
     // ----------
     // add root 0

--- a/tests/state/dangling_branches/simple/proper_forward.rs
+++ b/tests/state/dangling_branches/simple/proper_forward.rs
@@ -17,7 +17,7 @@ async fn extension() {
 
     // root_block =
     // mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root_block = block_parser
+    let (root_block, root_block_bytes) = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
@@ -28,7 +28,7 @@ async fn extension() {
 
     // dangling_root_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let dangling_root_block = block_parser
+    let (dangling_root_block, _) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
         .await
         .unwrap();
@@ -41,7 +41,9 @@ async fn extension() {
     // initialize state
     // ----------------
 
-    let mut state = IndexerState::new_testing(&root_block, None, None, None, None, None).unwrap();
+    let mut state =
+        IndexerState::new_testing(&root_block, root_block_bytes, None, None, None, None, None)
+            .unwrap();
 
     // add dangling_root_block
     let (extension, _) = state
@@ -74,7 +76,7 @@ async fn extension() {
 
     // dangling_child_block =
     // mainnet-105492-3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ.json
-    let dangling_child_block = block_parser
+    let (dangling_child_block, _) = block_parser
         .get_precomputed_block("3NKt8qae6VMefUXGdprN1Nve78zCQr9FFaMyRfQbj8Mza1FKcXEQ")
         .await
         .unwrap();

--- a/tests/state/dangling_branches/simple/reverse.rs
+++ b/tests/state/dangling_branches/simple/reverse.rs
@@ -20,7 +20,7 @@ async fn extension() {
 
     // root_block =
     // mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root_block = block_parser
+    let (root_block, root_block_bytes) = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
@@ -32,7 +32,7 @@ async fn extension() {
     // *** parent ***
     // new_dangling_root_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let new_dangling_root_block = block_parser
+    let (new_dangling_root_block, _) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
         .await
         .unwrap();
@@ -44,7 +44,7 @@ async fn extension() {
     // *** child ***
     // new_dangling_root_block =
     // mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.json
-    let old_dangling_root_block = block_parser
+    let (old_dangling_root_block, _) = block_parser
         .get_precomputed_block("3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk")
         .await
         .unwrap();
@@ -58,7 +58,9 @@ async fn extension() {
     // ----------------
 
     // root_block is the root of the root branch
-    let mut state = IndexerState::new_testing(&root_block, None, None, None, None, None).unwrap();
+    let mut state =
+        IndexerState::new_testing(&root_block, root_block_bytes, None, None, None, None, None)
+            .unwrap();
 
     // old_dangling_root_block is originally the root of the 0th dangling branch
     let (extension_type, _) = state

--- a/tests/state/ledger/apply_diff.rs
+++ b/tests/state/ledger/apply_diff.rs
@@ -10,7 +10,7 @@ async fn account_diffs() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
-    let block = block_parser
+    let (block, _) = block_parser
         .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
         .await
         .unwrap();

--- a/tests/state/ledger/diff_from_precomputed.rs
+++ b/tests/state/ledger/diff_from_precomputed.rs
@@ -19,7 +19,7 @@ async fn account_diffs() {
     let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
 
     // mainnet-105490-3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC.json
-    let block = block_parser
+    let (block, _) = block_parser
         .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
         .await
         .unwrap();

--- a/tests/state/root_branch/prune.rs
+++ b/tests/state/root_branch/prune.rs
@@ -5,7 +5,7 @@ use mina_indexer::{
 use std::path::PathBuf;
 
 #[tokio::test]
-async fn transition_frontier() {
+async fn transition_frontier() -> anyhow::Result<()> {
     //   0
     //  / \
     // 1   6
@@ -18,15 +18,14 @@ async fn transition_frontier() {
     // |
     // 5
 
-    let log_dir = PathBuf::from("./tests/data/sequential_blocks");
-    let mut block_parser = BlockParser::new_testing(&log_dir).unwrap();
+    let blocks_dir = PathBuf::from("./tests/data/sequential_blocks");
+    let mut block_parser = BlockParser::new_testing(&blocks_dir).unwrap();
 
     // root_block =
     // mainnet-105491-3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3.json
-    let root_block = block_parser
+    let (root_block, _) = block_parser
         .get_precomputed_block("3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         root_block.state_hash,
         "3NKizDx3nnhXha2WqHDNUvJk9jW7GsonsEGYs26tCPW2Wow1ZoR3".to_owned()
@@ -34,10 +33,9 @@ async fn transition_frontier() {
 
     // main_1_block =
     // mainnet-105492-3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk.json
-    let main_1_block = block_parser
+    let (main_1_block, _) = block_parser
         .get_precomputed_block("3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         main_1_block.state_hash,
         "3NKAqzELKDp2BbdKKwdRWEoMNehyMrxJGCoGCyH1t1PyyH7VQMgk".to_owned()
@@ -45,10 +43,9 @@ async fn transition_frontier() {
 
     // fork_block =
     // mainnet-105492-3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN.json
-    let fork_block = block_parser
+    let (fork_block, _) = block_parser
         .get_precomputed_block("3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         fork_block.state_hash,
         "3NKsUS3TtwvXsfFFnRAJ8US8wPLKKaRDTnbv4vzrwCDkb8HNaMWN".to_owned()
@@ -56,10 +53,9 @@ async fn transition_frontier() {
 
     // main_2_block =
     // mainnet-105493-3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db.json
-    let main_2_block = block_parser
+    let (main_2_block, _) = block_parser
         .get_precomputed_block("3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         main_2_block.state_hash,
         "3NKakum3B2Tigw9TSsxwvXvV3x8L2LvrJ3yXFLEAJDMZu2vkn7db".to_owned()
@@ -67,10 +63,9 @@ async fn transition_frontier() {
 
     // main_3_block =
     // mainnet-105494-3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww.json
-    let main_3_block = block_parser
+    let (main_3_block, _) = block_parser
         .get_precomputed_block("3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         main_3_block.state_hash,
         "3NKqd3XGqkLmZVmPC3iG6AnrwQoZdBKdmYTzEJT3vwwnn2H1Z4ww".to_owned()
@@ -78,10 +73,9 @@ async fn transition_frontier() {
 
     // main_4_block =
     // mainnet-105495-3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9.json
-    let main_4_block = block_parser
+    let (main_4_block, _) = block_parser
         .get_precomputed_block("3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         main_4_block.state_hash,
         "3NKmDYoFs5MRNE4PoGMkMT5udM4JrnB5NJYFLJcDUUob363aj5e9".to_owned()
@@ -89,17 +83,16 @@ async fn transition_frontier() {
 
     // main_5_block =
     // mainnet-105496-3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL.json
-    let main_5_block = block_parser
+    let (main_5_block, _) = block_parser
         .get_precomputed_block("3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL")
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(
         main_5_block.state_hash,
         "3NK7yacg7pjHgV52sUmbNv9p7xxrKUV4sevy4Su5j6CrdTjyzaPL".to_owned()
     );
 
     // create the tree and add blocks
-    let mut branch = Branch::new(&root_block).unwrap();
+    let mut branch = Branch::new(&root_block)?;
 
     branch.simple_extension(&fork_block).unwrap();
     branch.simple_extension(&main_1_block).unwrap();
@@ -123,4 +116,5 @@ async fn transition_frontier() {
         Block::from_precomputed(&main_4_block, 0),
         branch.root_block().clone()
     );
+    Ok(())
 }

--- a/tests/state/root_branch/simple_proper.rs
+++ b/tests/state/root_branch/simple_proper.rs
@@ -16,7 +16,7 @@ async fn extension() {
 
     // root_block =
     // mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json
-    let root_block = block_parser
+    let (root_block, _) = block_parser
         .get_precomputed_block("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT")
         .await
         .unwrap();
@@ -39,7 +39,7 @@ async fn extension() {
 
     // extend the branch with a child of the root
     let mut tree2 = Branch::new(&root_block).unwrap();
-    let child_block = block_parser
+    let (child_block, _) = block_parser
         .get_precomputed_block("3NKxEA9gztvEGxL4uk4eTncZAxuRmMsB8n81UkeAMevUjMbLHmkC")
         .await
         .unwrap();


### PR DESCRIPTION
- length-sorts all block parsers
- uses terminology `canoncical_root` over `canonical_tip`
- uses bytes rate over blocks rate

Fixes https://github.com/Granola-Team/mina-indexer/issues/589
Fixes https://github.com/Granola-Team/mina-indexer/issues/590
Fixes https://github.com/Granola-Team/mina-indexer/issues/599