### PR TITLE
(ingestion) improve file watcher triggers

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -926,15 +926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "file-id"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,7 +1377,6 @@ dependencies = [
  "mina_serialization_proc_macros",
  "mina_serialization_versioned",
  "notify",
- "notify-debouncer-full",
  "num",
  "pretty_assertions",
  "quickcheck",
@@ -1479,20 +1469,6 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "notify-debouncer-full"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
-dependencies = [
- "crossbeam-channel",
- "file-id",
- "log",
- "notify",
- "parking_lot",
- "walkdir",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,7 +51,6 @@ hex-literal = "0.4.1"
 chrono = "0.4.35"
 csv = "1.3.0"
 notify = "6.1.1"
-notify-debouncer-full = "0.3.1"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -10,14 +10,12 @@ use crate::{
     store::IndexerStore,
     unix_socket_server::{self, UnixSocketServer},
 };
-use notify::{EventKind, RecursiveMode, Watcher};
-use notify_debouncer_full::new_debouncer;
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
     fs,
     path::{Path, PathBuf},
     process,
     sync::Arc,
-    time::Duration,
 };
 use tokio::{
     runtime::Handle,
@@ -209,37 +207,27 @@ pub async fn run(
     ledger_watch_dir: impl AsRef<Path>,
     state: Arc<RwLock<IndexerState>>,
 ) -> anyhow::Result<()> {
-    let (tx, mut rx) = mpsc::channel(100);
+    let (tx, mut rx) = mpsc::channel(4096);
     let rt = Handle::current();
 
-    let mut debouncer = new_debouncer(Duration::from_secs(1), None, move |result| {
-        let tx = tx.clone();
-        rt.spawn(async move {
-            if let Err(e) = tx.send(result).await {
-                error!("Error sending event result: {:?}", e);
-            }
-        });
-    })
-    .unwrap();
+    let mut watcher = RecommendedWatcher::new(
+        move |result| {
+            let tx = tx.clone();
+            rt.spawn(async move {
+                if let Err(e) = tx.send(result).await {
+                    error!("Error sending event result: {:?}", e);
+                }
+            });
+        },
+        Config::default(),
+    )?;
 
-    debouncer
-        .watcher()
-        .watch(block_watch_dir.as_ref(), RecursiveMode::NonRecursive)?;
-    debouncer
-        .watcher()
-        .watch(ledger_watch_dir.as_ref(), RecursiveMode::NonRecursive)?;
-
-    debouncer
-        .cache()
-        .add_root(block_watch_dir.as_ref(), RecursiveMode::Recursive);
-    debouncer
-        .cache()
-        .add_root(ledger_watch_dir.as_ref(), RecursiveMode::Recursive);
-
+    watcher.watch(block_watch_dir.as_ref(), RecursiveMode::NonRecursive)?;
     info!(
         "Watching for new blocks in directory: {:?}",
         block_watch_dir.as_ref()
     );
+    watcher.watch(ledger_watch_dir.as_ref(), RecursiveMode::NonRecursive)?;
     info!(
         "Watching for staking ledgers in directory: {:?}",
         ledger_watch_dir.as_ref()
@@ -247,37 +235,34 @@ pub async fn run(
 
     while let Some(res) = rx.recv().await {
         match res {
-            Ok(events) => {
-                for d_event in events {
-                    let event = d_event.event;
-                    if let EventKind::Create(notify::event::CreateKind::File)
-                    | EventKind::Modify(notify::event::ModifyKind::Name(_)) = event.kind
-                    {
-                        for path in event.paths {
-                            if block::is_valid_block_file(&path) {
-                                debug!("Valid precomputed block file: {}", path.display());
-                                if let Ok(block) = PrecomputedBlock::parse_file(&path) {
-                                    let mut state = state.write().await;
-                                    if state.block_pipeline(&block).is_ok() {
-                                        info!(
-                                            "Added block (length {}): {}",
-                                            block.blockchain_length, block.state_hash
-                                        );
-                                    }
-                                } else {
-                                    warn!("Unable to parse precomputed block: {path:?}");
+            Ok(event) => {
+                trace!("Event: {:?}", event.clone());
+                if let EventKind::Modify(notify::event::ModifyKind::Data(notify::event::DataChange::Content))
+                    | EventKind::Modify(notify::event::ModifyKind::Name(_)) = event.kind {
+                    for path in event.paths {
+                        if block::is_valid_block_file(&path) {
+                            debug!("Valid precomputed block file: {}", path.display());
+                            if let Ok(block) = PrecomputedBlock::parse_file(&path) {
+                                let mut state = state.write().await;
+                                if state.block_pipeline(&block).is_ok() {
+                                    info!(
+                                        "Added block (length {}): {}",
+                                        block.blockchain_length, block.state_hash
+                                    );
                                 }
-                            } else if staking::is_valid_ledger_file(&path) {
-                                let state = state.write().await;
-                                if let Some(store) = state.indexer_store.as_ref() {
-                                    if let Ok(staking_ledger) = StakingLedger::parse_file(&path) {
-                                        let ledger_hash = staking_ledger.ledger_hash.clone();
-                                        match store.add_staking_ledger(staking_ledger) {
-                                            Ok(_) => {
-                                                info!("Added staking ledger {:?}", ledger_hash);
-                                            }
-                                            Err(e) => error!("Error adding staking ledger: {}", e),
+                            } else {
+                                warn!("Unable to parse precomputed block: {path:?}");
+                            }
+                        } else if staking::is_valid_ledger_file(&path) {
+                            let state = state.write().await;
+                            if let Some(store) = state.indexer_store.as_ref() {
+                                if let Ok(staking_ledger) = StakingLedger::parse_file(&path) {
+                                    let ledger_hash = staking_ledger.ledger_hash.clone();
+                                    match store.add_staking_ledger(staking_ledger) {
+                                        Ok(_) => {
+                                            info!("Added staking ledger {:?}", ledger_hash);
                                         }
+                                        Err(e) => error!("Error adding staking ledger: {}", e),
                                     }
                                 }
                             }

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -203,22 +203,22 @@ pub async fn initialize(
 
 #[cfg(target_os = "linux")]
 fn matches_event_kind(kind: EventKind) -> bool {
-    match kind {
-        EventKind::Access(notify::event::AccessKind::Close(notify::event::AccessMode::Write))
-        | EventKind::Modify(notify::event::ModifyKind::Name(_)) => true,
-
-        _ => false,
-    }
+    matches!(
+        kind,
+        EventKind::Access(notify::event::AccessKind::Close(
+            notify::event::AccessMode::Write
+        )) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+    )
 }
 
 #[cfg(target_os = "macos")]
 fn matches_event_kind(kind: EventKind) -> bool {
-    match kind {
-        EventKind::Modify(notify::event::ModifyKind::Data(notify::event::DataChange::Content))
-        | EventKind::Modify(notify::event::ModifyKind::Name(_)) => true,
-
-        _ => false,
-    }
+    matches!(
+        kind,
+        EventKind::Modify(notify::event::ModifyKind::Data(
+            notify::event::DataChange::Content
+        )) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+    )
 }
 
 #[instrument(skip_all)]

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -237,8 +237,11 @@ pub async fn run(
         match res {
             Ok(event) => {
                 trace!("Event: {:?}", event.clone());
-                if let EventKind::Modify(notify::event::ModifyKind::Data(notify::event::DataChange::Content))
-                    | EventKind::Modify(notify::event::ModifyKind::Name(_)) = event.kind {
+                if let EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                ))
+                | EventKind::Modify(notify::event::ModifyKind::Name(_)) = event.kind
+                {
                     for path in event.paths {
                         if block::is_valid_block_file(&path) {
                             debug!("Valid precomputed block file: {}", path.display());


### PR DESCRIPTION
Conditionally compile ingestion code to listen on filesystem events. Use inotify on linux and fsevents on macos. Inotify is more granular and likely accurate.