### PR TITLE
(ci) disable incremental builds in CI

### DIFF
--- a/ops/buildkite-pipeline.yaml
+++ b/ops/buildkite-pipeline.yaml
@@ -9,5 +9,7 @@ steps:
     nix-shell --pure --run "just test-ci | tee build.log"
   key: prereqs
   artifact_paths: "build.log"
+  env:
+    CARGO_INCREMENTAL: 0
   agents:
     os: linux


### PR DESCRIPTION
Incremental builds add unnecessary dependency-tracking and IO overhead. Not needed in CI since it's closer to building from scratch.