### PR TITLE
Separate `mina-rs` unit tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,9 @@ test-ci: lint test-unit
 test-unit: build
   cd rust && cargo nextest run --release
 
+test-unit-mina-rs:
+  cd rust && cargo nextest run --release --features mina_rs
+
 test-regression: build
   cd rust && ./test
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 # required for tests - see https://github.com/rust-lang/cargo/issues/2911
 default = ["loose_deserialization"]
 loose_deserialization = []
+mina_rs = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/src/proof_systems/signer/seckey.rs
+++ b/rust/src/proof_systems/signer/seckey.rs
@@ -156,7 +156,7 @@ impl SecKey {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mina_rs"))]
 mod tests {
     use super::*;
 

--- a/rust/src/protocol/bin_prot/polyvar/caml_hash_variant.rs
+++ b/rust/src/protocol/bin_prot/polyvar/caml_hash_variant.rs
@@ -31,7 +31,7 @@ pub fn caml_hash_variant(label: &str) -> VariantHash {
     }
 */
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mina_rs"))]
 mod tests {
     use super::*;
 

--- a/rust/src/protocol/bin_prot/value/index.rs
+++ b/rust/src/protocol/bin_prot/value/index.rs
@@ -69,7 +69,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mina_rs"))]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/rust/src/protocol/bin_prot/value/layout/traverse.rs
+++ b/rust/src/protocol/bin_prot/value/layout/traverse.rs
@@ -123,7 +123,7 @@ impl IntoIterator for BinProtRule {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "mina_rs"))]
 mod tests {
     use super::*;
     use crate::protocol::bin_prot::value::layout::Layout;

--- a/rust/tests/mod.rs
+++ b/rust/tests/mod.rs
@@ -2,6 +2,7 @@ mod block;
 mod canonicity;
 mod command;
 mod event;
+#[cfg(all(test, feature = "mina_rs"))]
 mod protocol;
 mod snark_work;
 mod state;


### PR DESCRIPTION
In order to facilitate tiered testing, this PR separates the `mina-rs` unit tests from the `mina-indexer` unit tests. `mina-rs` unit tests will _not_ be run during tier 1 unit testing, i.e. `just test-unit`. They can be run via `just test-unit-mina-rs` and can later be included in a higher tier.

Fixes https://github.com/Granola-Team/mina-indexer/issues/642