### PR TITLE
Revert "Deprecate nix-shell use (#663)"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
 use flake
-has just

--- a/Justfile
+++ b/Justfile
@@ -34,7 +34,8 @@ format:
 test: test-unit
   cd rust && ./test
 
-test-ci: lint test-unit test-regression
+test-ci: lint test-unit
+  cd rust && ./test
 
 test-unit: build
   cd rust && cargo nextest run --release

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ compile the `mina-indexer` binary and place it in `./result/bin`.
 Execute unit tests to validate code functionality with:
 
 ```bash
-just test-unit
+nix-shell --run "just test-unit"
 ```
 
 #### Regression Tests
@@ -76,7 +76,7 @@ To perform regression tests, which check for new bugs in existing
 features after updates, use:
 
 ```bash
-just test-regression"
+nix-shell --run "just test-regression"
 ```
 
 ## Generating OCI Images With Nix

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
This reverts commit f83e8bb9e36bdb23c2d21acf9439867480ebdfc4.

Removing `nix.shell` broke support in VS Code