### PR TITLE
Correct integration tests

### DIFF
--- a/rust/test
+++ b/rust/test
@@ -17,6 +17,7 @@ SUMMARY_SCHEMA="$SRC"/rust/tests/json-schemas/summary.json
 # The rest of this script's logic assumes that the testing is done from within
 # this temporary directory.
 TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')"
+DOMAIN_SOCKET_PATH="$TEST_DIR"/mina-indexer.sock
 cd "$TEST_DIR"
 
 # Invoke this function when exiting this script for any reason.
@@ -47,7 +48,6 @@ ephemeral_port() {
     set -e
 }
 
-DOMAIN_SOCKET_PATH="$SRC"/mina-indexer.sock
 wait_for_socket() {
     num_retries=0
     while [ $num_retries -lt 10 ]; do

--- a/rust/test
+++ b/rust/test
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # Collect the binaries under test and the test ledgers.
-SRC="$(git rev-parse --show-toplevel)"
+SRC="$(CDPATH= cd "$(dirname "$0")" && pwd)"/..
 IDXR="$SRC"/rust/target/release/mina-indexer
 LEDGER="$SRC"/rust/tests/data/genesis_ledgers/mainnet.json
 STAKING_LEDGERS="$SRC"/rust/tests/data/staking_ledgers

--- a/rust/test
+++ b/rust/test
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -ex
+set -x
+set -eu
 
 # Collect the binaries under test and the test ledgers.
 IDXR="$(pwd)"/target/release/mina-indexer

--- a/rust/test
+++ b/rust/test
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 set -x
 set -eu
+set -o pipefail
 
 # Collect the binaries under test and the test ledgers.
-IDXR="$(pwd)"/target/release/mina-indexer
-LEDGER="$(pwd)"/tests/data/genesis_ledgers/mainnet.json
-STAKING_LEDGERS="$(pwd)"/tests/data/staking_ledgers
-LOCKED_CSV="$(pwd)"/data/locked.csv
-BLOCKS_FETCHER="$(pwd)"/download_blocks
+SRC="$(git rev-parse --show-toplevel)"
+IDXR="$SRC"/rust/target/release/mina-indexer
+LEDGER="$SRC"/rust/tests/data/genesis_ledgers/mainnet.json
+STAKING_LEDGERS="$SRC"/rust/tests/data/staking_ledgers
+LOCKED_CSV="$SRC"/rust/data/locked.csv
+BLOCKS_FETCHER="$SRC"/rust/download_blocks
 
 # JSON Schemas
-SUMMARY_SCHEMA="$(pwd)"/tests/json-schemas/summary.json
+SUMMARY_SCHEMA="$SRC"/rust/tests/json-schemas/summary.json
 
 # The rest of this script's logic assumes that the testing is done from within
 # this temporary directory.
@@ -45,7 +47,7 @@ ephemeral_port() {
     set -e
 }
 
-DOMAIN_SOCKET_PATH="$(pwd)"/mina-indexer.sock
+DOMAIN_SOCKET_PATH="$SRC"/mina-indexer.sock
 wait_for_socket() {
     num_retries=0
     while [ $num_retries -lt 10 ]; do
@@ -128,8 +130,7 @@ test_indexer_cli_reports() {
     test=test_indexer_cli_reports
 
     # Indexer reports usage with no arguments
-    idxr 2>&1 |
-        grep -iq "Usage:"
+    ( "$IDXR" 2>&1 || true ) | grep -iq "Usage:"
 
     # Indexer reports usage for server subcommand
     idxr_server 2>&1 |


### PR DESCRIPTION
Fixes #703 

The lack of the relatively obscure incantation 'set -o pipefail' in this script caused lines with '|' which were failing to be considered "success". This PR adds the incantation, and corrects the failing lines. Also corrected was an oversight in which 2 concurrently running tests in the same directory would use the same socket, causing both false positive tests and false negative tests, which was very confusing.