### PR TITLE
Cleanly shutdown various processes in the indexer

### DIFF
--- a/rust/src/bin/mina-indexer.rs
+++ b/rust/src/bin/mina-indexer.rs
@@ -223,10 +223,16 @@ pub async fn main() -> anyhow::Result<()> {
             let config = process_indexer_configuration(args, mode)?;
             let db = Arc::new(IndexerStore::new(&database_dir)?);
             let indexer = MinaIndexer::new(config, db.clone(), domain_socket_path).await?;
-            mina_indexer::web::start_web_server(db, (web_hostname, web_port), locked_supply_csv)
-                .await
-                .unwrap();
+            mina_indexer::web::start_web_server(
+                db.clone(),
+                (web_hostname, web_port),
+                locked_supply_csv,
+            )
+            .await
+            .unwrap();
             indexer.await_loop().await;
+            info!("Cleaningly shutting down primary rocksdb");
+            drop(db);
             Ok(())
         }
     }

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -59,7 +59,7 @@ impl MinaIndexer {
         let block_watch_dir = config.block_watch_dir.clone();
         let ledger_watch_dir = config.ledger_watch_dir.clone();
         let _witness_join_handle = tokio::spawn(async move {
-            let state = initialize(config, store).await.unwrap_or_else(|e| {
+            let state = initialize(config, store).unwrap_or_else(|e| {
                 error!("Error in server initialization: {}", e);
                 std::process::exit(1);
             });
@@ -102,7 +102,7 @@ async fn wait_for_signal() {
     }
 }
 
-pub async fn initialize(
+pub fn initialize(
     config: IndexerConfiguration,
     store: Arc<IndexerStore>,
 ) -> anyhow::Result<IndexerState> {
@@ -177,9 +177,7 @@ pub async fn initialize(
                     }
                 };
                 info!("Initializing indexer state");
-                state
-                    .initialize_with_canonical_chain_discovery(&mut block_parser)
-                    .await?;
+                state.initialize_with_canonical_chain_discovery(&mut block_parser)?;
             }
             InitializationMode::Replay => {
                 let min_length_filter = state.replay_events()?;
@@ -188,7 +186,7 @@ pub async fn initialize(
 
                 if block_parser.total_num_blocks > 0 {
                     info!("Adding new blocks from {}", blocks_dir.display());
-                    state.add_blocks(&mut block_parser).await?;
+                    state.add_blocks(&mut block_parser)?;
                 }
             }
             InitializationMode::Sync => {
@@ -198,7 +196,7 @@ pub async fn initialize(
 
                 if block_parser.total_num_blocks > 0 {
                     info!("Adding new blocks from {}", blocks_dir.display());
-                    state.add_blocks(&mut block_parser).await?;
+                    state.add_blocks(&mut block_parser)?;
                 }
             }
         }

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -66,7 +66,7 @@ impl MinaIndexer {
             });
             let state = Arc::new(RwLock::new(state));
             // Needs read-only state for summary
-            unix_socket_server::start(UnixSocketServer::new(state.clone()), &domain_socket_path)
+            unix_socket_server::start(UnixSocketServer::new(state.clone(), domain_socket_path))
                 .await;
 
             // This modifies the state

--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -309,7 +309,7 @@ impl IndexerState {
     /// blocks
     ///
     /// Short-circuits adding canonical blocks to the witness tree
-    pub async fn initialize_with_canonical_chain_discovery(
+    pub fn initialize_with_canonical_chain_discovery(
         &mut self,
         block_parser: &mut BlockParser,
     ) -> anyhow::Result<()> {
@@ -385,24 +385,23 @@ impl IndexerState {
         info!("Adding recent blocks to the witness tree and orphaned blocks to the block store");
         // now add the orphaned blocks
         self.add_blocks_with_time(block_parser, Some(total_time.elapsed()))
-            .await
     }
 
     /// Initialize indexer state without short-circuiting canonical blocks
-    pub async fn initialize_without_canonical_chain_discovery(
+    pub fn initialize_without_canonical_chain_discovery(
         &mut self,
         block_parser: &mut BlockParser,
     ) -> anyhow::Result<()> {
-        self.add_blocks(block_parser).await
+        self.add_blocks(block_parser)
     }
 
     /// Adds blocks to the state according to `block_parser` then changes phase
     /// to Watching
-    pub async fn add_blocks(&mut self, block_parser: &mut BlockParser) -> anyhow::Result<()> {
-        self.add_blocks_with_time(block_parser, None).await
+    pub fn add_blocks(&mut self, block_parser: &mut BlockParser) -> anyhow::Result<()> {
+        self.add_blocks_with_time(block_parser, None)
     }
 
-    async fn add_blocks_with_time(
+    fn add_blocks_with_time(
         &mut self,
         block_parser: &mut BlockParser,
         elapsed: Option<Duration>,

--- a/rust/tests/canonicity/blocks.rs
+++ b/rust/tests/canonicity/blocks.rs
@@ -24,7 +24,7 @@ async fn test() {
     )
     .unwrap();
 
-    state.add_blocks(&mut block_parser).await.unwrap();
+    state.add_blocks(&mut block_parser).unwrap();
 
     println!("CANONICAL ROOT: {:?}", state.canonical_root_block());
     println!("BEST TIP:       {:?}", state.best_tip_block());

--- a/rust/tests/canonicity/ledgers.rs
+++ b/rust/tests/canonicity/ledgers.rs
@@ -18,7 +18,7 @@ async fn test() -> anyhow::Result<()> {
     let genesis_ledger = serde_json::from_str::<GenesisRoot>(genesis_contents)?;
     let mut state = IndexerState::new(genesis_ledger.clone().into(), indexer_store.clone(), 10)?;
 
-    state.add_blocks(&mut block_parser).await?;
+    state.add_blocks(&mut block_parser)?;
 
     let network = "mainnet";
     let indexer_store = state.indexer_store.as_ref().unwrap();

--- a/rust/tests/event/log.rs
+++ b/rust/tests/event/log.rs
@@ -50,7 +50,7 @@ async fn test() {
     .unwrap();
 
     // add parser0 blocks to state0
-    state0.add_blocks(&mut block_parser0).await.unwrap();
+    state0.add_blocks(&mut block_parser0).unwrap();
 
     // add parser1 blocks to state1
     // - add block to db

--- a/rust/tests/event/memoize_ledger.rs
+++ b/rust/tests/event/memoize_ledger.rs
@@ -23,7 +23,7 @@ async fn test() -> anyhow::Result<()> {
     let mut state = IndexerState::new(genesis_ledger.clone().into(), indexer_store.clone(), 10)?;
 
     // add all blocks & get store handle
-    state.add_blocks(&mut block_parser).await?;
+    state.add_blocks(&mut block_parser)?;
     let network = "mainnet".to_string();
     let indexer_store = state.indexer_store.as_ref().unwrap();
 

--- a/rust/tests/event/replay.rs
+++ b/rust/tests/event/replay.rs
@@ -19,7 +19,7 @@ async fn test() {
         IndexerState::new(genesis_ledger.clone().into(), indexer_store.clone(), 10).unwrap();
 
     // add all blocks to the state
-    state.add_blocks(&mut block_parser).await.unwrap();
+    state.add_blocks(&mut block_parser).unwrap();
 
     // fresh state to replay events on top of
     let config = IndexerStateConfig::new(genesis_ledger.into(), indexer_store, 10);

--- a/rust/tests/event/sync.rs
+++ b/rust/tests/event/sync.rs
@@ -19,7 +19,7 @@ async fn test() {
         IndexerState::new(genesis_root.clone().into(), indexer_store.clone(), 10).unwrap();
 
     // add all blocks to the state
-    state.add_blocks(&mut block_parser).await.unwrap();
+    state.add_blocks(&mut block_parser).unwrap();
 
     // fresh state to sync events with no genesis events
     let config = IndexerStateConfig::new(genesis_root.into(), indexer_store, 10);

--- a/rust/tests/event/witness_tree.rs
+++ b/rust/tests/event/witness_tree.rs
@@ -20,7 +20,7 @@ async fn test() {
         IndexerState::new(genesis_root.clone().into(), indexer_store.clone(), 10).unwrap();
 
     // add all blocks to the state
-    state.add_blocks(&mut block_parser).await.unwrap();
+    state.add_blocks(&mut block_parser).unwrap();
 
     let event_log = indexer_store.get_event_log().unwrap();
 

--- a/rust/tests/state/orphaned_blocks.rs
+++ b/rust/tests/state/orphaned_blocks.rs
@@ -18,7 +18,7 @@ async fn not_added_to_witness_tree() -> anyhow::Result<()> {
     let mut state = IndexerState::new(genesis_ledger.clone().into(), indexer_store.clone(), 10)?;
 
     // add all blocks to the state
-    state.add_blocks(&mut block_parser).await?;
+    state.add_blocks(&mut block_parser)?;
 
     // This block is deep canonical:
     // 0: mainnet-105489-3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT.json

--- a/tests/regression
+++ b/tests/regression
@@ -1584,6 +1584,24 @@ test_start_without_blocks_dir() {
     teardown
 }
 
+test_clean_shutdown() {
+    test=test_clean_shutdown
+
+    setup
+    idxr_server_start \
+        --block-watch-dir ./blocks \
+        --ledgers-dir ./staking-ledgers \
+        --database-dir ./database \
+        --log-dir ./logs
+
+    wait_for_socket
+
+    echo "Sending Mina Indexer a SIGTERM"
+    PID="$(cat ./idxr_pid)"
+    kill "$PID"
+    wait "$PID"
+}
+
 # Check command-line arguments
 if [ "$#" -eq 0 ]; then
     # No arguments provided, run all tests
@@ -1615,6 +1633,7 @@ if [ "$#" -eq 0 ]; then
     test_staking_delegations
     test_internal_commands
     test_start_from_config
+    test_clean_shutdown
 else
     # Run only specified tests
     for test_name in "$@"; do
@@ -1648,6 +1667,7 @@ else
             "test_internal_commands") test_internal_commands ;;
             "test_start_from_config") test_start_from_config ;;
             "test_many_blocks") test_many_blocks ;;
+            "test_clean_shutdown") test_clean_shutdown ;;
             "test_release") test_release ;;
             *) echo "Unknown test: $test_name" ;;
         esac


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/255
Fixes: https://github.com/Granola-Team/mina-indexer/issues/726

* Add async pattern to shutdown various processes cleanly
* Remove async from the initialization function