### PR TITLE
Enhancement: store date_time in SignedCommandWithData and add functions to better store/retrieve transactions

### DIFF
--- a/rust/src/command/signed.rs
+++ b/rust/src/command/signed.rs
@@ -25,6 +25,7 @@ pub struct SignedCommandWithData {
     pub status: CommandStatusData,
     pub tx_hash: String,
     pub blockchain_length: u32,
+    pub date_time: u64,
 }
 
 impl SignedCommand {
@@ -153,6 +154,7 @@ impl SignedCommandWithData {
         user_cmd: &UserCommandWithStatus,
         state_hash: &str,
         blockchain_length: u32,
+        date_time: u64,
     ) -> Self {
         let command = SignedCommand::from(user_cmd.clone());
         Self {
@@ -163,6 +165,7 @@ impl SignedCommandWithData {
                 .expect("valid transaction hash"),
             command,
             blockchain_length,
+            date_time,
         }
     }
 
@@ -170,7 +173,14 @@ impl SignedCommandWithData {
         block
             .commands()
             .iter()
-            .map(|cmd| Self::from(cmd, &block.state_hash, block.blockchain_length))
+            .map(|cmd| {
+                Self::from(
+                    cmd,
+                    &block.state_hash,
+                    block.blockchain_length,
+                    block.timestamp(),
+                )
+            })
             .collect()
     }
 }

--- a/rust/src/command/signed.rs
+++ b/rust/src/command/signed.rs
@@ -114,6 +114,8 @@ impl SignedCommand {
         self.payload().common.clone().inner().inner().inner()
     }
 
+    /// This returns a user command (transaction) hash that starts with
+    /// [TXN_HASH_START]
     pub fn hash_signed_command(&self) -> anyhow::Result<String> {
         let mut binprot_bytes = Vec::new();
         bin_prot::to_writer(&mut binprot_bytes, &self.0).map_err(anyhow::Error::from)?;
@@ -466,8 +468,10 @@ fn payload_json(value: mina_rs::SignedCommandV1) -> serde_json::Value {
     Value::Object(payload_obj)
 }
 
+pub const TXN_HASH_START: &str = "Ckp";
+
 pub fn is_valid_tx_hash(input: &str) -> bool {
-    input.starts_with("Ckp") && input.len() == 53
+    input.starts_with(TXN_HASH_START) && input.len() == 53
 }
 
 #[cfg(test)]

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -1014,6 +1014,7 @@ impl CommandStore for IndexerStore {
                 command,
                 &block.state_hash,
                 block.blockchain_length,
+                block.timestamp(),
             ))?;
             self.database.put_cf(commands_cf, key, value)?;
         }
@@ -1032,7 +1033,14 @@ impl CommandStore for IndexerStore {
             let block_pk_commands: Vec<SignedCommandWithData> = user_commands
                 .iter()
                 .filter(|cmd| cmd.contains_public_key(&pk))
-                .map(|c| SignedCommandWithData::from(c, &block.state_hash, block.blockchain_length))
+                .map(|c| {
+                    SignedCommandWithData::from(
+                        c,
+                        &block.state_hash,
+                        block.blockchain_length,
+                        block.timestamp(),
+                    )
+                })
                 .collect();
 
             if !block_pk_commands.is_empty() {

--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -1,11 +1,9 @@
 use crate::{
     block::{precomputed::PrecomputedBlock, store::BlockStore, BlockHash},
     canonicity::{store::CanonicityStore, Canonicity},
+    ledger::LedgerHash,
     proof_systems::signer::pubkey::CompressedPubKey,
-    protocol::serialization_types::{
-        common::{Base58EncodableVersionedType, HashV1},
-        version_bytes,
-    },
+    protocol::serialization_types::{common::Base58EncodableVersionedType, version_bytes},
     store::IndexerStore,
 };
 use async_graphql::{Context, InputObject, Object, Result, SimpleObject};
@@ -194,16 +192,6 @@ struct CreatorAccount {
 fn millis_to_date_string(millis: i64) -> String {
     let date_time = DateTime::from_timestamp_millis(millis).unwrap();
     date_time.to_rfc3339_opts(SecondsFormat::Millis, true)
-}
-
-pub struct LedgerHash(pub String);
-
-impl LedgerHash {
-    pub fn from_hashv1(hashv1: HashV1) -> Self {
-        let versioned: Base58EncodableVersionedType<{ version_bytes::LEDGER_HASH }, _> =
-            hashv1.into();
-        Self(versioned.to_base58_string().unwrap())
-    }
 }
 
 impl From<PrecomputedBlock> for Block {


### PR DESCRIPTION
This is needed as a blocker for #554.

I split this PR into multiple commits for easier review.

[move CommandStore into command/store](https://github.com/Granola-Team/mina-indexer/commit/b6230dabde23c3492db4a581fe048ff05e24b223) - This isn't strictly necessary, but seems like a good move to me. We can drop this commit if we don't want this.