### PR TITLE
Global slot prefix transaction keys in db

### DIFF
--- a/rust/src/block/store.rs
+++ b/rust/src/block/store.rs
@@ -49,4 +49,7 @@ pub trait BlockStore {
 
     /// Get blocks for the given public key
     fn get_blocks_at_public_key(&self, pk: &PublicKey) -> anyhow::Result<Vec<PrecomputedBlock>>;
+
+    /// Get children of a block
+    fn get_block_children(&self, state_hash: &BlockHash) -> anyhow::Result<Vec<PrecomputedBlock>>;
 }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -131,6 +131,18 @@ pub enum Blocks {
         #[arg(long, default_value_t = false)]
         verbose: bool,
     },
+    /// Query a block's children
+    Children {
+        /// Retrieve the children of the block with given state hash
+        #[arg(long)]
+        state_hash: String,
+        /// Path to write the children [default: stdout]
+        #[arg(long)]
+        path: Option<PathBuf>,
+        /// Display the entire precomputed block
+        #[arg(long, default_value_t = false)]
+        verbose: bool,
+    },
 }
 
 #[derive(Subcommand, Debug, Encode, Decode)]
@@ -350,7 +362,6 @@ pub async fn run(command: &ClientCli, domain_socket_path: &Path) -> anyhow::Resu
     let (reader, mut writer) = conn.into_split();
     let mut reader = BufReader::new(reader);
     let mut buffer = Vec::with_capacity(BUFFER_SIZE);
-
     let encoded = bincode::encode_to_vec(command, BIN_CODE_CONFIG)?;
 
     writer.write_all(&encoded).await?;
@@ -359,6 +370,5 @@ pub async fn run(command: &ClientCli, domain_socket_path: &Path) -> anyhow::Resu
     let msg = String::from_utf8(buffer)?;
     let msg = msg.trim_end();
     println!("{msg}");
-
     Ok(())
 }

--- a/rust/src/command/signed.rs
+++ b/rust/src/command/signed.rs
@@ -26,6 +26,7 @@ pub struct SignedCommandWithData {
     pub tx_hash: String,
     pub blockchain_length: u32,
     pub date_time: u64,
+    pub global_slot_since_genesis: u32,
 }
 
 impl SignedCommand {
@@ -155,17 +156,19 @@ impl SignedCommandWithData {
         state_hash: &str,
         blockchain_length: u32,
         date_time: u64,
+        global_slot_since_genesis: u32,
     ) -> Self {
         let command = SignedCommand::from(user_cmd.clone());
         Self {
+            date_time,
+            blockchain_length,
+            global_slot_since_genesis,
             state_hash: state_hash.into(),
             status: user_cmd.status_data(),
             tx_hash: command
                 .hash_signed_command()
                 .expect("valid transaction hash"),
             command,
-            blockchain_length,
-            date_time,
         }
     }
 
@@ -179,6 +182,7 @@ impl SignedCommandWithData {
                     &block.state_hash,
                     block.blockchain_length,
                     block.timestamp(),
+                    block.global_slot_since_genesis(),
                 )
             })
             .collect()

--- a/rust/src/ledger/store.rs
+++ b/rust/src/ledger/store.rs
@@ -1,3 +1,5 @@
+//! Store of staged ledgers, staking ledgers, and staking delegations
+
 use crate::{
     block::BlockHash,
     ledger::{
@@ -6,7 +8,6 @@ use crate::{
     },
 };
 
-/// Store of canonical ledgers
 pub trait LedgerStore {
     /// Add a ledger with assoociated hash
     fn add_ledger(

--- a/rust/src/unix_socket_server.rs
+++ b/rust/src/unix_socket_server.rs
@@ -424,6 +424,69 @@ async fn handle_conn(
                     }
                 }
             }
+            Blocks::Children {
+                state_hash,
+                verbose,
+                path,
+            } => {
+                info!("Received block-children command for block {}", state_hash);
+
+                let mut children = db.get_block_children(&state_hash.clone().into())?;
+                children.sort();
+
+                let blocks_str = if verbose {
+                    let blocks: Vec<PrecomputedBlockWithCanonicity> = children
+                        .iter()
+                        .flat_map(|block| {
+                            if let Ok(Some(canonicity)) =
+                                db.get_block_canonicity(&block.state_hash.clone().into())
+                            {
+                                Some(block.with_canonicity(canonicity))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    serde_json::to_string(&blocks)?
+                } else {
+                    let blocks: Vec<BlockWithoutHeight> = children
+                        .iter()
+                        .flat_map(|block| {
+                            if let Ok(Some(canonicity)) =
+                                db.get_block_canonicity(&block.state_hash.clone().into())
+                            {
+                                Some(BlockWithoutHeight::with_canonicity(block, canonicity))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    format_vec_jq_compatible(&blocks)
+                };
+
+                if path.is_none() {
+                    info!("Writing children of block {} to stdout", state_hash);
+                    Some(blocks_str)
+                } else {
+                    let path = path.unwrap();
+                    if !path.is_dir() {
+                        info!(
+                            "Writing children of block {} to {}",
+                            state_hash,
+                            path.display()
+                        );
+
+                        std::fs::write(path.clone(), blocks_str)?;
+                        Some(format!(
+                            "Children of block {} written to {}",
+                            state_hash,
+                            path.display()
+                        ))
+                    } else {
+                        file_must_not_be_a_directory(&path)
+                    }
+                }
+            }
         },
         ClientCli::Chain(__) => match __ {
             Chain::Best {

--- a/rust/tests/command/store.rs
+++ b/rust/tests/command/store.rs
@@ -1,48 +1,54 @@
 use crate::helpers::setup_new_db_dir;
 use mina_indexer::{
-    block::parser::BlockParser,
+    block::{parser::BlockParser, precomputed::PrecomputedBlock, store::BlockStore},
     command::{signed::SignedCommand, store::CommandStore},
     constants::*,
     ledger::genesis::parse_file,
     state::IndexerState,
-    store::IndexerStore,
+    store::{
+        user_commands_iterator, user_commands_iterator_global_slot, user_commands_iterator_network,
+        user_commands_iterator_signed_command, user_commands_iterator_txn_hash, IndexerStore,
+    },
 };
 use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
-async fn add_and_get() {
-    let store_dir = setup_new_db_dir("command-store").unwrap();
+async fn add_and_get() -> anyhow::Result<()> {
+    let store_dir = setup_new_db_dir("command-store")?;
     let blocks_dir = &PathBuf::from("./tests/data/non_sequential_blocks");
-
-    let indexer_store = Arc::new(IndexerStore::new(store_dir.path()).unwrap());
+    let indexer_store = Arc::new(IndexerStore::new(store_dir.path())?);
     let genesis_ledger_path = &PathBuf::from("./tests/data/genesis_ledgers/mainnet.json");
-    let genesis_root = parse_file(genesis_ledger_path).unwrap();
+    let genesis_root = parse_file(genesis_ledger_path)?;
     let indexer = IndexerState::new(
         genesis_root.into(),
         indexer_store.clone(),
         MAINNET_TRANSITION_FRONTIER_K,
-    )
-    .unwrap();
+    )?;
 
     let mut bp = BlockParser::new_with_canonical_chain_discovery(
         blocks_dir,
         MAINNET_CANONICAL_THRESHOLD,
         BLOCK_REPORTING_FREQ_NUM,
-    )
-    .unwrap();
+    )?;
+
+    // add the first block to the store
+    if let Some((block, _)) = bp.next_block()? {
+        let block: PrecomputedBlock = block.into();
+        indexer.add_block_to_store(&block)?;
+    }
+
     let state_hash = "3NL4HLb7MQrxmAqVw8D4vEXCj2tdT8zgP9DFWGRoDxP72b4wxyUw";
-    let (block, _) = bp.get_precomputed_block(state_hash).await.unwrap();
+    let (block, _) = bp.get_precomputed_block(state_hash).await?;
     let block_cmds = block.commands();
     let pks = block.all_command_public_keys();
 
-    // add the block to the block store
-    indexer.add_block_to_store(&block).unwrap();
+    // add another block to the store
+    indexer.add_block_to_store(&block)?;
 
     // check state hash key
     let result_cmds = indexer_store
         .as_ref()
-        .get_commands_in_block(&state_hash.into())
-        .unwrap();
+        .get_commands_in_block(&state_hash.into())?;
     assert_eq!(result_cmds, block_cmds);
 
     // check each pk key
@@ -55,8 +61,7 @@ async fn add_and_get() {
             .collect();
         let result_pk_cmds: Vec<SignedCommand> = indexer_store
             .as_ref()
-            .get_commands_for_public_key(&pk)
-            .unwrap()
+            .get_commands_for_public_key(&pk)?
             .into_iter()
             .map(SignedCommand::from)
             .collect();
@@ -66,10 +71,44 @@ async fn add_and_get() {
     // check transaction hash key
     for cmd in SignedCommand::from_precomputed(&block) {
         let result_cmd: SignedCommand = indexer_store
-            .get_command_by_hash(&cmd.hash_signed_command().unwrap())
-            .unwrap()
+            .get_command_by_hash(&cmd.hash_signed_command()?)?
             .unwrap()
             .into();
         assert_eq!(result_cmd, cmd);
     }
+
+    // iterate over transactions
+    let network = "mainnet";
+    let mut curr_slot = 0;
+
+    for entry in user_commands_iterator(network.to_string(), &indexer_store) {
+        // no longer iterating over global slot prefixed keys
+        if String::from_utf8(entry.to_owned()?.0[..network.as_bytes().len()].to_vec())
+            == Ok(network.to_string())
+        {
+            // networks match
+            assert_eq!(network.to_string(), user_commands_iterator_network(&entry)?);
+
+            // txn hashes should match
+            assert_eq!(
+                user_commands_iterator_signed_command(&entry)?.tx_hash,
+                user_commands_iterator_txn_hash(network, &entry)?,
+            );
+
+            // global slot numbers should match
+            let cmd_slot = user_commands_iterator_global_slot(network, &entry);
+            assert!(curr_slot <= cmd_slot);
+            assert_eq!(
+                cmd_slot,
+                user_commands_iterator_signed_command(&entry)?.global_slot_since_genesis,
+            );
+
+            // blocks should be present
+            let state_hash = user_commands_iterator_signed_command(&entry)?.state_hash;
+            assert!(indexer_store.get_block(&state_hash)?.is_some());
+
+            curr_slot = cmd_slot;
+        }
+    }
+    Ok(())
 }

--- a/tests/regression
+++ b/tests/regression
@@ -1617,17 +1617,12 @@ test_clean_shutdown() {
         --block-watch-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database
-
     wait_for_socket
 
-    echo "Sending Mina Indexer a SIGTERM"
-    PID="$(cat ./idxr_pid)"
-    kill "$PID"
-    ps -p "$PID" || true
-    wait "$PID"  # Sometimes hangs!
-    ps -p "$PID" || true
-
-    teardown
+    kill_idxr
+    if [ -f ./idxr_pid ]; then
+        exit 1
+    fi
 }
 
 test_block_children() {

--- a/tests/regression
+++ b/tests/regression
@@ -1613,7 +1613,7 @@ test_clean_shutdown() {
 
     setup
     idxr_server_start \
-	--log-level TRACE \
+	    --log-level TRACE \
         --block-watch-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database
@@ -1626,6 +1626,48 @@ test_clean_shutdown() {
     ps -p "$PID" || true
     wait "$PID"  # Sometimes hangs!
     ps -p "$PID" || true
+
+    teardown
+}
+
+test_block_children() {
+    test=test_block_children
+
+    setup
+    dl_mainnet 10 ./blocks
+
+    idxr_server_start \
+        --blocks-dir ./blocks \
+        --staking-ledger-watch-dir ./staking-ledgers \
+        --database-dir ./database
+    wait_for_socket
+
+    block_5_state_hash=3NKQUoBfi9vkbuqtDJmSEYBQrcSo4GjwG8bPCiii4yqM8AxEQvtY
+    children=$(idxr blocks children --state-hash $block_5_state_hash)
+
+    assert 6 $(echo "$children" | jq -r .[0].blockchain_length)
+    assert 'Canonical' $(echo "$children" | jq -r .[0].canonicity)
+    assert 5 $(echo "$children" | jq -r .[0].global_slot_since_genesis)
+    assert $block_5_state_hash $(echo "$children" | jq -r .[0].parent_hash)
+    assert '3NKqRR2BZFV7Ad5kxtGKNNL59neXohf4ZEC5EMKrrnijB1jy4R5v' $(echo "$children" | jq -r .[0].state_hash)
+
+    assert 6 $(echo "$children" | jq -r .[1].blockchain_length)
+    assert 'Orphaned' $(echo "$children" | jq -r .[1].canonicity)
+    assert 5 $(echo "$children" | jq -r .[1].global_slot_since_genesis)
+    assert $block_5_state_hash $(echo "$children" | jq -r .[1].parent_hash)
+    assert '3NKvdydTvLVDJ9PKAXrisjsXoZQvUy1V2sbComWyB2uyhARCJZ5M' $(echo "$children" | jq -r .[1].state_hash)
+
+    assert 6 $(echo "$children" | jq -r .[2].blockchain_length)
+    assert 'Orphaned' $(echo "$children" | jq -r .[2].canonicity)
+    assert 5 $(echo "$children" | jq -r .[2].global_slot_since_genesis)
+    assert $block_5_state_hash $(echo "$children" | jq -r .[2].parent_hash)
+    assert '3NLM3k3Vk1qs36hZWdbWvi4sqwer3skbgPyHMWrZMBoscNLyjnY2' $(echo "$children" | jq -r .[2].state_hash)
+
+    assert 6 $(echo "$children" | jq -r .[3].blockchain_length)
+    assert 'Orphaned' $(echo "$children" | jq -r .[3].canonicity)
+    assert 5 $(echo "$children" | jq -r .[3].global_slot_since_genesis)
+    assert $block_5_state_hash $(echo "$children" | jq -r .[3].parent_hash)
+    assert '3NKqMEewA8gvEiW7So7nZ3DN6tPnmCtHpWuAzADN5ff9wiqkGf45' $(echo "$children" | jq -r .[3].state_hash)
 
     teardown
 }
@@ -1647,6 +1689,7 @@ if [ "$#" -eq 0 ]; then
     test_block_copy
     test_missing_blocks
     test_best_chain
+    test_block_children
     test_ledgers
     test_sync
     test_replay
@@ -1681,6 +1724,7 @@ else
             "test_block_copy") test_block_copy ;;
             "test_missing_blocks") test_missing_blocks ;;
             "test_best_chain") test_best_chain ;;
+            "test_block_children") test_block_children ;;
             "test_ledgers") test_ledgers ;;
             "test_sync") test_sync ;;
             "test_replay") test_replay ;;


### PR DESCRIPTION
This PR

- adds `get_block_children` function to `BlockStore`
- changes transaction iteration order to use global slot number
- fixes infinite wait in `test_clean_shutdown` regression test

Fixes #732
Fixes #745