### PR TITLE
 feat: add GraphQL - transaction

### DIFF
--- a/tests/hurl/transaction.hurl
+++ b/tests/hurl/transaction.hurl
@@ -1,0 +1,14 @@
+POST {{url}}
+```graphql
+query TransactionQuery {
+  transaction(query: {hash: "CkpaJFpf2q9syHb6dmufSNUii4b5iHvPyakoWgNzKnU7AQ68fzY1P"}) {
+    block {
+      stateHash
+    }
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.data.transaction.block.stateHash" == "3NLgPYVDSV6y7ZKSQrjowedjZn9RuLwdx311vheWZEy3mBjKDbmj"
+duration < 1000


### PR DESCRIPTION
Implements Granola-Team/mina-indexer#784

Allows fetching a single transaction by transaction hash.