### PR TITLE
fix: fast transaction queries with limited supported sorters

### DIFF
--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use log::{error, trace, warn};
-use speedb::{ColumnFamilyDescriptor, DBCompressionType, DBIterator, DB};
+use speedb::{ColumnFamilyDescriptor, DBCompressionType, DBIterator, IteratorMode, DB};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -1029,9 +1029,8 @@ pub fn convert_user_command_db_key_to_block_hash(db_key: &[u8]) -> anyhow::Resul
 }
 
 /// [DBIterator] for user commands (transactions)
-pub fn user_commands_iterator(db: &Arc<IndexerStore>) -> DBIterator<'_> {
-    db.database
-        .iterator_cf(db.commands_slot_mainnet_cf(), speedb::IteratorMode::Start)
+pub fn user_commands_iterator<'a>(db: &'a Arc<IndexerStore>, mode: IteratorMode) -> DBIterator<'a> {
+    db.database.iterator_cf(db.commands_slot_mainnet_cf(), mode)
 }
 
 /// Global slot number from `entry` in [user_commands_iterator]

--- a/rust/tests/command/store.rs
+++ b/rust/tests/command/store.rs
@@ -7,6 +7,7 @@ use mina_indexer::{
     state::IndexerState,
     store::*,
 };
+use speedb::IteratorMode;
 use std::{path::PathBuf, sync::Arc};
 
 #[tokio::test]
@@ -76,7 +77,7 @@ async fn add_and_get() -> anyhow::Result<()> {
 
     // iterate over transactions
     let mut curr_slot = 0;
-    for entry in user_commands_iterator(&indexer_store) {
+    for entry in user_commands_iterator(&indexer_store, IteratorMode::End) {
         // txn hashes should match
         assert_eq!(
             user_commands_iterator_signed_command(&entry)?.tx_hash,

--- a/tests/hurl/transactions.hurl
+++ b/tests/hurl/transactions.hurl
@@ -1,6 +1,6 @@
 POST {{url}}
 ```graphql
-query Transactions($limit: Int = 10, $sort_by: TransactionSortByInput!, $query: TransactionQueryInput!) {
+query Transactions($limit: Int, $sort_by: TransactionSortByInput!, $query: TransactionQueryInput!) {
   transactions(limit: $limit, sortBy: $sort_by, query: $query ) {
     blockHeight
     canonical


### PR DESCRIPTION
This attempts to fix Granola-Team/mina-indexer#785.