### PR TITLE
Add transactions to the block GQL endpoint

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -1,10 +1,23 @@
-use super::{db, get_block_canonicity};
+use super::{
+    db, get_block_canonicity,
+    transactions::{decode_memo, nanomina_to_mina_f64},
+};
 use crate::{
     block::{self, precomputed::PrecomputedBlock, store::BlockStore},
-    command::internal::{InternalCommand, InternalCommandWithData},
-    ledger::LedgerHash,
+    command::{
+        internal::{InternalCommand, InternalCommandWithData},
+        signed::{SignedCommand, SignedCommandWithData},
+        CommandStatusData,
+    },
+    ledger::{public_key::PublicKey, LedgerHash},
     proof_systems::signer::pubkey::CompressedPubKey,
-    protocol::serialization_types::{common::Base58EncodableVersionedType, version_bytes},
+    protocol::serialization_types::{
+        common::Base58EncodableVersionedType,
+        staged_ledger_diff::{
+            SignedCommandPayloadBody, StakeDelegation, TransactionStatusFailedType,
+        },
+        version_bytes,
+    },
     store::{blocks_global_slot_idx_iterator, blocks_global_slot_idx_state_hash_from_entry},
     web::graphql::gen::BlockQueryInput,
 };
@@ -166,6 +179,42 @@ struct Transactions {
     coinbase_receiver_account: CoinbaseReceiverAccount,
     /// Value fee transfer
     fee_transfer: Vec<BlockFeetransfer>,
+    /// Value user commands
+    user_commands: Vec<UserCommand>,
+}
+
+#[derive(SimpleObject)]
+struct UserCommand {
+    /// Value block height
+    block_height: u32,
+    /// Value from
+    from: String,
+    /// Value to
+    to: String,
+    /// Value hash
+    hash: String,
+    /// Value fee
+    fee: f64,
+    /// Value amount
+    amount: f64,
+    /// Value kind
+    kind: String,
+    /// Value nonce
+    nonce: u32,
+    /// Value memo
+    memo: String,
+    /// Value token
+    token: u64,
+    /// Value failure reason
+    failure_reason: String,
+    /// Value transaction receiver
+    receiver: BlockTransactionReceiver,
+}
+
+#[derive(SimpleObject)]
+struct BlockTransactionReceiver {
+    /// Value public key
+    public_key: String,
 }
 
 #[derive(SimpleObject)]
@@ -444,6 +493,11 @@ impl From<PrecomputedBlock> for Block {
             .map(|cmd| InternalCommandWithData::from_internal_cmd(cmd, &block))
             .map(|ft| ft.into())
             .collect();
+
+        let user_commands: Vec<UserCommand> = SignedCommandWithData::from_precomputed(&block)
+            .into_iter()
+            .map(|cmd| cmd.into())
+            .collect();
         Block {
             state_hash: block.state_hash,
             block_height: block.blockchain_length,
@@ -505,6 +559,7 @@ impl From<PrecomputedBlock> for Block {
                     public_key: coinbase_receiver_account,
                 },
                 fee_transfer: fee_transfers,
+                user_commands,
             },
         }
     }
@@ -559,6 +614,100 @@ impl From<InternalCommandWithData> for BlockFeetransfer {
                 recipient: receiver.0,
                 feetransfer_kind: kind.to_string(),
             },
+        }
+    }
+}
+
+impl From<SignedCommandWithData> for UserCommand {
+    fn from(cmd: SignedCommandWithData) -> Self {
+        let failure_reason = match cmd.status {
+            CommandStatusData::Applied { .. } => "".to_owned(),
+            CommandStatusData::Failed(failed_types, _) => failed_types
+                .first()
+                .map_or("".to_owned(), |f| f.to_string()),
+        };
+        match cmd.command {
+            SignedCommand(signed_cmd) => {
+                let payload = signed_cmd.t.t.payload;
+                let common = payload.t.t.common.t.t.t;
+                let token = common.fee_token.t.t.t;
+                let nonce = common.nonce.t.t;
+                let fee = common.fee.t.t;
+                let (sender, receiver, kind, token_id, amount) = {
+                    match payload.t.t.body.t.t {
+                        SignedCommandPayloadBody::PaymentPayload(payload) => (
+                            payload.t.t.source_pk,
+                            payload.t.t.receiver_pk,
+                            "PAYMENT",
+                            token,
+                            payload.t.t.amount.t.t,
+                        ),
+                        SignedCommandPayloadBody::StakeDelegation(payload) => {
+                            let StakeDelegation::SetDelegate {
+                                delegator,
+                                new_delegate,
+                            } = payload.t;
+                            (delegator, new_delegate, "STAKE_DELEGATION", token, 0)
+                        }
+                    }
+                };
+
+                let memo = decode_memo(common.memo.t.0).expect("decoded memo");
+                Self {
+                    amount: nanomina_to_mina_f64(amount),
+                    failure_reason,
+                    block_height: cmd.blockchain_length,
+                    fee: nanomina_to_mina_f64(fee),
+                    from: PublicKey::from(sender).0,
+                    hash: cmd.tx_hash,
+                    kind: kind.to_owned(),
+                    memo,
+                    nonce: nonce.try_into().unwrap(),
+                    receiver: BlockTransactionReceiver {
+                        public_key: PublicKey::from(receiver.clone()).0,
+                    },
+                    to: PublicKey::from(receiver).0,
+                    token: token_id,
+                }
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for TransactionStatusFailedType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransactionStatusFailedType::Predicate => write!(f, "Predicate"),
+            TransactionStatusFailedType::SourceNotPresent => write!(f, "Source_not_present"),
+            TransactionStatusFailedType::ReceiverNotPresent => write!(f, "Receiver_not_present"),
+            TransactionStatusFailedType::AmountInsufficientToCreateAccount => {
+                write!(f, "Amount_insufficient_to_create_account")
+            }
+            TransactionStatusFailedType::CannotPayCreationFeeInToken => {
+                write!(f, "Cannot_pay_creation_fee_in_token")
+            }
+            TransactionStatusFailedType::SourceInsufficientBalance => {
+                write!(f, "Source_insufficient_balance")
+            }
+            TransactionStatusFailedType::SourceMinimumBalanceViolation => {
+                write!(f, "Source_minimum_balance_violation")
+            }
+            TransactionStatusFailedType::ReceiverAlreadyExists => {
+                write!(f, "Receiver_already_exists")
+            }
+            TransactionStatusFailedType::NotTokenOwner => write!(f, "Not_token_owner"),
+            TransactionStatusFailedType::MismatchedTokenPermissions => {
+                write!(f, "Mismatched_token_permissions")
+            }
+            TransactionStatusFailedType::Overflow => write!(f, "Overflow"),
+            TransactionStatusFailedType::SignedCommandOnSnappAccount => {
+                write!(f, "Signed_command_on_snapp_account")
+            }
+            TransactionStatusFailedType::SnappAccountNotPresent => {
+                write!(f, "Snapp_account_not_present")
+            }
+            TransactionStatusFailedType::UpdateNotPermitted => write!(f, "Update_not_permitted"),
+            TransactionStatusFailedType::IncorrectNonce => write!(f, "Incorrect_nonce"),
         }
     }
 }

--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -219,7 +219,7 @@ struct BlockTransactionReceiver {
 
 #[derive(SimpleObject)]
 struct BlockFeetransfer {
-    pub fee: u64,
+    pub fee: String,
     pub recipient: String,
     #[graphql(name = "type")]
     pub feetransfer_kind: String,
@@ -600,7 +600,7 @@ impl From<InternalCommandWithData> for BlockFeetransfer {
                 kind,
                 ..
             } => Self {
-                fee: amount,
+                fee: amount.to_string(),
                 recipient: receiver.0,
                 feetransfer_kind: kind.to_string(),
             },
@@ -610,7 +610,7 @@ impl From<InternalCommandWithData> for BlockFeetransfer {
                 kind,
                 ..
             } => Self {
-                fee: amount,
+                fee: amount.to_string(),
                 recipient: receiver.0,
                 feetransfer_kind: kind.to_string(),
             },

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -57,3 +57,42 @@ POST {{url}}
 HTTP 200
 [Asserts]
 jsonpath "$.data.blocks" count == 3
+
+POST {{url}}
+```graphql
+{
+  blocks(query: {stateHash: "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R"}) {
+    stateHash
+    transactions {
+      coinbase
+      coinbaseReceiverAccount {
+        publicKey
+      }
+      userCommands {
+        failureReason
+        hash
+        kind
+        from
+        to
+        amount
+        fee
+        blockHeight
+      }
+    }
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.data.blocks[0].stateHash" == "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R"
+jsonpath "$.data.blocks[0].transactions.coinbase" == 720000000000
+jsonpath "$.data.blocks[0].transactions.coinbaseReceiverAccount.publicKey" == "B62qqSUUCnoC8Vehw5xwhrnaNxhk6Xe3FcBhngoxyXCbJBfvVhiqia1"
+jsonpath "$.data.blocks[0].transactions.userCommands" count == 4
+jsonpath "$.data.blocks[0].transactions.userCommands[0].kind" == "PAYMENT"
+jsonpath "$.data.blocks[0].transactions.userCommands[0].from" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"
+jsonpath "$.data.blocks[0].transactions.userCommands[0].to" == "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM"
+jsonpath "$.data.blocks[0].transactions.userCommands[0].amount" == 0.000001
+jsonpath "$.data.blocks[0].transactions.userCommands[0].fee" == 0.01
+jsonpath "$.data.blocks[0].transactions.userCommands[0].blockHeight" == 3
+
+duration < 1000

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -68,6 +68,11 @@ POST {{url}}
       coinbaseReceiverAccount {
         publicKey
       }
+      feeTransfer {
+        type
+        recipient
+        fee
+      }
       userCommands {
         failureReason
         hash
@@ -87,6 +92,10 @@ HTTP 200
 jsonpath "$.data.blocks[0].stateHash" == "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R"
 jsonpath "$.data.blocks[0].transactions.coinbase" == 720000000000
 jsonpath "$.data.blocks[0].transactions.coinbaseReceiverAccount.publicKey" == "B62qqSUUCnoC8Vehw5xwhrnaNxhk6Xe3FcBhngoxyXCbJBfvVhiqia1"
+jsonpath "$.data.blocks[0].transactions.feeTransfer" count == 2
+jsonpath "$.data.blocks[0].transactions.feeTransfer[0].type" == "Coinbase"
+jsonpath "$.data.blocks[0].transactions.feeTransfer[0].recipient" == "B62qqSUUCnoC8Vehw5xwhrnaNxhk6Xe3FcBhngoxyXCbJBfvVhiqia1"
+jsonpath "$.data.blocks[0].transactions.feeTransfer[0].fee" == "720000000000"
 jsonpath "$.data.blocks[0].transactions.userCommands" count == 4
 jsonpath "$.data.blocks[0].transactions.userCommands[0].kind" == "PAYMENT"
 jsonpath "$.data.blocks[0].transactions.userCommands[0].from" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -105,3 +105,26 @@ jsonpath "$.data.blocks[0].transactions.userCommands[0].fee" == 0.01
 jsonpath "$.data.blocks[0].transactions.userCommands[0].blockHeight" == 3
 
 duration < 1000
+
+POST {{url}}
+```graphql
+{
+  blocks(query: {stateHash: "3NLj4yaEa4kGamq93k8ZMqbiZWuR26USzzndXVGoBupEZRQ6zJjm"}) {
+    snarkJobs {
+      blockHeight
+      blockStateHash
+      dateTime
+      prover
+      fee
+    }
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.data.blocks[0].snarkJobs" count == 64
+jsonpath "$.data.blocks[0].snarkJobs[0].blockHeight" == 111
+jsonpath "$.data.blocks[0].snarkJobs[0].blockStateHash" == "3NLj4yaEa4kGamq93k8ZMqbiZWuR26USzzndXVGoBupEZRQ6zJjm"
+jsonpath "$.data.blocks[0].snarkJobs[0].dateTime" == "2021-03-17T08:06:00.000Z"
+jsonpath "$.data.blocks[0].snarkJobs[0].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"
+jsonpath "$.data.blocks[0].snarkJobs[0].fee" == 0


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/802

* Adds transactions resolver to the block(s) GQL endpoint
* Adds fee transfer resolver to the block(s) GQL endpoint