### PR TITLE
(gql) filter coinbase feetransfers so the UI doesn't display duplicates

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -443,6 +443,7 @@ impl Block {
         let fee_transfers: Vec<BlockFeetransfer> = InternalCommand::from_precomputed(&block)
             .into_iter()
             .map(|cmd| InternalCommandWithData::from_internal_cmd(cmd, &block))
+            .filter(|x| matches!(x, InternalCommandWithData::FeeTransfer { .. }))
             .map(|ft| ft.into())
             .collect();
 

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -92,10 +92,10 @@ HTTP 200
 jsonpath "$.data.blocks[0].stateHash" == "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R"
 jsonpath "$.data.blocks[0].transactions.coinbase" == "720000000000"
 jsonpath "$.data.blocks[0].transactions.coinbaseReceiverAccount.publicKey" == "B62qqSUUCnoC8Vehw5xwhrnaNxhk6Xe3FcBhngoxyXCbJBfvVhiqia1"
-jsonpath "$.data.blocks[0].transactions.feeTransfer" count == 2
-jsonpath "$.data.blocks[0].transactions.feeTransfer[0].type" == "Coinbase"
+jsonpath "$.data.blocks[0].transactions.feeTransfer" count == 1
+jsonpath "$.data.blocks[0].transactions.feeTransfer[0].type" == "Fee_transfer"
 jsonpath "$.data.blocks[0].transactions.feeTransfer[0].recipient" == "B62qqSUUCnoC8Vehw5xwhrnaNxhk6Xe3FcBhngoxyXCbJBfvVhiqia1"
-jsonpath "$.data.blocks[0].transactions.feeTransfer[0].fee" == "720000000000"
+jsonpath "$.data.blocks[0].transactions.feeTransfer[0].fee" == "120000000"
 jsonpath "$.data.blocks[0].transactions.userCommands" count == 4
 jsonpath "$.data.blocks[0].transactions.userCommands[0].kind" == "PAYMENT"
 jsonpath "$.data.blocks[0].transactions.userCommands[0].from" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/827

* Filter out Coinbase fee transfers from the block(s) GQL endpoints