### PR TITLE
Use index when creator_account.public_key is in the filter

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -156,6 +156,23 @@ impl BlocksQueryRoot {
             return Ok(blocks);
         }
 
+        // creator account query
+        if let Some(creator_account) = query.as_ref().and_then(|q| {
+            q.creator_account
+                .as_ref()
+                .and_then(|cb| cb.public_key.clone())
+        }) {
+            let mut blocks: Vec<BlockWithCanonicity> = db
+                .get_blocks_at_public_key(&creator_account.into())?
+                .into_iter()
+                .filter_map(|b| precomputed_matches_query(db, &query, b))
+                .collect();
+
+            reorder_asc(&mut blocks, sort_by);
+            blocks.truncate(limit);
+            return Ok(blocks);
+        }
+
         // block height bounded query
         if query
             .as_ref()


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/846

* Use `get_blocks_at_public_key` when creator_account.public_key is in the filter