### PR TITLE
(gql) rename gql schema objects for stakes to be singular

### DIFF
--- a/rust/src/web/graphql/mod.rs
+++ b/rust/src/web/graphql/mod.rs
@@ -22,7 +22,7 @@ const MINA_SCALE: u32 = 9;
 #[derive(MergedObject, Default)]
 pub struct Root(
     blocks::BlocksQueryRoot,
-    stakes::StakesQueryRoot,
+    stakes::StakeQueryRoot,
     next_stakes::NextStakesQueryRoot,
     accounts::AccountQueryRoot,
     transactions::TransactionsQueryRoot,

--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -9,7 +9,7 @@ use async_graphql::{Context, Enum, InputObject, Object, Result, SimpleObject};
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 
 #[derive(InputObject)]
-pub struct StakesQueryInput {
+pub struct StakeQueryInput {
     epoch: Option<u32>,
     delegate: Option<String>,
     ledger_hash: Option<String>,
@@ -19,22 +19,22 @@ pub struct StakesQueryInput {
 }
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
-pub enum StakesSortByInput {
+pub enum StakeSortByInput {
     BalanceDesc,
 }
 
 #[derive(Default)]
-pub struct StakesQueryRoot;
+pub struct StakeQueryRoot;
 
 #[Object]
-impl StakesQueryRoot {
+impl StakeQueryRoot {
     // Cache for 1 day
     #[graphql(cache_control(max_age = 86400))]
     async fn stakes<'ctx>(
         &self,
         ctx: &Context<'ctx>,
-        query: Option<StakesQueryInput>,
-        sort_by: Option<StakesSortByInput>,
+        query: Option<StakeQueryInput>,
+        sort_by: Option<StakeSortByInput>,
         #[graphql(default = 100)] limit: usize,
     ) -> Result<Option<Vec<StakesLedgerAccountWithMeta>>> {
         let db = db(ctx);
@@ -65,7 +65,7 @@ impl StakesQueryRoot {
             .into_values()
             .filter(|account| {
                 if let Some(ref query) = query {
-                    let StakesQueryInput {
+                    let StakeQueryInput {
                         delegate,
                         public_key,
                         epoch: query_epoch,
@@ -121,7 +121,7 @@ impl StakesQueryRoot {
             })
             .collect();
 
-        if let Some(StakesSortByInput::BalanceDesc) = sort_by {
+        if let Some(StakeSortByInput::BalanceDesc) = sort_by {
             accounts.sort_by(|a, b| b.account.balance_nanomina.cmp(&a.account.balance_nanomina));
         }
 

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -1,6 +1,6 @@
 POST {{url}}
 ```graphql
-query StakesQuery($limit: Int, $sort_by: StakesSortByInput!, $query: StakesQueryInput!) {
+query StakesQuery($limit: Int, $sort_by: StakeSortByInput!, $query: StakeQueryInput!) {
   stakes(limit: $limit, sortBy: $sort_by, query: $query) {
     balance
     chainId
@@ -46,7 +46,7 @@ jsonpath "$.data.stakes[0].delegationTotals.totalDelegated" == 2498323.273015384
 
 POST {{url}}
 ```graphql
-query StakesQuery($limit: Int, $sort_by: StakesSortByInput!, $query: StakesQueryInput!) {
+query StakesQuery($limit: Int, $sort_by: StakeSortByInput!, $query: StakeQueryInput!) {
   stakes(limit: $limit, sortBy: $sort_by, query: $query) {
     pk
     balance


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/849

* rename gql schema objects to work with the frontend