### PR TITLE
Integrate snarks to fe

### DIFF
--- a/rust/src/web/graphql/snarks/mod.rs
+++ b/rust/src/web/graphql/snarks/mod.rs
@@ -15,6 +15,12 @@ use std::sync::Arc;
 pub struct Snark {
     pub fee: u64,
     pub prover: String,
+    pub block: SnarkBlock,
+}
+
+#[derive(SimpleObject, Debug)]
+pub struct SnarkBlock {
+    pub state_hash: String,
 }
 
 #[derive(SimpleObject, Debug)]
@@ -24,7 +30,7 @@ pub struct SnarkWithCanonicity {
     pub canonical: bool,
     /// Value optional block
     #[graphql(skip)]
-    pub block: PrecomputedBlock,
+    pub pcb: PrecomputedBlock,
     /// Value snark
     #[graphql(flatten)]
     pub snark: Snark,
@@ -34,15 +40,15 @@ pub struct SnarkWithCanonicity {
 impl SnarkWithCanonicity {
     /// Value state hash
     async fn state_hash(&self) -> String {
-        self.block.state_hash().0.to_owned()
+        self.pcb.state_hash().0.to_owned()
     }
     /// Value block height
     async fn block_height(&self) -> u32 {
-        self.block.blockchain_length()
+        self.pcb.blockchain_length()
     }
     /// Value date time
     async fn date_time(&self) -> String {
-        millis_to_iso_date_string(self.block.timestamp() as i64)
+        millis_to_iso_date_string(self.pcb.timestamp() as i64)
     }
 }
 
@@ -118,8 +124,8 @@ impl SnarkQueryRoot {
                     .into_iter()
                     .map(|snark| SnarkWithCanonicity {
                         canonical,
-                        block: block.clone(),
-                        snark: snark.into(),
+                        pcb: block.clone(),
+                        snark: (snark, state_hash).into(),
                     })
                     .collect()
             });
@@ -149,7 +155,7 @@ fn snark_summary_matches_query(
         .get_block(&snark.state_hash.clone().into())?
         .and_then(|block| {
             let snark_with_canonicity = SnarkWithCanonicity {
-                block,
+                pcb: block,
                 canonical,
                 snark: snark.into(),
             };
@@ -164,11 +170,14 @@ fn snark_summary_matches_query(
         }))
 }
 
-impl From<SnarkWorkSummary> for Snark {
-    fn from(snark: SnarkWorkSummary) -> Self {
+impl From<(SnarkWorkSummary, String)> for Snark {
+    fn from(snark: (SnarkWorkSummary, String)) -> Self {
         Snark {
-            fee: snark.fee,
-            prover: snark.prover.0,
+            fee: snark.0.fee,
+            prover: snark.0.prover.0,
+            block: SnarkBlock {
+                state_hash: snark.1,
+            },
         }
     }
 }
@@ -178,6 +187,9 @@ impl From<SnarkWorkSummaryWithStateHash> for Snark {
         Snark {
             fee: snark.fee,
             prover: snark.prover.0,
+            block: SnarkBlock {
+                state_hash: snark.state_hash.clone(),
+            },
         }
     }
 }
@@ -194,11 +206,11 @@ impl SnarkQueryInput {
         } = self;
 
         if let Some(state_hash) = state_hash {
-            matches &= snark.block.state_hash().0 == *state_hash;
+            matches &= snark.pcb.state_hash().0 == *state_hash;
         }
         if let Some(prover) = prover {
             matches &= snark
-                .block
+                .pcb
                 .prover_keys()
                 .contains(&<String as Into<PublicKey>>::into(prover.clone()));
         }

--- a/rust/src/web/graphql/snarks/mod.rs
+++ b/rust/src/web/graphql/snarks/mod.rs
@@ -112,6 +112,7 @@ impl SnarkQueryRoot {
             SnarkSortByInput::BlockHeightAsc => speedb::IteratorMode::Start,
             SnarkSortByInput::BlockHeightDesc => speedb::IteratorMode::End,
         };
+        let mut capacity_reached = false;
         for entry in blocks_global_slot_idx_iterator(db, mode) {
             let state_hash = blocks_global_slot_idx_state_hash_from_entry(&entry)?;
             let block = db
@@ -125,7 +126,7 @@ impl SnarkQueryRoot {
                     .map(|snark| SnarkWithCanonicity {
                         canonical,
                         pcb: block.clone(),
-                        snark: (snark, state_hash).into(),
+                        snark: (snark, state_hash.clone()).into(),
                     })
                     .collect()
             });
@@ -136,11 +137,14 @@ impl SnarkQueryRoot {
                 }
 
                 if snarks.len() == limit {
+                    capacity_reached = true;
                     break;
                 }
             }
+            if capacity_reached {
+                break;
+            }
         }
-
         Ok(snarks)
     }
 }

--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -22,6 +22,7 @@ variables {
 ```
 HTTP 200
 [Asserts]
+jsonpath "$.data.snarks" count == 10
 jsonpath "$.data.snarks[0].dateTime" == "2021-03-17T08:06:00.000Z"
 jsonpath "$.data.snarks[0].canonical" == true
 jsonpath "$.data.snarks[0].blockHeight" == 111

--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -7,6 +7,9 @@ query Snarks($limit: Int = 10, $sort_by: SnarkSortByInput!, $query: SnarkQueryIn
     prover
     fee
     dateTime
+    block {
+      stateHash
+    }
   }
 }
 variables {
@@ -24,5 +27,6 @@ jsonpath "$.data.snarks[0].canonical" == true
 jsonpath "$.data.snarks[0].blockHeight" == 111
 jsonpath "$.data.snarks[0].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"
 jsonpath "$.data.snarks[0].fee" == 0
+jsonpath "$.data.snarks[0].block.stateHash" == "3NL33j16AWm3Jhjj1Ud25E54hu7HpUq4WBQcAiijEKMfXqwFJwzK"
 
 duration < 1000


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/857
Fixes: https://github.com/Granola-Team/mina-indexer/issues/858

* bound SNARK results to limit
* support querying and returning by state_hash that is equivalent to ME