### PR TITLE
(gql) add total stake percentage to (next)stakes endpoint

### DIFF
--- a/rust/src/ledger/staking/mod.rs
+++ b/rust/src/ledger/staking/mod.rs
@@ -20,6 +20,7 @@ pub struct StakingLedger {
     pub epoch: u32,
     pub network: Network,
     pub ledger_hash: LedgerHash,
+    pub total_currency: u64,
     pub staking_ledger: HashMap<PublicKey, StakingAccount>,
 }
 
@@ -159,15 +160,18 @@ impl StakingLedger {
 
         let bytes = std::fs::read(path)?;
         let staking_ledger: Vec<StakingAccountJson> = serde_json::from_slice(&bytes)?;
-        let staking_ledger = staking_ledger
+        let staking_ledger: HashMap<PublicKey, StakingAccount> = staking_ledger
             .into_iter()
             .map(|acct| (acct.pk.clone(), acct.into()))
             .collect();
         let (network, epoch, ledger_hash) = split_ledger_path(path);
 
+        let total_currency: u64 = staking_ledger.values().map(|account| account.balance).sum();
+
         Ok(Self {
             epoch,
             network,
+            total_currency,
             ledger_hash,
             staking_ledger,
         })

--- a/rust/src/web/graphql/next_stakes/mod.rs
+++ b/rust/src/web/graphql/next_stakes/mod.rs
@@ -59,7 +59,7 @@ impl NextStakesQueryRoot {
 
         // Delegations will be present if the staking ledger is
         let delegations = db.get_delegations_epoch(&network, epoch)?.unwrap();
-
+        let total_currency = staking_ledger.total_currency;
         let ledger_hash = staking_ledger.ledger_hash.clone().0;
         let mut accounts: Vec<NextStakesLedgerAccountWithMeta> = staking_ledger
             .staking_ledger
@@ -113,6 +113,7 @@ impl NextStakesQueryRoot {
                     ledger_hash: ledger_hash.clone(),
                     account: StakesLedgerAccount::from(account),
                     next_delegation_totals: StakesDelegationTotals {
+                        total_currency,
                         total_delegated,
                         total_delegated_nanomina,
                         count_delegates,

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -78,3 +78,18 @@ jsonpath "$.data.stakes[0].timing.cliff_time" == 345600
 jsonpath "$.data.stakes[0].timing.initial_minimum_balance" == 1000000000
 jsonpath "$.data.stakes[0].timing.vesting_increment" == 0
 jsonpath "$.data.stakes[0].timing.vesting_period" == 1
+
+POST {{url}}
+```graphql
+{
+  stakes(query: {epoch: 42, public_key: "B62qptmpH9PVe76ZEfS1NWVV27XjZJEJyr8mWZFjfohxppmS11DfKFG"} limit: 1) {
+    delegationTotals {
+      totalStakePercentage
+    }
+  }
+}
+```
+HTTP 200
+[Asserts]
+duration < 1000
+jsonpath "$.data.stakes[0].delegationTotals.totalStakePercentage" == "8.56%"


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/874

* Add `% of total stake` to GQL for stakes and next stakes