### PR TITLE
Time locked balances

### DIFF
--- a/rust/src/chain/store.rs
+++ b/rust/src/chain/store.rs
@@ -1,6 +1,6 @@
 use super::{ChainId, Network};
 
-pub trait ChainIdStore {
+pub trait ChainStore {
     /// Persists a (chain id, network) pair
     ///
     /// Error propogates from db

--- a/rust/src/ledger/genesis.rs
+++ b/rust/src/ledger/genesis.rs
@@ -26,7 +26,7 @@ pub struct GenesisAccount {
     pub balance: String,
     pub nonce: Option<u32>,
     pub delegate: Option<String>,
-    pub token: Option<u32>,
+    pub token: Option<u64>,
     pub token_permissions: Option<TokenPermissions>,
     pub receipt_chain_hash: Option<ReceiptChainHash>,
     pub voting_for: Option<String>,

--- a/rust/src/ledger/mod.rs
+++ b/rust/src/ledger/mod.rs
@@ -160,6 +160,19 @@ impl Ledger {
         Ok(())
     }
 
+    pub fn time_locked_amount(&self, curr_global_slot: u32) -> Amount {
+        Amount(
+            self.accounts
+                .values()
+                .filter_map(|acct| {
+                    acct.timing
+                        .as_ref()
+                        .map(|_| acct.current_minimum_balance(curr_global_slot))
+                })
+                .sum(),
+        )
+    }
+
     pub fn from(value: Vec<(&str, u64, Option<u32>, Option<&str>)>) -> anyhow::Result<Self> {
         let mut ledger = Ledger::new();
         for (pubkey, balance, nonce, delgation) in value {

--- a/rust/src/ledger/staking/mod.rs
+++ b/rust/src/ledger/staking/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         public_key::PublicKey,
         LedgerHash,
     },
+    mina_blocks::v2::ZkappAccount,
 };
 use log::trace;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
@@ -30,28 +31,28 @@ pub struct StakingAccount {
     pub pk: PublicKey,
     pub balance: u64,
     pub delegate: PublicKey,
-    pub token: Option<u32>,
+    pub token: Option<u64>,
     pub token_permissions: TokenPermissions,
     pub receipt_chain_hash: ReceiptChainHash,
     pub voting_for: BlockHash,
     pub permissions: Permissions,
     pub nonce: Option<u32>,
     pub timing: Option<Timing>,
-    pub zkapp: Option<String>,
+    pub zkapp: Option<ZkappAccount>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StakingAccountJson {
-    pk: PublicKey,
-    balance: String,
-    delegate: PublicKey,
-    token: String,
-    token_permissions: TokenPermissions,
-    receipt_chain_hash: ReceiptChainHash,
-    voting_for: BlockHash,
-    permissions: Permissions,
-    nonce: Option<String>,
-    timing: Option<TimingJson>,
+    pub pk: PublicKey,
+    pub balance: String,
+    pub delegate: PublicKey,
+    pub token: String,
+    pub token_permissions: TokenPermissions,
+    pub receipt_chain_hash: ReceiptChainHash,
+    pub voting_for: BlockHash,
+    pub permissions: Permissions,
+    pub nonce: Option<String>,
+    pub timing: Option<TimingJson>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -166,10 +167,9 @@ impl StakingLedger {
             .into_iter()
             .map(|acct| (acct.pk.clone(), acct.into()))
             .collect();
+
         let (network, epoch, ledger_hash) = split_ledger_path(path);
-
         let total_currency: u64 = staking_ledger.values().map(|account| account.balance).sum();
-
         Ok(Self {
             epoch,
             network,

--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         Block, BlockHash, BlockWithoutHeight,
     },
     canonicity::{store::CanonicityStore, Canonicity},
-    chain::store::ChainIdStore,
+    chain::store::ChainStore,
     command::store::CommandStore,
     constants::*,
     event::{block::*, db::*, ledger::*, store::*, witness_tree::*, IndexerEvent},

--- a/rust/src/store.rs
+++ b/rust/src/store.rs
@@ -8,7 +8,7 @@ use crate::{
         BlockHash,
     },
     canonicity::{store::CanonicityStore, Canonicity},
-    chain::{store::ChainIdStore, ChainId, Network},
+    chain::{store::ChainStore, ChainId, Network},
     command::{
         internal::{InternalCommand, InternalCommandWithData},
         signed::{SignedCommand, SignedCommandWithData},
@@ -1621,7 +1621,7 @@ impl SnarkStore for IndexerStore {
     }
 }
 
-impl ChainIdStore for IndexerStore {
+impl ChainStore for IndexerStore {
     fn set_chain_id_for_network(
         &self,
         chain_id: &ChainId,

--- a/rust/src/web/graphql/accounts/mod.rs
+++ b/rust/src/web/graphql/accounts/mod.rs
@@ -2,6 +2,7 @@ use super::db;
 use crate::{
     block::store::BlockStore,
     ledger::{account, store::LedgerStore},
+    web::graphql::Timing,
 };
 use async_graphql::{Context, Enum, InputObject, Object, Result, SimpleObject};
 
@@ -13,20 +14,27 @@ pub struct Account {
     balance: u64,
     nonce: u32,
     time_locked: bool,
+    timing: Option<Timing>,
 }
 
 #[derive(InputObject)]
 pub struct AccountQueryInput {
     public_key: Option<String>,
+    // username: Option<String>,
     balance: Option<u64>,
+
     #[graphql(name = "balance_gt")]
     balance_gt: Option<u64>,
+
     #[graphql(name = "balance_gte")]
     balance_gte: Option<u64>,
+
     #[graphql(name = "balance_lt")]
     balance_lt: Option<u64>,
+
     #[graphql(name = "balance_lte")]
     balance_lte: Option<u64>,
+
     #[graphql(name = "balance_ne")]
     balance_ne: Option<u64>,
 }
@@ -63,37 +71,27 @@ impl AccountQueryRoot {
             }
         };
 
-        let mut accounts: Vec<Account> = ledger
-            .accounts
-            .into_values()
-            .filter(|account| {
-                if let Some(ref query) = query {
-                    if let Some(public_key) = &query.public_key {
-                        return *public_key == account.public_key.0;
-                    }
-                    if let Some(balance) = &query.balance {
-                        return *balance == account.balance.0;
-                    }
-                    if let Some(balance_gt) = &query.balance_gt {
-                        return *balance_gt < account.balance.0;
-                    }
-                    if let Some(balance_gte) = &query.balance_gte {
-                        return *balance_gte <= account.balance.0;
-                    }
-                    if let Some(balance_lt) = &query.balance_lt {
-                        return *balance_lt > account.balance.0;
-                    }
-                    if let Some(balance_lte) = &query.balance_lte {
-                        return *balance_lte >= account.balance.0;
-                    }
-                    if let Some(balance_ne) = &query.balance_ne {
-                        return *balance_ne != account.balance.0;
-                    }
-                }
-                true
-            })
-            .map(Account::from)
-            .collect();
+        // public key query handler
+        if let Some(public_key) = query.as_ref().and_then(|q| q.public_key.clone()) {
+            return Ok(ledger
+                .accounts
+                .get(&public_key.into())
+                .filter(|acct| query.unwrap().matches(acct))
+                .map(|acct| vec![Account::from(acct.clone())]));
+        }
+
+        // TODO default query handler sort balance-sorted accounts
+        let mut accounts: Vec<Account> = if let Some(query) = query {
+            ledger
+                .accounts
+                .into_values()
+                .filter(|account| query.matches(account))
+                .map(Account::from)
+                .collect()
+        } else {
+            ledger.accounts.into_values().map(Account::from).collect()
+        };
+
         if let Some(sort_by) = sort_by {
             match sort_by {
                 AccountSortByInput::BalanceDesc => {
@@ -110,15 +108,71 @@ impl AccountQueryRoot {
     }
 }
 
+impl AccountQueryInput {
+    fn matches(&self, account: &account::Account) -> bool {
+        let AccountQueryInput {
+            public_key,
+            // username,
+            balance,
+            balance_gt,
+            balance_gte,
+            balance_lt,
+            balance_lte,
+            balance_ne,
+        } = self;
+        if let Some(public_key) = public_key {
+            return *public_key == account.public_key.0;
+        }
+        // if let Some(username) = username {
+        //     return account
+        //         .username
+        //         .as_ref()
+        //         .map_or(false, |u| *username == u.0);
+        // }
+        if let Some(balance) = balance {
+            return *balance == account.balance.0;
+        }
+        if let Some(balance_gt) = balance_gt {
+            return *balance_gt < account.balance.0;
+        }
+        if let Some(balance_gte) = balance_gte {
+            return *balance_gte <= account.balance.0;
+        }
+        if let Some(balance_lt) = balance_lt {
+            return *balance_lt > account.balance.0;
+        }
+        if let Some(balance_lte) = balance_lte {
+            return *balance_lte >= account.balance.0;
+        }
+        if let Some(balance_ne) = balance_ne {
+            return *balance_ne != account.balance.0;
+        }
+        true
+    }
+}
+
 impl From<account::Account> for Account {
-    fn from(ledger: account::Account) -> Self {
-        Account {
-            public_key: ledger.public_key.0,
-            delegate: ledger.delegate.0,
-            nonce: ledger.nonce.0,
-            balance: ledger.balance.0,
-            time_locked: ledger.timing.is_some(),
-            username: ledger.username.map(|u| u.0),
+    fn from(account: account::Account) -> Self {
+        Self {
+            public_key: account.public_key.0,
+            delegate: account.delegate.0,
+            nonce: account.nonce.0,
+            balance: account.balance.0,
+            time_locked: account.timing.is_some(),
+            timing: account.timing.map(|t| t.into()),
+            username: account.username.map(|u| u.0),
+        }
+    }
+}
+
+impl From<account::Timing> for Timing {
+    fn from(timing: account::Timing) -> Self {
+        Self {
+            initial_minimum_balance: Some(timing.initial_minimum_balance),
+            cliff_time: Some(timing.cliff_time),
+            cliff_amount: Some(timing.cliff_amount),
+            vesting_period: Some(timing.vesting_period),
+            vesting_increment: Some(timing.vesting_increment),
         }
     }
 }

--- a/rust/src/web/graphql/mod.rs
+++ b/rust/src/web/graphql/mod.rs
@@ -27,6 +27,24 @@ pub struct Root(
     snarks::SnarkQueryRoot,
 );
 
+#[derive(SimpleObject)]
+pub struct Timing {
+    #[graphql(name = "cliff_amount")]
+    pub cliff_amount: Option<u64>,
+
+    #[graphql(name = "cliff_time")]
+    pub cliff_time: Option<u32>,
+
+    #[graphql(name = "initial_minimum_balance")]
+    pub initial_minimum_balance: Option<u64>,
+
+    #[graphql(name = "vesting_period")]
+    pub vesting_period: Option<u32>,
+
+    #[graphql(name = "vesting_increment")]
+    pub vesting_increment: Option<u64>,
+}
+
 /// Build schema for all endpoints
 pub fn build_schema(store: Arc<IndexerStore>) -> Schema<Root, EmptyMutation, EmptySubscription> {
     Schema::build(Root::default(), EmptyMutation, EmptySubscription)

--- a/rust/src/web/graphql/next_stakes/mod.rs
+++ b/rust/src/web/graphql/next_stakes/mod.rs
@@ -3,7 +3,10 @@ use crate::{
     block::store::BlockStore,
     constants::*,
     ledger::store::LedgerStore,
-    web::graphql::stakes::{StakesDelegationTotals, StakesLedgerAccount, StakesTiming},
+    web::graphql::{
+        stakes::{StakesDelegationTotals, StakesLedgerAccount},
+        Timing,
+    },
 };
 use async_graphql::{Context, Enum, InputObject, Object, Result, SimpleObject};
 use rust_decimal::{prelude::ToPrimitive, Decimal};
@@ -99,7 +102,7 @@ impl NextStakesQueryRoot {
                 decimal.set_scale(9).ok();
 
                 let total_delegated = decimal.to_f64().unwrap_or_default();
-                let timing = account.timing.as_ref().map(|timing| StakesTiming {
+                let timing = account.timing.as_ref().map(|timing| Timing {
                     cliff_amount: Some(timing.cliff_amount),
                     cliff_time: Some(timing.cliff_time),
                     initial_minimum_balance: Some(timing.initial_minimum_balance),
@@ -140,13 +143,17 @@ impl NextStakesQueryRoot {
 pub struct NextStakesLedgerAccountWithMeta {
     /// Value next epoch
     epoch: u32,
+
     /// Value next ledger hash
     ledger_hash: String,
+
     /// Value delegation totals
     next_delegation_totals: StakesDelegationTotals,
+
     /// Value accounts
     #[graphql(flatten)]
     account: StakesLedgerAccount,
+
     /// Value timing
-    timing: Option<StakesTiming>,
+    timing: Option<Timing>,
 }

--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     chain::chain_id,
     constants::*,
     ledger::{staking::StakingAccount, store::LedgerStore},
+    web::graphql::Timing,
 };
 use async_graphql::{ComplexObject, Context, Enum, InputObject, Object, Result, SimpleObject};
 use rust_decimal::{prelude::ToPrimitive, Decimal};
@@ -95,7 +96,7 @@ impl StakeQueryRoot {
 
                 let total_delegated = decimal.to_f64().unwrap_or_default();
 
-                let timing = account.timing.as_ref().map(|timing| StakesTiming {
+                let timing = account.timing.as_ref().map(|timing| Timing {
                     cliff_amount: Some(timing.cliff_amount),
                     cliff_time: Some(timing.cliff_time),
                     initial_minimum_balance: Some(timing.initial_minimum_balance),
@@ -139,32 +140,41 @@ pub struct StakesLedgerAccountWithMeta {
     #[graphql(flatten)]
     account: StakesLedgerAccount,
     /// Value timing
-    timing: Option<StakesTiming>,
+    timing: Option<Timing>,
 }
 
 #[derive(SimpleObject)]
 pub struct StakesLedgerAccount {
     /// Value chainId
     pub chain_id: String,
+
     /// Value balance
     pub balance: f64,
+
     /// Value nonce
     pub nonce: u32,
+
     /// Value delegate
     pub delegate: String,
+
     /// Value epoch
     pub pk: String,
+
     /// Value public key
     #[graphql(name = "public_key")]
     pub public_key: String,
+
     /// Value token
-    pub token: u32,
+    pub token: u64,
+
     /// Value receipt chain hash
     #[graphql(name = "receipt_chain_hash")]
     pub receipt_chain_hash: String,
+
     /// Value voting for
     #[graphql(name = "voting_for")]
     pub voting_for: String,
+
     /// Value balance nanomina
     pub balance_nanomina: u64,
 }
@@ -174,10 +184,13 @@ pub struct StakesLedgerAccount {
 pub struct StakesDelegationTotals {
     /// Value total currency
     pub total_currency: u64,
+
     /// Value total delegated
     pub total_delegated: f64,
+
     /// Value total delegated in nanomina
     pub total_delegated_nanomina: u64,
+
     /// Value count delegates
     pub count_delegates: u32,
 }
@@ -196,20 +209,6 @@ impl StakesDelegationTotals {
         let rounded_ratio = ratio.round_dp(2);
         format!("{:.2}%", rounded_ratio)
     }
-}
-
-#[derive(SimpleObject)]
-pub struct StakesTiming {
-    #[graphql(name = "cliff_amount")]
-    pub cliff_amount: Option<u64>,
-    #[graphql(name = "cliff_time")]
-    pub cliff_time: Option<u64>,
-    #[graphql(name = "initial_minimum_balance")]
-    pub initial_minimum_balance: Option<u64>,
-    #[graphql(name = "vesting_increment")]
-    pub vesting_increment: Option<u64>,
-    #[graphql(name = "vesting_period")]
-    pub vesting_period: Option<u64>,
 }
 
 impl From<StakingAccount> for StakesLedgerAccount {

--- a/tests/hurl/accounts.hurl
+++ b/tests/hurl/accounts.hurl
@@ -13,8 +13,50 @@ query Accounts {
 ```
 HTTP 200
 [Asserts]
-duration < 1000
+
 jsonpath "$.data.accounts[0].publicKey" == "B62qj8KB2fk59NkV4VuoTkVXHjw8VJzC3ybKrWo7zuDC9xTiWXPygEe"
 jsonpath "$.data.accounts[0].balance" == 719020000000
 jsonpath "$.data.accounts[0].nonce" == 1
 jsonpath "$.data.accounts[0].delegate" == "B62qj8KB2fk59NkV4VuoTkVXHjw8VJzC3ybKrWo7zuDC9xTiWXPygEe"
+jsonpath "$.data.accounts[0].timeLocked" == false
+
+duration < 100
+
+POST {{url}}
+```graphql
+query Accounts {
+  accounts(query: {publicKey: "B62qoTaYnDYrtmver4jnkgJbFU6iohjtALTU4ebf4yCKrxFFHd9Dimh" }) {
+    publicKey
+    balance
+    username
+    nonce
+    delegate
+    timeLocked
+    timing {
+      initial_minimum_balance
+      cliff_time
+      cliff_amount
+      vesting_period
+      vesting_increment
+    }
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# account info
+jsonpath "$.data.accounts[0].publicKey" == "B62qoTaYnDYrtmver4jnkgJbFU6iohjtALTU4ebf4yCKrxFFHd9Dimh"
+jsonpath "$.data.accounts[0].balance" == 502777775000000
+jsonpath "$.data.accounts[0].nonce" == 0
+jsonpath "$.data.accounts[0].delegate" == "B62qj8KB2fk59NkV4VuoTkVXHjw8VJzC3ybKrWo7zuDC9xTiWXPygEe"
+
+# timing info
+jsonpath "$.data.accounts[0].timeLocked" == true
+jsonpath "$.data.accounts[0].timing.initial_minimum_balance" == 1000000000
+jsonpath "$.data.accounts[0].timing.cliff_time" == 691200
+jsonpath "$.data.accounts[0].timing.cliff_amount" == 1000000000
+jsonpath "$.data.accounts[0].timing.vesting_period" == 1
+jsonpath "$.data.accounts[0].timing.vesting_increment" == 0
+
+duration < 100

--- a/tests/regression
+++ b/tests/regression
@@ -1094,7 +1094,7 @@ test_rest_endpoints() {
     assert '5f704cc0c82e0ed70e873f0893d7e06f148524e3f0bdae2afb02e7819a0c24d1' $chain_id
 
     circulating_supply=$(cat output.json | jq -r .circulatingSupply)
-    assert '89031537.840039233' $circulating_supply
+    assert '18320777783.342609316' $circulating_supply
 
     # date_time=$(cat output.json | jq -r .dateTime)
     # assert 'Wed, 17 Mar 2021 07:15:00 GMT' $date_time
@@ -1106,7 +1106,7 @@ test_rest_endpoints() {
     assert '145' $global_slot
 
     locked_supply=$(cat output.json | jq -r .lockedSupply)
-    assert '716354155' $locked_supply
+    assert '931351983.206981533' $locked_supply
 
     min_window_density=$(cat output.json | jq -r .minWindowDensity)
     assert '77' $min_window_density


### PR DESCRIPTION
- subtract time-locked tokens from circulating supply (fixes #496)
- add timing info to GQL accounts (fixes #876)