### PR TITLE
Problem: Nix image tag uses 9 digits (1 too many)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
             name = "mina-indexer";
             created = "now";
             # This is equivalent to `git rev-parse --short HEAD`
-            tag = builtins.substring 0 9 (self.rev or "dev");
+            tag = builtins.substring 0 8 (self.rev or "dev");
             copyToRoot = pkgs.buildEnv {
               paths = with pkgs; [ mina-indexer openssl zstd bash self ];
               name = "mina-indexer-root";


### PR DESCRIPTION
Solution: Use only 8 digits in tag, consistent with output of `git rev-parse --short`.