### PR TITLE
Problem: production indexer listens only to localhost for connections

### DIFF
--- a/ops/productionize
+++ b/ops/productionize
@@ -56,6 +56,7 @@ setsid \
       --domain-socket-path "$SOCKET" \
       server start \
         --log-level DEBUG \
+        --web-hostname 0.0.0.0 \
         --genesis-ledger "$SRC"/data/genesis_ledgers/mainnet.json \
         --locked-supply-csv "$SRC"/data/locked.csv \
         --blocks-dir /mnt/mina-log-storage/mina_network_block_data \


### PR DESCRIPTION
Solution: listening to "0.0.0.0" is made explicit on production command line with this PR.

Fixes #851 