### PR TITLE
Problem: Robin can't count to 8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
             name = "mina-indexer";
             created = "now";
             # This is equivalent to `git rev-parse --short HEAD`
-            tag = builtins.substring 0 7 (self.rev or "dev");
+            tag = builtins.substring 0 8 (self.rev or "dev");
             copyToRoot = pkgs.buildEnv {
               paths = with pkgs; [ mina-indexer openssl zstd bash self ];
               name = "mina-indexer-root";


### PR DESCRIPTION
Corrects a failure in the "create OCI image" step due to the image label having 1 digit too few.