### PR TITLE
(gql) remove percent symbol from total stake weight

### DIFF
--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -22,6 +22,7 @@ pub struct StakeQueryInput {
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub enum StakeSortByInput {
     BalanceDesc,
+    StakeDesc,
 }
 
 #[derive(Default)]
@@ -122,6 +123,13 @@ impl StakeQueryRoot {
         if let Some(StakeSortByInput::BalanceDesc) = sort_by {
             accounts.sort_by(|a, b| b.account.balance_nanomina.cmp(&a.account.balance_nanomina));
         }
+        if let Some(StakeSortByInput::StakeDesc) = sort_by {
+            accounts.sort_by(|a, b| {
+                b.delegation_totals
+                    .total_delegated_nanomina
+                    .cmp(&a.delegation_totals.total_delegated_nanomina)
+            });
+        }
 
         accounts.truncate(limit);
         Ok(Some(accounts))
@@ -159,7 +167,8 @@ pub struct StakesLedgerAccount {
 
     /// Value epoch
     pub pk: String,
-
+    /// Value username
+    pub username: Option<String>,
     /// Value public key
     #[graphql(name = "public_key")]
     pub public_key: String,
@@ -207,7 +216,7 @@ impl StakesDelegationTotals {
             Decimal::ZERO
         };
         let rounded_ratio = ratio.round_dp(2);
-        format!("{:.2}%", rounded_ratio)
+        format!("{:.2}", rounded_ratio)
     }
 }
 
@@ -242,6 +251,7 @@ impl From<StakingAccount> for StakesLedgerAccount {
             receipt_chain_hash,
             voting_for,
             balance_nanomina,
+            username: None,
         }
     }
 }

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -155,5 +155,5 @@ jsonpath "$.data.stakes[2].delegationTotals.totalStakePercentage" == "3.79"
 jsonpath "$.data.stakes[3].delegationTotals.totalStakePercentage" == "3.50"
 jsonpath "$.data.stakes[4].delegationTotals.totalStakePercentage" == "3.10"
 
-duration < 800
+duration < 1200
 

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -123,6 +123,37 @@ HTTP 200
 jsonpath "$.data.stakes" count == 1
 
 # only datum
-jsonpath "$.data.stakes[0].delegationTotals.totalStakePercentage" == "8.56%"
+jsonpath "$.data.stakes[0].delegationTotals.totalStakePercentage" == "8.56"
 
 duration < 800
+
+#
+# Stakes delegation total stake percentage query sort by stakes desc
+#
+
+POST {{url}}
+```graphql
+{
+  stakes(query: {epoch: 42}, sortBy: STAKE_DESC, limit: 5) {
+    delegationTotals {
+      totalStakePercentage
+    }
+  }
+}
+```
+
+HTTP 200
+[Asserts]
+
+# total data count
+jsonpath "$.data.stakes" count == 5
+
+# only datum
+jsonpath "$.data.stakes[0].delegationTotals.totalStakePercentage" == "8.56"
+jsonpath "$.data.stakes[1].delegationTotals.totalStakePercentage" == "5.06"
+jsonpath "$.data.stakes[2].delegationTotals.totalStakePercentage" == "3.79"
+jsonpath "$.data.stakes[3].delegationTotals.totalStakePercentage" == "3.50"
+jsonpath "$.data.stakes[4].delegationTotals.totalStakePercentage" == "3.10"
+
+duration < 800
+


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/925

* Add sort_by STAKES_DESC
* Return username is None
* Remove percent symbol when returning stake weight percentage