### PR TITLE
Add regression test for blocks panic

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -174,16 +174,12 @@ impl BlocksQueryRoot {
         }
 
         // block height bounded query
-        if query
-            .as_ref()
-            .map(|q| {
-                q.block_height_gt.is_some()
-                    || q.block_height_gte.is_some()
-                    || q.block_height_lt.is_some()
-                    || q.block_height_lte.is_some()
-            })
-            .unwrap()
-        {
+        if query.as_ref().map_or(false, |q| {
+            q.block_height_gt.is_some()
+                || q.block_height_gte.is_some()
+                || q.block_height_lt.is_some()
+                || q.block_height_lte.is_some()
+        }) {
             let (min, max) = match query.as_ref() {
                 Some(block_query_input) => {
                     let BlockQueryInput {
@@ -230,16 +226,12 @@ impl BlocksQueryRoot {
         }
 
         // global slot bounded query
-        if query
-            .as_ref()
-            .map(|q| {
-                q.global_slot_gt.is_some()
-                    || q.global_slot_gte.is_some()
-                    || q.global_slot_lt.is_some()
-                    || q.global_slot_lte.is_some()
-            })
-            .unwrap()
-        {
+        if query.as_ref().map_or(false, |q| {
+            q.global_slot_gt.is_some()
+                || q.global_slot_gte.is_some()
+                || q.global_slot_lt.is_some()
+                || q.global_slot_lte.is_some()
+        }) {
             let (min, max) = match query.as_ref() {
                 Some(block_query_input) => {
                     let BlockQueryInput {

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -434,4 +434,24 @@ jsonpath "$.data.blocks[61].canonical" == true
 
 duration < 200
 
+#
+# Simple blocks query - https://github.com/Granola-Team/mina-indexer/issues/928
+#
+
+POST {{url}}
+```graphql
+{
+  blocks(limit: 10) {
+    stateHash
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# total data count
+jsonpath "$.data.blocks" count == 10
+
+duration < 200
+
 # TODO date time bounded query


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/928

* use `map_or` rather than `unwrap` on block height and global slot bounded queries