### PR TITLE
(gql) fix casing for blockHeight_lte so it works with the frontend

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -213,8 +213,7 @@ impl BlocksQueryRoot {
                 None => (1, db.get_best_block()?.unwrap().blockchain_length()),
             };
 
-            let mut block_heights: Vec<u32> = (min..=max).collect();
-            reorder_desc(&mut block_heights, sort_by);
+            let block_heights: Vec<u32> = (min..=max).collect();
 
             for height in block_heights {
                 for block in db.get_blocks_at_height(height)? {

--- a/rust/src/web/graphql/gen/mod.rs
+++ b/rust/src/web/graphql/gen/mod.rs
@@ -570,16 +570,16 @@ pub struct BlockQueryInput {
     #[graphql(name = "global_slot_since_genesis")]
     pub global_slot_since_genesis: Option<u32>,
 
-    #[graphql(name = "block_height_gt")]
+    #[graphql(name = "blockHeight_gt")]
     pub block_height_gt: Option<u32>,
 
-    #[graphql(name = "block_height_gte")]
+    #[graphql(name = "blockHeight_gte")]
     pub block_height_gte: Option<u32>,
 
-    #[graphql(name = "block_height_lt")]
+    #[graphql(name = "blockHeight_lt")]
     pub block_height_lt: Option<u32>,
 
-    #[graphql(name = "block_height_lte")]
+    #[graphql(name = "blockHeight_lte")]
     pub block_height_lte: Option<u32>,
 
     #[graphql(name = "global_slot_gt")]

--- a/tests/hurl/blocks.hurl
+++ b/tests/hurl/blocks.hurl
@@ -374,8 +374,8 @@ variables {
   "sort_by": "BLOCKHEIGHT_DESC",
   "query": {
     "canonical": true,
-    "block_height_lte": 50,
-    "block_height_gt": 10
+    "blockHeight_lte": 50,
+    "blockHeight_gt": 10
   }
 }
 ```


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/947
Fixes: https://github.com/Granola-Team/mina-indexer/issues/901
Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/667

* Correct `block_height_lte` to `blockHeight_lte`
* Remove double sorting for block height bounded queries