### PR TITLE
Add filter by `blockHeight_lte` for frontend equivalence

### DIFF
--- a/rust/src/web/graphql/feetransfers/mod.rs
+++ b/rust/src/web/graphql/feetransfers/mod.rs
@@ -91,25 +91,21 @@ impl FeetransferQueryRoot {
         #[graphql(default = 100)] limit: usize,
     ) -> Result<Vec<FeetransferWithMeta>> {
         let db = db(ctx);
-        let has_state_hash = query
+
+        //state_hash
+        if let Some(state_hash) = query
             .as_ref()
             .and_then(|f| f.block_state_hash.as_ref())
-            .map_or(false, |q| q.state_hash.is_some());
-
-        if has_state_hash {
-            let state_hash = query
-                .as_ref()
-                .and_then(|b| b.block_state_hash.as_ref())
-                .and_then(|q| q.state_hash.as_ref())
-                .map_or(MAINNET_GENESIS_HASH, |s| s);
-            let state_hash = BlockHash::from(state_hash);
+            .and_then(|f| f.state_hash.clone())
+        {
             return Ok(get_fee_transfers_for_state_hash(
                 db,
-                &state_hash,
+                &state_hash.into(),
                 sort_by,
                 limit,
             ));
         }
+
         // recipient
         if let Some(recipient) = query.as_ref().and_then(|q| q.recipient.clone()) {
             let mut fee_transfers: Vec<FeetransferWithMeta> = db

--- a/tests/hurl/feetransfers.hurl
+++ b/tests/hurl/feetransfers.hurl
@@ -78,3 +78,40 @@ jsonpath "$.data.feetransfers[0].blockStateHash.stateHash" == "3NLNyQC4XgQX2Q9H7
 jsonpath "$.data.feetransfers[0].blockStateHash.total_num_blocks" == 204
 
 duration < 500
+
+POST {{url}}
+```graphql
+query InternalCommandsQuery(
+  $sort_by: FeetransferSortByInput!
+  $limit: Int = 10
+  $query: FeetransferQueryInput!
+) {
+  feetransfers(sortBy: $sort_by, limit: $limit, query: $query) {
+    blockHeight
+    blockStateHash {
+      stateHash
+    }
+    fee
+    recipient
+    type
+    dateTime
+    canonical
+  }
+}
+
+variables {
+  "sort_by": "BLOCKHEIGHT_DESC",
+  "limit": 100,
+  "query": {
+    "canonical": true,
+    "blockHeight_lte": 120
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+jsonpath "$.data.feetransfers" count == 100
+
+jsonpath "$.data.feetransfers[0].blockHeight" == 120
+jsonpath "$.data.feetransfers[99].blockHeight" == 71


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/684

* Add filter by `blockHeight_lte` for frontend equivalence
* Improve feetransfer logic for filtering by `state_hash`