### PR TITLE
Force one-at-a-time concurrency for tier-2 CI

### DIFF
--- a/ops/buildkite/tier2-pipeline.yaml
+++ b/ops/buildkite/tier2-pipeline.yaml
@@ -2,6 +2,8 @@ steps:
 - label: "Tier 2 Testing"
   if: build.branch == "main"
   key: "tier2"
+  concurrency: 1
+  concurrency_group: "tier2"
   timeout_in_minutes: 2880
   agents:
     mina-log-storage: true


### PR DESCRIPTION
Force one-at-a-time concurrency for tier-2 CI

Problem: multiple tier-2 tests, which take 15 hours to run, may run
concurrently. We want only 1 concurrent run, due to the high load.

Solution: use Buildkite's concurrency control settings.
