### PR TITLE
(cli) append git commit hash to the CLI version command

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .expect("Failed to execute git command");
+    let git_commit_hash =
+        String::from_utf8(output.stdout).expect("Failed to convert git output to string");
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit_hash.trim());
+}

--- a/rust/src/bin/mina-indexer.rs
+++ b/rust/src/bin/mina-indexer.rs
@@ -15,8 +15,10 @@ use mina_indexer::{
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc};
 use stderrlog::{ColorChoice, Timestamp};
 
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_COMMIT_HASH"));
+
 #[derive(Parser, Debug)]
-#[command(name = "mina-indexer", author, version, about, long_about = Some("Mina Indexer\n\n\
+#[command(name = "mina-indexer", author, version = VERSION, about, long_about = Some("Mina Indexer\n\n\
 Efficiently index and query the Mina blockchain"))]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/971

* Append git commit hash to the CLI version command