### PR TITLE
fix(CORS): set response header `Access-Control-Allow-Origin: *`

### DIFF
--- a/rust/src/web/mod.rs
+++ b/rust/src/web/mod.rs
@@ -50,7 +50,7 @@ pub async fn start_web_server<A: net::ToSocketAddrs, P: AsRef<Path>>(
                     .guard(guard::Get())
                     .to(indexer_graphiql),
             )
-            .wrap(Cors::permissive())
+            .wrap(Cors::default().allow_any_origin().send_wildcard())
             .wrap(middleware::Logger::default())
     })
     .bind(addrs)?


### PR DESCRIPTION
Fixes Granola-Team/mina-indexer#951