### PR TITLE
(tier2) run the ingest-all script in nix

### DIFF
--- a/ops/tier2-test
+++ b/ops/tier2-test
@@ -20,4 +20,4 @@ nix develop --command tests/regression test_many_blocks
 #
 nix develop --command ops/test-justfile-targets
 
-ops/ingest-all
+nix develop --command ops/ingest-all


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/982

* Run the ingest-all script in nix when calling tier2-testing