### PR TITLE
(gql) add version resolver to return indexer version

### DIFF
--- a/rust/src/bin/mina-indexer.rs
+++ b/rust/src/bin/mina-indexer.rs
@@ -15,8 +15,6 @@ use mina_indexer::{
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc};
 use stderrlog::{ColorChoice, Timestamp};
 
-const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_COMMIT_HASH"));
-
 #[derive(Parser, Debug)]
 #[command(name = "mina-indexer", author, version = VERSION, about, long_about = Some("Mina Indexer\n\n\
 Efficiently index and query the Mina blockchain"))]

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -1,6 +1,10 @@
 use crate::ledger::account::Amount;
 use chrono::{DateTime, SecondsFormat, Utc};
 
+// version
+
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_COMMIT_HASH"));
+
 // indexer constants
 
 pub const BLOCK_REPORTING_FREQ_NUM: u32 = 1000;

--- a/rust/src/web/graphql/mod.rs
+++ b/rust/src/web/graphql/mod.rs
@@ -6,6 +6,7 @@ pub mod next_stakes;
 pub mod snarks;
 pub mod stakes;
 pub mod transactions;
+pub mod version;
 
 use super::ENDPOINT_GRAPHQL;
 use crate::{constants::*, store::IndexerStore};
@@ -25,6 +26,7 @@ pub struct Root(
     transactions::TransactionsQueryRoot,
     feetransfers::FeetransferQueryRoot,
     snarks::SnarkQueryRoot,
+    version::VersionQueryRoot,
 );
 
 #[derive(SimpleObject)]

--- a/rust/src/web/graphql/version/mod.rs
+++ b/rust/src/web/graphql/version/mod.rs
@@ -1,0 +1,12 @@
+use crate::constants;
+use async_graphql::Object;
+
+#[derive(Default)]
+pub struct VersionQueryRoot;
+
+#[Object]
+impl VersionQueryRoot {
+    async fn version(&self) -> String {
+        constants::VERSION.to_string()
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/974

* Add version GQL resolver to return the mina indexer version