### PR TITLE
Improve shutdown testing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,8 +42,8 @@ test-unit:
 test-unit-mina-rs:
   cd rust && cargo nextest run --release --features mina_rs
 
-test-regression: build
-  ./tests/regression
+test-regression subtest='': build
+  ./tests/regression {{subtest}}
 
 test-release: build
   ./tests/regression test_release

--- a/ops/buildkite/ci-pipeline.yaml
+++ b/ops/buildkite/ci-pipeline.yaml
@@ -3,7 +3,7 @@ steps:
 - label: "Developer Environment Build and Tier 1 Test"
   key: "build"
   env:
-    NOCOLOR: 1
+    NO_COLOR: 1
   command: "nix develop --command just tier1-test"
   agents:
     nix: true
@@ -17,5 +17,5 @@ steps:
     nix: true
     production: true
   env:
-    NOCOLOR: 1
+    NO_COLOR: 1
   command: "nix develop --command just productionize"

--- a/ops/buildkite/ci-pipeline.yaml
+++ b/ops/buildkite/ci-pipeline.yaml
@@ -2,6 +2,8 @@ steps:
 
 - label: "Developer Environment Build and Tier 1 Test"
   key: "build"
+  env:
+    NOCOLOR: 1
   command: "nix develop --command just tier1-test"
   agents:
     nix: true
@@ -14,4 +16,6 @@ steps:
   agents:
     nix: true
     production: true
+  env:
+    NOCOLOR: 1
   command: "nix develop --command just productionize"

--- a/ops/buildkite/tier2-pipeline.yaml
+++ b/ops/buildkite/tier2-pipeline.yaml
@@ -9,4 +9,6 @@ steps:
     nix: true
     production: false
     mina-log-storage: true
+  env:
+    NO_COLOR: 1
   command: "nix develop --command just tier2-test"

--- a/tests/regression
+++ b/tests/regression
@@ -82,7 +82,7 @@ wait_forever_for_socket() {
         if [ -S ./mina-indexer.sock ]; then
             return
         fi
-        sleep 10
+        sleep 60
     done
 }
 

--- a/tests/regression
+++ b/tests/regression
@@ -526,8 +526,7 @@ test_block_copy() {
 
     dl_mainnet 10 ./blocks
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_for_socket
 
     # start without block 11
@@ -567,8 +566,7 @@ test_missing_blocks() {
     dl_mainnet_range 12 20 ./blocks # missing 11
     dl_mainnet_range 22 30 ./blocks # missing 21
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_for_socket
 
     # start out missing block 11 & 21
@@ -767,8 +765,7 @@ test_replay() {
 
     dl_mainnet 15 ./blocks
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_for_socket
 
     assert 26 $(idxr summary --json | jq -r .blocks_processed)
@@ -898,8 +895,7 @@ test_snark_work() {
     dl_mainnet 120 ./blocks
 
     idxr_server_start_standard \
-        --canonical-threshold 5 \
-        --log-level debug
+        --canonical-threshold 5
     wait_for_socket
 
     # pk SNARK work queries
@@ -999,8 +995,7 @@ test_many_blocks() {
     stage_mainnet_blocks 1000 ./blocks
 
     idxr_server_start_standard \
-        --ledger-cadence 100 \
-        --log-level debug
+        --ledger-cadence 100
     wait_forever_for_socket
 
     # results
@@ -1038,7 +1033,6 @@ test_rest_accounts_summary() {
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database \
-        --log-level debug \
         --web-port "$port" \
         --web-hostname "0.0.0.0"
     wait_for_socket
@@ -1118,7 +1112,6 @@ test_rest_blocks() {
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database \
-        --log-level debug \
         --web-port "$port" \
         --web-hostname "0.0.0.0"
     wait_for_socket
@@ -1148,8 +1141,7 @@ test_release() {
 
     stage_mainnet_blocks 5000 ./blocks
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_forever_for_socket
 
     # results
@@ -1180,8 +1172,7 @@ test_release() {
 test_genesis_block_creator() {
     enter_test test_genesis_block_creator
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_for_socket
 
     pk=B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg
@@ -1198,8 +1189,7 @@ test_txn_nonces() {
 
     dl_mainnet 100 ./blocks
 
-    idxr_server_start_standard \
-        --log-level debug
+    idxr_server_start_standard
     wait_for_socket
 
     pk=B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy
@@ -1258,8 +1248,7 @@ test_watch_staking_ledgers() {
     enter_test test_watch_staking_ledgers
 
     idxr_server_start_standard \
-        --staking-ledger-watch-dir ./staking-ledgers \
-        --log-level debug
+        --staking-ledger-watch-dir ./staking-ledgers
     wait_for_socket
 
     # copy epoch 0 staking ledger from data to watched directory
@@ -1333,8 +1322,7 @@ test_staking_delegations() {
     idxr_server_start \
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
-        --database-dir ./database \
-        --log-level debug
+        --database-dir ./database
     wait_for_socket
 
     # check account
@@ -1553,7 +1541,6 @@ test_clean_shutdown() {
     enter_test test_clean_shutdown
 
     idxr_server_start \
-        --log-level TRACE \
         --block-watch-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database
@@ -1632,7 +1619,6 @@ test_hurl() {
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
         --database-dir ./database \
-        --log-level debug \
         --web-port "$port" \
         --web-hostname "0.0.0.0"
     wait_for_socket
@@ -1652,7 +1638,6 @@ test_hurl_tier2() {
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
         --database-dir ./database \
-        --log-level debug \
         --web-port "$port" \
         --web-hostname "0.0.0.0"
     wait_for_socket
@@ -1672,8 +1657,7 @@ test_missing_block_recovery() {
     idxr_server_start_standard \
         --missing-block-recovery-exe "$SRC"/tests/recovery.sh \
         --missing-block-recovery-delay 3 \
-        --missing-block-recovery-batch true \
-        --log-level debug
+        --missing-block-recovery-batch true
     wait_for_socket
 
     # miss blocks at heights 6, 8, 11-16, 18-20

--- a/tests/regression
+++ b/tests/regression
@@ -1716,6 +1716,7 @@ if [ "$#" -eq 0 ]; then
     test_ipc_is_available_immediately
     test_startup_dirs_get_created
     test_start_without_blocks_dir
+    test_clean_shutdown
     test_account_balance_cli
     test_account_public_key_json
     test_canonical_root
@@ -1743,8 +1744,6 @@ if [ "$#" -eq 0 ]; then
     test_internal_commands
     test_start_from_config
     test_hurl
-    # TODO: still not working
-    # test_clean_shutdown
 else
     # Run only specified tests
     for test_name in "$@"; do

--- a/tests/regression
+++ b/tests/regression
@@ -182,25 +182,6 @@ test_indexer_cli_reports() {
     # Indexer reports usage with no arguments
     ( "$IDXR" 2>&1 || true ) | grep -iq "Usage:"
 
-    # Indexer reports usage for server subcommand
-    idxr_server 2>&1 |
-        grep -iq "Usage: mina-indexer server"
-
-    # Indexer server cli subcommand works with default args
-    idxr_server --help 2>/dev/null
-
-    idxr_server start --help 2>&1 |
-        grep -iq "Usage: mina-indexer server start"
-
-    idxr_server start-via-config --help 2>&1 |
-        grep -iq "Usage: mina-indexer server start-via-config"
-
-    idxr_server sync --help 2>&1 |
-        grep -iq "Usage: mina-indexer server sync"
-
-    idxr_server replay --help 2>&1 |
-        grep -iq "Usage: mina-indexer server replay"
-
     # Indexer reports usage for client subcommands
     idxr accounts --help 2>&1 |
         grep -iq "Usage: mina-indexer accounts"

--- a/tests/regression
+++ b/tests/regression
@@ -18,7 +18,26 @@ SUMMARY_SCHEMA="$SRC"/tests/data/json-schemas/summary.json
 TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')"
 cd "$TEST_DIR"
 
+idxr() {
+    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock "$@"
+}
+
+# Performs a forcible shutdown of the Indexer, possibly returning failure.
+#
+kill_idxr() {
+    echo "Shutting down Mina Indexer."
+    idxr server shutdown
+
+    # Wait no more than 10 seconds for the process.
+    timeout 10s pwait -F ./idxr_pid ||
+        true  # Because the process may already be gone, yielding an error.
+
+    echo "Deleting PID file."
+    rm -f ./idxr_pid
+}
+
 # Invoke this function when exiting this script for any reason.
+#
 cleanup() {
     err=$?
     if [ $err != 0 ]; then
@@ -28,6 +47,7 @@ cleanup() {
     rm -rf "${TEST_DIR}"
     exit "$err"
 }
+
 trap cleanup EXIT
 
 ephemeral_port() {
@@ -66,27 +86,9 @@ wait_forever_for_socket() {
     done
 }
 
-idxr() {
-    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock "$@"
-}
-
 idxr_server() {
     idxr server "$@" &
     echo $! > ./idxr_pid
-}
-
-# Performs a forcible shutdown of the Indexer, possibly returning failure.
-#
-kill_idxr() {
-    echo "Shutting down Mina Indexer."
-    idxr server shutdown
-
-    # Wait no more than 10 seconds for the process.
-    timeout 10s pwait -F ./idxr_pid ||
-        true  # Because the process may already be gone, yielding an error.
-
-    echo "Deleting PID file."
-    rm -f ./idxr_pid
 }
 
 idxr_server_start() {
@@ -302,6 +304,7 @@ test_ipc_is_available_immediately() {
     wait_for_socket
 
     idxr summary
+
     teardown
 }
 

--- a/tests/regression
+++ b/tests/regression
@@ -71,8 +71,8 @@ idxr() {
 }
 
 idxr_server() {
-    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock server "$@" &
-    echo $! > idxr_pid
+    idxr server "$@" &
+    echo $! > ./idxr_pid
 }
 
 # Performs a forcible shutdown of the Indexer, possibly returning failure.

--- a/tests/regression
+++ b/tests/regression
@@ -776,7 +776,7 @@ test_sync() {
 
     # sync from previous indexer db
     idxr_server_sync --database-dir ./database
-    sleep 1
+    wait_for_socket
     idxr summary --verbose
 
     # post-sync results
@@ -807,7 +807,7 @@ test_replay() {
 
     # replay events from previous indexer instance & ingest the new blocks
     idxr_server_replay
-    sleep 1
+    wait_for_socket
 
     # post-replay results
     root_hash_replay=$(idxr summary --json | jq -r .witness_tree.canonical_root_hash)

--- a/tests/regression
+++ b/tests/regression
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2046,SC2086,SC2002
 
-set -x
-set -eu
-set -o pipefail
+# To debug, uncomment:
+#set -x
+
+set -euo pipefail
 
 # Collect the binaries under test and the test ledgers.
 SRC="$(CDPATH='' cd "$(dirname "$0")" && pwd)"/..
@@ -145,10 +146,10 @@ assert() {
     actual="$2"
 
     if [ "$expected" != "$actual" ]; then
-        echo "Test Failed: Expected $expected, but got $actual"
+        echo "  Test Failed: Expected $expected, but got $actual"
         exit 1
     else
-        echo "Test Passed!"
+        echo "  True: ${expected} = ${actual}"
     fi
 }
 
@@ -156,10 +157,10 @@ assert_directory_exists() {
     directory="$1"
 
     if [ ! -d "$directory" ]; then
-        echo "Test Failed: Expected directory $directory to exist, but it does not."
+        echo "  Test Failed: Expected directory $directory to exist, but it does not."
         exit 1
     else
-        echo "Test Passed: Directory $directory exists."
+        echo "  True: Directory $directory exists."
     fi
 }
 
@@ -173,7 +174,10 @@ teardown() {
 
 enter_test() {
   test_name="$1"
+  echo
   echo "Test: $1"
+  >&2 echo
+  >&2 echo "Test: $1"
 }
 
 test_indexer_cli_reports() {
@@ -540,7 +544,6 @@ test_block_copy() {
     # add block 11
     dl_mainnet_single 11 ./blocks
     sleep 1
-    ls -l ./blocks
 
     # check
     best_hash=$(idxr summary --json | jq -r .witness_tree.best_tip_hash)
@@ -1556,7 +1559,7 @@ test_clean_shutdown() {
         --database-dir ./database
     wait_for_socket
 
-    echo "Sending Mina Indexer a SIGTERM"
+    echo "  Sending Mina Indexer a SIGTERM"
     PID="$(cat ./idxr_pid)"
     kill "$PID"
 
@@ -1569,10 +1572,10 @@ test_clean_shutdown() {
 
     # Check the success of trying to kill the process with SIGTERM.
     if ps -p "$PID"; then
-        echo "PID $PID not killed."
+        echo "  PID $PID not killed."
         exit 1
     else
-        echo "PID $PID no longer present."
+        echo "  PID $PID no longer present."
     fi
 
     teardown
@@ -1777,4 +1780,5 @@ else
     done
 fi
 
-echo "Done"
+echo
+echo "Regression testing complete."

--- a/tests/regression
+++ b/tests/regression
@@ -162,13 +162,6 @@ assert_directory_exists() {
     fi
 }
 
-setup() {
-    echo "setup"
-    mkdir blocks
-    mkdir staking-ledgers
-    mkdir database
-}
-
 teardown() {
     kill_idxr
     rm -rf ./blocks
@@ -289,7 +282,6 @@ test_indexer_cli_reports() {
 test_server_startup() {
     test=test_server_startup
 
-    setup
     idxr_server_start_standard
     wait_for_socket
 
@@ -303,7 +295,6 @@ test_server_startup() {
 test_ipc_is_available_immediately() {
     test=test_ipc_is_available_immediately
 
-    setup
     dl_mainnet 100 ./blocks
 
     idxr_server_start_standard \
@@ -319,7 +310,6 @@ test_ipc_is_available_immediately() {
 test_startup_dirs_get_created() {
     test=test_startup_dirs_get_created
 
-    setup
     idxr_server_start \
         --blocks-dir ./startup-blocks \
         --block-watch-dir ./watch-blocks \
@@ -341,7 +331,6 @@ test_startup_dirs_get_created() {
 test_account_balance_cli() {
     test=test_account_balance_cli
 
-    setup
     idxr_server_start_standard
     wait_for_socket
 
@@ -355,7 +344,6 @@ test_account_balance_cli() {
 test_account_public_key_json() {
     test=test_account_public_key_json
 
-    setup
     idxr_server_start_standard
     wait_for_socket
 
@@ -369,7 +357,6 @@ test_account_public_key_json() {
 test_canonical_root() {
     test=test_canonical_root
 
-    setup
     dl_mainnet 15 ./blocks
 
     idxr_server_start_standard
@@ -391,7 +378,6 @@ test_canonical_threshold() {
     num_seq_blocks=15
     canonical_threshold=2
 
-    setup
     dl_mainnet $num_seq_blocks ./blocks
 
     idxr_server_start_standard \
@@ -411,7 +397,6 @@ test_canonical_threshold() {
 test_best_tip() {
     test=test_best_tip
 
-    setup
     dl_mainnet 15 ./blocks
 
     idxr_server_start_standard
@@ -439,7 +424,6 @@ test_best_tip() {
 test_blocks() {
     test=test_blocks
 
-    setup
     dl_mainnet 10 ./blocks
 
     idxr_server_start_standard
@@ -548,7 +532,6 @@ test_blocks() {
 test_block_copy() {
     test=test_block_copy
 
-    setup
     dl_mainnet 10 ./blocks
 
     idxr_server_start_standard \
@@ -589,7 +572,6 @@ test_block_copy() {
 test_missing_blocks() {
     test=test_missing_blocks
 
-    setup
     dl_mainnet 10 ./blocks
     dl_mainnet_range 12 20 ./blocks # missing 11
     dl_mainnet_range 22 30 ./blocks # missing 21
@@ -653,7 +635,6 @@ test_missing_blocks() {
 test_best_chain() {
     test=test_best_chain
 
-    setup
     mkdir best_chain
     dl_mainnet 12 ./blocks
 
@@ -702,7 +683,6 @@ test_best_chain() {
 test_ledgers() {
     test=test_ledgers
 
-    setup
     mkdir ledgers
     dl_mainnet 15 ./blocks
 
@@ -762,7 +742,6 @@ test_ledgers() {
 test_sync() {
     test=test_sync
 
-    setup
     dl_mainnet 15 ./blocks
 
     idxr_server_start_standard
@@ -795,7 +774,6 @@ test_sync() {
 test_replay() {
     test=test_replay
 
-    setup
     dl_mainnet 15 ./blocks
 
     idxr_server_start_standard \
@@ -829,7 +807,6 @@ test_replay() {
 test_transactions() {
     test=test_transactions
 
-    setup
     mkdir transactions
     dl_mainnet 13 ./blocks
 
@@ -926,7 +903,6 @@ test_transactions() {
 test_snark_work() {
     test=test_snark_work
 
-    setup
     mkdir snark_work
     dl_mainnet 120 ./blocks
 
@@ -986,7 +962,6 @@ test_snark_work() {
 test_checkpoint() {
     test=test_checkpoint
 
-    setup
     dl_mainnet 13 ./blocks
 
     idxr_server_start_standard
@@ -1006,7 +981,6 @@ test_checkpoint() {
     teardown
 
     # sync a new indexer from checkpointed db
-    setup
     idxr_server_sync --database-dir ./checkpoint
     wait_for_socket
 
@@ -1031,7 +1005,6 @@ test_checkpoint() {
 test_many_blocks() {
     test=test_many_blocks
 
-    setup
     stage_mainnet_blocks 1000 ./blocks
 
     idxr_server_start_standard \
@@ -1067,7 +1040,6 @@ test_many_blocks() {
 test_rest_accounts_summary() {
     test=test_rest_accounts_summary
 
-    setup
     dl_mainnet 100 ./blocks
     port=$(ephemeral_port)
 
@@ -1148,7 +1120,6 @@ test_rest_accounts_summary() {
 test_rest_blocks() {
     test=test_rest_blocks
 
-    setup
     dl_mainnet 100 ./blocks
     port=$(ephemeral_port)
 
@@ -1184,7 +1155,6 @@ test_rest_blocks() {
 test_release() {
     test=test_release
 
-    setup
     stage_mainnet_blocks 5000 ./blocks
 
     idxr_server_start_standard \
@@ -1219,7 +1189,6 @@ test_release() {
 test_genesis_block_creator() {
     test=test_genesis_block_creator
 
-    setup
     idxr_server_start_standard \
         --log-level debug
     wait_for_socket
@@ -1236,7 +1205,6 @@ test_genesis_block_creator() {
 test_txn_nonces() {
     test=test_txn_nonces
 
-    setup
     dl_mainnet 100 ./blocks
 
     idxr_server_start_standard \
@@ -1261,7 +1229,6 @@ test_txn_nonces() {
 test_startup_staking_ledgers() {
     test=test_startup_staking_ledgers
 
-    setup
     idxr_server_start \
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
@@ -1299,7 +1266,6 @@ test_startup_staking_ledgers() {
 test_watch_staking_ledgers() {
     test=test_watch_staking_ledgers
 
-    setup
     idxr_server_start_standard \
         --staking-ledger-watch-dir ./staking-ledgers \
         --log-level debug
@@ -1373,7 +1339,6 @@ test_watch_staking_ledgers() {
 test_staking_delegations() {
     test=test_staking_delegations
 
-    setup
     idxr_server_start \
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
@@ -1422,7 +1387,6 @@ test_staking_delegations() {
 test_internal_commands() {
     test=test_internal_commands
 
-    setup
     dl_mainnet 11 ./blocks
 
     idxr_server_start_standard
@@ -1487,7 +1451,6 @@ test_internal_commands() {
 test_start_from_config() {
     test=test_start_from_config
 
-    setup
     idxr_server_start_standard
     wait_for_socket
     teardown
@@ -1495,7 +1458,6 @@ test_start_from_config() {
     cp $LEDGER ./mainnet.json
     cp $LOCKED_CSV ./locked.csv
 
-    setup
     dl_mainnet 15 ./blocks
 
     port=$(ephemeral_port)
@@ -1535,7 +1497,6 @@ test_start_from_config() {
 test_start_without_blocks_dir() {
     test=test_start_without_blocks_dir
 
-    setup
     idxr_server_start \
         --block-watch-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
@@ -1558,7 +1519,6 @@ test_start_without_blocks_dir() {
 test_start_without_ledgers_dir() {
     test=test_start_without_ledgers_dir
 
-    setup
     idxr_server_start \
         --ledgers-watch-dir ./staking-ledgers \
         --database-dir ./database
@@ -1601,7 +1561,6 @@ test_start_without_ledgers_dir() {
 test_clean_shutdown() {
     test=test_clean_shutdown
 
-    setup
     idxr_server_start \
         --log-level TRACE \
         --block-watch-dir ./blocks \
@@ -1634,7 +1593,6 @@ test_clean_shutdown() {
 test_block_children() {
     test=test_block_children
 
-    setup
     dl_mainnet 10 ./blocks
 
     idxr_server_start \
@@ -1676,7 +1634,6 @@ test_block_children() {
 test_hurl() {
     test=test_hurl
 
-    setup
     dl_mainnet 120 ./blocks
     port=$(ephemeral_port)
 
@@ -1697,7 +1654,6 @@ test_hurl() {
 test_hurl_tier2() {
     test=test_hurl_tier2
 
-    setup
     dl_mainnet 120 ./blocks
     port=$(ephemeral_port)
 
@@ -1718,7 +1674,6 @@ test_hurl_tier2() {
 test_missing_block_recovery() {
     test=test_missing_block_recovery
 
-    setup
     dl_mainnet 5 ./blocks
 
     # start the indexer using the block recovery exe on path "$SRC"/tests/recovery.sh

--- a/tests/regression
+++ b/tests/regression
@@ -19,17 +19,16 @@ TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')"
 cd "$TEST_DIR"
 
 # Invoke this function when exiting this script for any reason.
-test_cleanup() {
+cleanup() {
     err=$?
     if [ $err != 0 ]; then
         echo "Test failed ($test): $err"
-        teardown
-        exit 1
+        kill_idxr || :
     fi
     rm -rf "${TEST_DIR}"
+    exit "$err"
 }
-
-trap test_cleanup EXIT
+trap cleanup EXIT
 
 ephemeral_port() {
     set +e
@@ -76,10 +75,11 @@ idxr_server() {
     echo $! > idxr_pid
 }
 
+# Performs a forcible shutdown of the Indexer, possibly returning failure.
+#
 kill_idxr() {
     echo "Shutting down Mina Indexer."
-    idxr server shutdown ||
-        true  # Because the mina-indexer may already be shut down.
+    idxr server shutdown
 
     # Wait no more than 10 seconds for the process.
     timeout 10s pwait -F ./idxr_pid ||

--- a/tests/regression
+++ b/tests/regression
@@ -41,7 +41,7 @@ kill_idxr() {
 cleanup() {
     err=$?
     if [ $err != 0 ]; then
-        echo "Test failed ($test): $err"
+        echo "Test failed ($test_name): $err"
         kill_idxr || :
     fi
     rm -rf "${TEST_DIR}"
@@ -171,8 +171,13 @@ teardown() {
     rm -f ./mina-indexer.sock
 }
 
+enter_test() {
+  test_name="$1"
+  echo "Test: $1"
+}
+
 test_indexer_cli_reports() {
-    test=test_indexer_cli_reports
+    enter_test test_indexer_cli_reports
 
     # Indexer reports usage with no arguments
     ( "$IDXR" 2>&1 || true ) | grep -iq "Usage:"
@@ -281,7 +286,7 @@ test_indexer_cli_reports() {
 
 # Indexer server starts up without any precomputed blocks
 test_server_startup() {
-    test=test_server_startup
+    enter_test test_server_startup
 
     idxr_server_start_standard
     wait_for_socket
@@ -294,7 +299,7 @@ test_server_startup() {
 
 # Indexer server ipc is available during initialization
 test_ipc_is_available_immediately() {
-    test=test_ipc_is_available_immediately
+    enter_test test_ipc_is_available_immediately
 
     dl_mainnet 100 ./blocks
 
@@ -310,7 +315,7 @@ test_ipc_is_available_immediately() {
 
 # Indexer server starts and creates directories with minimal args
 test_startup_dirs_get_created() {
-    test=test_startup_dirs_get_created
+    enter_test test_startup_dirs_get_created
 
     idxr_server_start \
         --blocks-dir ./startup-blocks \
@@ -331,7 +336,7 @@ test_startup_dirs_get_created() {
 
 # Indexer server reports correct balance for Genesis Ledger Account
 test_account_balance_cli() {
-    test=test_account_balance_cli
+    enter_test test_account_balance_cli
 
     idxr_server_start_standard
     wait_for_socket
@@ -344,7 +349,7 @@ test_account_balance_cli() {
 
 # Indexer server returns the correct account
 test_account_public_key_json() {
-    test=test_account_public_key_json
+    enter_test test_account_public_key_json
 
     idxr_server_start_standard
     wait_for_socket
@@ -357,7 +362,7 @@ test_account_public_key_json() {
 
 # Indexer summary returns the correct canonical root
 test_canonical_root() {
-    test=test_canonical_root
+    enter_test test_canonical_root
 
     dl_mainnet 15 ./blocks
 
@@ -375,7 +380,7 @@ test_canonical_root() {
 
 # Indexer server handles canonical threshold correctly
 test_canonical_threshold() {
-    test=test_canonical_threshold
+    enter_test test_canonical_threshold
 
     num_seq_blocks=15
     canonical_threshold=2
@@ -397,7 +402,7 @@ test_canonical_threshold() {
 
 # Indexer server returns the correct best tip
 test_best_tip() {
-    test=test_best_tip
+    enter_test test_best_tip
 
     dl_mainnet 15 ./blocks
 
@@ -424,7 +429,7 @@ test_best_tip() {
 
 # Indexer server returns the correct blocks for height and slot queries
 test_blocks() {
-    test=test_blocks
+    enter_test test_blocks
 
     dl_mainnet 10 ./blocks
 
@@ -532,7 +537,7 @@ test_blocks() {
 
 # Indexer handles copied blocks correctly
 test_block_copy() {
-    test=test_block_copy
+    enter_test test_block_copy
 
     dl_mainnet 10 ./blocks
 
@@ -572,7 +577,7 @@ test_block_copy() {
 
 # Indexer handles missing blocks correctly
 test_missing_blocks() {
-    test=test_missing_blocks
+    enter_test test_missing_blocks
 
     dl_mainnet 10 ./blocks
     dl_mainnet_range 12 20 ./blocks # missing 11
@@ -635,7 +640,7 @@ test_missing_blocks() {
 
 # Indexer server returns the correct best chain
 test_best_chain() {
-    test=test_best_chain
+    enter_test test_best_chain
 
     mkdir best_chain
     dl_mainnet 12 ./blocks
@@ -683,7 +688,7 @@ test_best_chain() {
 
 # Indexer server returns correct ledgers
 test_ledgers() {
-    test=test_ledgers
+    enter_test test_ledgers
 
     mkdir ledgers
     dl_mainnet 15 ./blocks
@@ -742,7 +747,7 @@ test_ledgers() {
 
 # Indexer server syncs with existing Speedb
 test_sync() {
-    test=test_sync
+    enter_test test_sync
 
     dl_mainnet 15 ./blocks
 
@@ -774,7 +779,7 @@ test_sync() {
 
 # Indexer server replays events
 test_replay() {
-    test=test_replay
+    enter_test test_replay
 
     dl_mainnet 15 ./blocks
 
@@ -807,7 +812,7 @@ test_replay() {
 
 # Indexer server returns correct transactions
 test_transactions() {
-    test=test_transactions
+    enter_test test_transactions
 
     mkdir transactions
     dl_mainnet 13 ./blocks
@@ -903,7 +908,7 @@ test_transactions() {
 
 # Indexer server returns correct SNARK work
 test_snark_work() {
-    test=test_snark_work
+    enter_test test_snark_work
 
     mkdir snark_work
     dl_mainnet 120 ./blocks
@@ -962,7 +967,7 @@ test_snark_work() {
 
 # Indexer server correctly creates a db checkpoint
 test_checkpoint() {
-    test=test_checkpoint
+    enter_test test_checkpoint
 
     dl_mainnet 13 ./blocks
 
@@ -1005,7 +1010,7 @@ test_checkpoint() {
 
 # Indexer server starts with many blocks
 test_many_blocks() {
-    test=test_many_blocks
+    enter_test test_many_blocks
 
     stage_mainnet_blocks 1000 ./blocks
 
@@ -1040,7 +1045,7 @@ test_many_blocks() {
 }
 
 test_rest_accounts_summary() {
-    test=test_rest_accounts_summary
+    enter_test test_rest_accounts_summary
 
     dl_mainnet 100 ./blocks
     port=$(ephemeral_port)
@@ -1120,7 +1125,7 @@ test_rest_accounts_summary() {
 }
 
 test_rest_blocks() {
-    test=test_rest_blocks
+    enter_test test_rest_blocks
 
     dl_mainnet 100 ./blocks
     port=$(ephemeral_port)
@@ -1155,7 +1160,7 @@ test_rest_blocks() {
 
 # Release version is fast
 test_release() {
-    test=test_release
+    enter_test test_release
 
     stage_mainnet_blocks 5000 ./blocks
 
@@ -1189,7 +1194,7 @@ test_release() {
 }
 
 test_genesis_block_creator() {
-    test=test_genesis_block_creator
+    enter_test test_genesis_block_creator
 
     idxr_server_start_standard \
         --log-level debug
@@ -1205,7 +1210,7 @@ test_genesis_block_creator() {
 }
 
 test_txn_nonces() {
-    test=test_txn_nonces
+    enter_test test_txn_nonces
 
     dl_mainnet 100 ./blocks
 
@@ -1229,7 +1234,7 @@ test_txn_nonces() {
 }
 
 test_startup_staking_ledgers() {
-    test=test_startup_staking_ledgers
+    enter_test test_startup_staking_ledgers
 
     idxr_server_start \
         --blocks-dir ./blocks \
@@ -1266,7 +1271,7 @@ test_startup_staking_ledgers() {
 }
 
 test_watch_staking_ledgers() {
-    test=test_watch_staking_ledgers
+    enter_test test_watch_staking_ledgers
 
     idxr_server_start_standard \
         --staking-ledger-watch-dir ./staking-ledgers \
@@ -1339,7 +1344,7 @@ test_watch_staking_ledgers() {
 }
 
 test_staking_delegations() {
-    test=test_staking_delegations
+    enter_test test_staking_delegations
 
     idxr_server_start \
         --blocks-dir ./blocks \
@@ -1387,7 +1392,7 @@ test_staking_delegations() {
 }
 
 test_internal_commands() {
-    test=test_internal_commands
+    enter_test test_internal_commands
 
     dl_mainnet 11 ./blocks
 
@@ -1451,7 +1456,7 @@ test_internal_commands() {
 
 # Indexer correctly starts from config
 test_start_from_config() {
-    test=test_start_from_config
+    enter_test test_start_from_config
 
     idxr_server_start_standard
     wait_for_socket
@@ -1497,7 +1502,7 @@ test_start_from_config() {
 
 # Indexer correctly starts without blocks dir
 test_start_without_blocks_dir() {
-    test=test_start_without_blocks_dir
+    enter_test test_start_without_blocks_dir
 
     idxr_server_start \
         --block-watch-dir ./blocks \
@@ -1519,7 +1524,7 @@ test_start_without_blocks_dir() {
 
 # Indexer correctly starts without staking ledgers dir
 test_start_without_ledgers_dir() {
-    test=test_start_without_ledgers_dir
+    enter_test test_start_without_ledgers_dir
 
     idxr_server_start \
         --ledgers-watch-dir ./staking-ledgers \
@@ -1561,7 +1566,7 @@ test_start_without_ledgers_dir() {
 }
 
 test_clean_shutdown() {
-    test=test_clean_shutdown
+    enter_test test_clean_shutdown
 
     idxr_server_start \
         --log-level TRACE \
@@ -1593,7 +1598,7 @@ test_clean_shutdown() {
 }
 
 test_block_children() {
-    test=test_block_children
+    enter_test test_block_children
 
     dl_mainnet 10 ./blocks
 
@@ -1634,7 +1639,7 @@ test_block_children() {
 }
 
 test_hurl() {
-    test=test_hurl
+    enter_test test_hurl
 
     dl_mainnet 120 ./blocks
     port=$(ephemeral_port)
@@ -1654,7 +1659,7 @@ test_hurl() {
 }
 
 test_hurl_tier2() {
-    test=test_hurl_tier2
+    enter_test test_hurl_tier2
 
     dl_mainnet 120 ./blocks
     port=$(ephemeral_port)
@@ -1674,7 +1679,7 @@ test_hurl_tier2() {
 }
 
 test_missing_block_recovery() {
-    test=test_missing_block_recovery
+    enter_test test_missing_block_recovery
 
     dl_mainnet 5 ./blocks
 

--- a/tests/regression
+++ b/tests/regression
@@ -16,7 +16,6 @@ SUMMARY_SCHEMA="$SRC"/tests/data/json-schemas/summary.json
 # The rest of this script's logic assumes that the testing is done from within
 # this temporary directory.
 TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')"
-DOMAIN_SOCKET_PATH="$TEST_DIR"/mina-indexer.sock
 cd "$TEST_DIR"
 
 # Invoke this function when exiting this script for any reason.
@@ -51,7 +50,7 @@ wait_for_socket() {
     # We retry 100 times before giving up because there is a good chance that
     # the machine is heavily loaded.
     while [ $num_retries -lt 100 ]; do
-        if [ -S "$DOMAIN_SOCKET_PATH" ]; then
+        if [ -S ./mina-indexer.sock ]; then
             return
         fi
         (( num_retries+=1 ))
@@ -61,7 +60,7 @@ wait_for_socket() {
 
 wait_forever_for_socket() {
     while true; do
-        if [ -S "$DOMAIN_SOCKET_PATH" ]; then
+        if [ -S ./mina-indexer.sock ]; then
             return
         fi
         sleep 10
@@ -69,11 +68,11 @@ wait_forever_for_socket() {
 }
 
 idxr() {
-    RUST_BACKTRACE=full "$IDXR" --domain-socket-path "$DOMAIN_SOCKET_PATH" "$@"
+    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock "$@"
 }
 
 idxr_server() {
-    RUST_BACKTRACE=full "$IDXR" --domain-socket-path "$DOMAIN_SOCKET_PATH" server "$@" &
+    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock server "$@" &
     echo $! > idxr_pid
 }
 
@@ -167,7 +166,7 @@ teardown() {
     rm -rf ./blocks
     rm -rf ./staking-ledgers
     rm -rf ./database
-    rm -f "$DOMAIN_SOCKET_PATH"
+    rm -f ./mina-indexer.sock
 }
 
 test_indexer_cli_reports() {

--- a/tests/regression
+++ b/tests/regression
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2046,SC2086,SC2002
 
 # To debug, uncomment:
-#set -x
+set -x
 
 set -euo pipefail
 
@@ -23,15 +23,41 @@ idxr() {
     RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock "$@"
 }
 
-# Performs a forcible shutdown of the Indexer, possibly returning failure.
+# Performs a shutdown of the Indexer, possibly returning failure.
 #
-kill_idxr() {
+shutdown_idxr() {
     echo "Shutting down Mina Indexer."
-    idxr server shutdown
 
-    # Wait no more than 10 seconds for the process.
-    timeout 10s pwait -F ./idxr_pid ||
-        true  # Because the process may already be gone, yielding an error.
+    if [ ! -S ./mina-indexer.sock ]; then
+       echo "  Missing socket. Shutdown failed."
+       return 1
+    fi
+
+    if [ ! -e ./idxr_pid ]; then
+        echo "  Missing PID file. Shutdown failed."
+        return 1
+    fi
+
+    if ! idxr server shutdown; then
+      echo "  Server shutdown command failed."
+      return 1
+    fi
+
+    # Shutdown command succeeded, but PID may still be active.
+    if ! timeout 10s pwait -F ./idxr_pid; then
+      # Either it timed out, or that PID did not exist.
+      if ps -p "$(cat ./idxr_pid)"; then
+        # The process still exists. The pwait must have timed out.
+        echo "  The shutdown command did not kill the process. Failure."
+        return 1
+      else
+        # The process does not exist. Check for socket deletion.
+        if [ -S ./mina-indexer.sock ]; then
+          echo "  The shutdown command did not delete the socket. Failure."
+          return 1
+        fi
+      fi
+    fi
 
     echo "Deleting PID file."
     rm -f ./idxr_pid
@@ -43,7 +69,12 @@ cleanup() {
     err=$?
     if [ $err != 0 ]; then
         echo "Test failed ($test_name): $err"
-        kill_idxr || :
+        if ! shutdown_idxr; then
+          # If there is a PID file, try to kill the process forcefully.
+          if [ -e ./idxr_pid ]; then
+            kill "$(cat ./idxr_pid)"
+          fi
+        fi
     fi
     rm -rf "${TEST_DIR}"
     exit "$err"
@@ -165,7 +196,7 @@ assert_directory_exists() {
 }
 
 teardown() {
-    kill_idxr
+    shutdown_idxr
     rm -rf ./blocks
     rm -rf ./staking-ledgers
     rm -rf ./database
@@ -738,7 +769,7 @@ test_sync() {
 
     idxr summary --verbose
     assert 26 $(idxr summary --json | jq -r .blocks_processed)
-    kill_idxr
+    shutdown_idxr
 
     # add more blocks to the watch dir while not indexing
     dl_mainnet_range 16 20 ./blocks
@@ -769,7 +800,7 @@ test_replay() {
     wait_for_socket
 
     assert 26 $(idxr summary --json | jq -r .blocks_processed)
-    kill_idxr
+    shutdown_idxr
 
     # add 8 more blocks to the watch dir while not indexing
     dl_mainnet_range 16 20 ./blocks
@@ -1540,30 +1571,42 @@ test_start_without_ledgers_dir() {
 test_clean_shutdown() {
     enter_test test_clean_shutdown
 
-    idxr_server_start \
-        --block-watch-dir ./blocks \
-        --staking-ledgers-dir ./staking-ledgers \
-        --database-dir ./database
+    idxr_server_start_standard
     wait_for_socket
+
+    teardown  # Calls shutdown_idxr, which checks for clean shutdown.
+}
+
+test_clean_kill() {
+    enter_test test_clean_kill
+
+    idxr_server_start_standard
+    wait_for_socket
+
+    if [ ! -e ./idxr_pid ]; then
+        echo "  Missing PID file. Cannot kill. Failure."
+        return 1
+    fi
 
     echo "  Sending Mina Indexer a SIGTERM"
     PID="$(cat ./idxr_pid)"
     kill "$PID"
 
-    # Debugging: see whether the process is still present. It often is.
-    ps -p "$PID" || true
+    # We must give the process a chance to die, with 'pwait'.
+    timeout 10s pwait -F ./idxr_pid || true
 
-    # Wait for the process, but for no more than 10 seconds.
-    timeout 10s pwait -F ./idxr_pid ||
-        true
-
-    # Check the success of trying to kill the process with SIGTERM.
+    # We waited with pwait. If the process is still there, it's a fail.
     if ps -p "$PID"; then
-        echo "  PID $PID not killed."
-        exit 1
-    else
-        echo "  PID $PID no longer present."
+        echo "  The signal did not kill the process. Failure."
+        return 1
     fi
+
+    # TODO:
+    #    # Check for socket deletion.
+    #    if [ -S ./mina-indexer.sock ]; then
+    #        echo "  The signal handler did not delete the socket. Failure."
+    #        return 1
+    #    fi
 
     teardown
 }
@@ -1690,6 +1733,7 @@ if [ "$#" -eq 0 ]; then
     test_startup_dirs_get_created
     test_start_without_blocks_dir
     test_clean_shutdown
+    test_clean_kill
     test_account_balance_cli
     test_account_public_key_json
     test_canonical_root
@@ -1755,6 +1799,7 @@ else
             "test_start_from_config") test_start_from_config ;;
             "test_hurl") test_hurl ;;
             "test_clean_shutdown") test_clean_shutdown ;;
+            "test_clean_kill") test_clean_kill ;;
             "test_release") test_release ;;
             # tier 2 tests (run via `just tier2-test`)
             "test_hurl_tier2") test_hurl_tier2 ;;

--- a/tests/stage-initial-blocks
+++ b/tests/stage-initial-blocks
@@ -15,5 +15,6 @@ OUT_DIR=$4
 
 for LENGTH in $(seq "$MIN_LENGTH" "$MAX_LENGTH")
 do
+  mkdir -p "${OUT_DIR}"
   cp "${MY_DIR}"/data/initial-blocks/"${NETWORK}"-"${LENGTH}"-*.json "${OUT_DIR}"/
 done


### PR DESCRIPTION
This attempts to improve/correct the testing logic around mina-indexer shutdown. This was prompted by intermittent failures in the regression test runs (e.g. https://buildkite.com/granola/mina-indexer-tier-1/builds/1273#018fd0f6-67b7-4e68-a1b9-3ab7685273bf), which were due either to improper shutdown or (more likely) to insufficiently short 'sleep' calls (corrected in this PR to become 'wait_for_socket' invocations).

I had to make a number of refactorings in order to see what was happening in the testing. They are included in this PR.

I was successful in making the tests error out in more frequent situations if the mina-indexer is misbehaved. However, we still do not correctly shutdown in response to a SIGINT. The proof is that the socket is not deleted after the process is gone.

The commits are individually reviewable, for ease of review.