### PR TITLE
(gql) support filtering by blockHeight_lte for SNARKs GQL

### DIFF
--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -154,5 +154,25 @@ jsonpath "$.data.snarks[63].blockHeight" == 111
 
 duration < 500
 
+#
+# SNARKs canonical block height lte
+#
+
+POST {{url}}
+```graphql
+{
+  snarks(query: {canonical: true, blockHeight_lte: 120}, limit: 1000) {
+    blockHeight
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# total data count
+jsonpath "$.data.snarks" count == 64
+
+duration < 500
+
 # TODO global slot query
 # TODO block height/global slot/date time bounded query

--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -172,6 +172,9 @@ HTTP 200
 # total data count
 jsonpath "$.data.snarks" count == 64
 
+jsonpath "$.data.snarks[0].blockHeight" == 111
+jsonpath "$.data.snarks[63].blockHeight" == 111
+
 duration < 500
 
 # TODO global slot query


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/688

* Add support for filtering by blockHeight_lte for SNARKs