### PR TITLE
(gql) fix username null issue by returning unknown

### DIFF
--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -467,7 +467,10 @@ impl StakesLedgerAccountWithMeta {
             .get_internal_commands_pk_total_count(&pk)
             .expect("pk total num internal commands");
 
-        let username = db.get_username(&pk).unwrap_or(Some("Unknown".to_string()));
+        let username = match db.get_username(&pk) {
+            Ok(None) | Err(_) => Some("Unknown".to_string()),
+            Ok(username) => username,
+        };
 
         Self {
             epoch,

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -232,13 +232,13 @@ jsonpath "$.data.stakes" count == 10
 jsonpath "$.data.stakes[0].pk" == "B62qptmpH9PVe76ZEfS1NWVV27XjZJEJyr8mWZFjfohxppmS11DfKFG"
 jsonpath "$.data.stakes[0].balance" == 83482371.13484836
 jsonpath "$.data.stakes[0].balanceNanomina" == 83482371134848360
-jsonpath "$.data.stakes[0].username" == null
+jsonpath "$.data.stakes[0].username" == "Unknown"
 
 # last datum
 jsonpath "$.data.stakes[9].pk" == "B62qq3TQ8AP7MFYPVtMx5tZGF3kWLJukfwG1A1RGvaBW1jfTPTkDBW6"
 jsonpath "$.data.stakes[9].balance" == 1104.686899999
 jsonpath "$.data.stakes[9].balanceNanomina" == 1104686899999
-jsonpath "$.data.stakes[9].username" == null
+jsonpath "$.data.stakes[9].username" == "Unknown"
 
 duration < 1000
 


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/1062

* Correctly return username "Unknown" when get_username doesn't return a value