### PR TITLE
Rename domain-socket-path CLI argument to socket

### DIFF
--- a/tests/regression
+++ b/tests/regression
@@ -20,7 +20,7 @@ TEST_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')"
 cd "$TEST_DIR"
 
 idxr() {
-    RUST_BACKTRACE=full "$IDXR" --domain-socket-path ./mina-indexer.sock "$@"
+    RUST_BACKTRACE=full "$IDXR" --socket ./mina-indexer.sock "$@"
 }
 
 # Performs a shutdown of the Indexer, possibly returning failure.


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/1010

* Rename domain-socket-path CLI argument for the server and client to socket