### PR TITLE
(chore) remove locked csv from CLI and include in binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,6 @@
             postBuild = ''
               set -ex
               mkdir -p $out/share/mina-indexer/data
-              cp ${dataDir}/locked.csv $out/share/mina-indexer/data/locked.csv
               cp -r ${dataDir}/genesis_blocks/mainnet-1-3NKeMoncuHab5ScarV5ViyF16cJPT4taWNSaTLS64Dp67wuXigPZ.json $out/share/mina-indexer/data
             '';
             doCheck = true;

--- a/ops/ingest-all
+++ b/ops/ingest-all
@@ -45,7 +45,6 @@ port="$(ephemeral_port)"
     --database-dir /mnt/mina-logs/"$VER"-database \
     --blocks-dir /mnt/mina-logs/mina_network_block_data \
     --staking-ledgers-dir /mnt/mina-logs/mina_network_ledger_data \
-    --locked-supply-csv "$src"/data/locked.csv \
     --ledger-cadence 5000 \
     > "$LOG"/out \
     2> "$LOG"/err \
@@ -73,7 +72,6 @@ wait "$PID"
     --database-dir /mnt/mina-logs/"$VER"-database \
     --blocks-dir /mnt/mina-logs/mina_network_block_data \
     --staking-ledgers-dir /mnt/mina-logs/mina_network_ledger_data \
-    --locked-supply-csv "$src"/data/locked.csv \
     --ledger-cadence 5000 \
     >> "$LOG"/out \
     2>> "$LOG"/err \

--- a/ops/productionize
+++ b/ops/productionize
@@ -87,7 +87,6 @@ setsid \
         --web-hostname 0.0.0.0 \
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
-        --locked-supply-csv ./data/locked.csv \
         --database-dir ./database \
   &
 

--- a/rust/src/web/mod.rs
+++ b/rust/src/web/mod.rs
@@ -12,10 +12,10 @@ use actix_cors::Cors;
 use actix_web::{guard, middleware, web, web::Data, App, HttpServer};
 use async_graphql_actix_web::GraphQL;
 use log::warn;
-use std::{net, path::Path, sync::Arc};
+use std::{net, sync::Arc};
 
-fn load_locked_balances<P: AsRef<Path>>(path: Option<P>) -> LockedBalances {
-    match LockedBalances::from_csv(path) {
+fn load_locked_balances() -> LockedBalances {
+    match LockedBalances::new() {
         Ok(locked_balances) => locked_balances,
         Err(e) => {
             warn!("locked supply csv ingestion failed. {}", e);
@@ -24,12 +24,11 @@ fn load_locked_balances<P: AsRef<Path>>(path: Option<P>) -> LockedBalances {
     }
 }
 
-pub async fn start_web_server<A: net::ToSocketAddrs, P: AsRef<Path>>(
+pub async fn start_web_server<A: net::ToSocketAddrs>(
     state: Arc<IndexerStore>,
     addrs: A,
-    locked_supply: Option<P>,
 ) -> std::io::Result<()> {
-    let locked = Arc::new(load_locked_balances(locked_supply));
+    let locked = Arc::new(load_locked_balances());
 
     HttpServer::new(move || {
         App::new()

--- a/rust/src/web/rest/locked_balances.rs
+++ b/rust/src/web/rest/locked_balances.rs
@@ -1,7 +1,7 @@
 use crate::ledger::account::Amount;
 use csv::Reader;
 use serde::Deserialize;
-use std::{collections::HashMap, fs::File, path::Path};
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 struct Record {
@@ -14,17 +14,18 @@ pub struct LockedBalances {
     locked: HashMap<u32, Amount>,
 }
 
+pub const LOCKED_BALANCES_CONTENTS: &str = include_str!("../../../../data/locked.csv");
+
 impl LockedBalances {
-    pub fn from_csv<P: AsRef<Path>>(path: Option<P>) -> anyhow::Result<Self> {
+    pub fn new() -> anyhow::Result<Self> {
         let mut locked = HashMap::new();
-        if let Some(path) = path {
-            let file = File::open(path)?;
-            let mut rdr = Reader::from_reader(file);
-            for result in rdr.deserialize() {
-                let record: Record = result?;
-                locked.insert(record.slot, Amount(record.locked * 1_000_000_000_u64));
-            }
+
+        let mut rdr = Reader::from_reader(LOCKED_BALANCES_CONTENTS.as_bytes());
+        for result in rdr.deserialize() {
+            let record: Record = result?;
+            locked.insert(record.slot, Amount(record.locked * 1_000_000_000_u64));
         }
+
         Ok(LockedBalances { locked })
     }
 

--- a/tests/regression
+++ b/tests/regression
@@ -10,7 +10,6 @@ set -euo pipefail
 SRC="$(CDPATH='' cd "$(dirname "$0")" && pwd)"/..
 IDXR="$SRC"/rust/target/release/mina-indexer
 STAKING_LEDGERS="$SRC"/tests/data/staking_ledgers
-LOCKED_CSV="$SRC"/data/locked.csv
 SUMMARY_SCHEMA="$SRC"/tests/data/json-schemas/summary.json
 
 # The rest of this script's logic assumes that the testing is done from within
@@ -129,7 +128,6 @@ idxr_server_start() {
 
 idxr_server_start_standard() {
     idxr_server_start \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database \
@@ -139,7 +137,6 @@ idxr_server_start_standard() {
 idxr_server_sync() {
     port=$(ephemeral_port)
     idxr_server sync --web-port "$port" \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         "$@"
@@ -148,7 +145,6 @@ idxr_server_sync() {
 idxr_server_replay() {
     port=$(ephemeral_port)
     idxr_server replay --web-port "$port" \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database
@@ -1065,7 +1061,6 @@ test_rest_accounts_summary() {
     port=$(ephemeral_port)
 
     idxr_server start \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --staking-ledgers-dir ./staking-ledgers \
         --database-dir ./database \
@@ -1258,7 +1253,6 @@ test_startup_staking_ledgers() {
     enter_test test_startup_staking_ledgers
 
     idxr_server_start \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --database-dir ./database \
         --staking-ledgers-dir $STAKING_LEDGERS
@@ -1368,7 +1362,6 @@ test_staking_delegations() {
     enter_test test_staking_delegations
 
     idxr_server_start \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --database-dir ./database \
         --staking-ledgers-dir $STAKING_LEDGERS
@@ -1483,8 +1476,6 @@ test_start_from_config() {
     wait_for_socket
     teardown
 
-    cp $LOCKED_CSV ./locked.csv
-
     dl_mainnet 15 ./blocks
 
     port=$(ephemeral_port)
@@ -1502,7 +1493,6 @@ test_start_from_config() {
       \"prune_interval\": 10,
       \"canonical_threshold\": 10,
       \"canonical_update_threshold\": 2,
-      \"locked_supply_csv\": \"./locked.csv\",
       \"web_hostname\": \"localhost\",
       \"web_port\": ${port},
       \"network\": \"mainnet\"
@@ -1669,7 +1659,6 @@ test_hurl() {
     port=$(ephemeral_port)
 
     idxr_server start \
-        --locked-supply-csv "$LOCKED_CSV" \
         --blocks-dir ./blocks \
         --staking-ledgers-dir $STAKING_LEDGERS \
         --database-dir ./database \


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/920

* Include locked.csv in the binary and remove CLI configuration