### PR TITLE
fix: increase hurl timeouts from 500 to 750

### DIFF
--- a/tests/hurl/accounts.hurl
+++ b/tests/hurl/accounts.hurl
@@ -28,7 +28,7 @@ jsonpath "$.data.accounts[0].nonce" == 1
 jsonpath "$.data.accounts[0].delegate" == "B62qj8KB2fk59NkV4VuoTkVXHjw8VJzC3ybKrWo7zuDC9xTiWXPygEe"
 jsonpath "$.data.accounts[0].timeLocked" == false
 
-duration < 500
+duration < 750
 
 #
 # Accounts public key timing query
@@ -79,7 +79,7 @@ jsonpath "$.data.accounts[0].timing.cliff_amount" == 1000000000
 jsonpath "$.data.accounts[0].timing.vesting_period" == 1
 jsonpath "$.data.accounts[0].timing.vesting_increment" == 0
 
-duration < 500
+duration < 750
 
 #
 # Accounts public key epoch & total blocks produced query
@@ -106,7 +106,7 @@ jsonpath "$.data.accounts[0].publicKey" == "B62qqE5R5pJDUjPrKZMtTkPKUPL27kwNZ1sH
 jsonpath "$.data.accounts[0].pk_epoch_num_blocks" == 5
 jsonpath "$.data.accounts[0].pk_total_num_blocks" == 5
 
-duration < 500
+duration < 750
 
 #
 # Accounts public key epoch & total snarks query
@@ -133,7 +133,7 @@ jsonpath "$.data.accounts[0].publicKey" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv
 jsonpath "$.data.accounts[0].pk_epoch_num_snarks" == 64
 jsonpath "$.data.accounts[0].pk_total_num_snarks" == 64
 
-duration < 500
+duration < 750
 
 #
 # Accounts public key epoch & total user commands query
@@ -160,7 +160,7 @@ jsonpath "$.data.accounts[0].publicKey" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqr
 jsonpath "$.data.accounts[0].pk_epoch_num_user_commands" == 294
 jsonpath "$.data.accounts[0].pk_total_num_user_commands" == 294
 
-duration < 500
+duration < 750
 
 #
 # Accounts public key epoch & total internal commands query
@@ -187,7 +187,7 @@ jsonpath "$.data.accounts[0].publicKey" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqr
 jsonpath "$.data.accounts[0].pk_epoch_num_internal_commands" == 198
 jsonpath "$.data.accounts[0].pk_total_num_internal_commands" == 198
 
-duration < 500
+duration < 750
 
 #
 # Account default (balance descending) query
@@ -239,7 +239,7 @@ jsonpath "$.data.accounts[99].timing.cliff_amount" == 1000000000
 jsonpath "$.data.accounts[99].timing.vesting_period" == 1
 jsonpath "$.data.accounts[99].timing.vesting_increment" == 0
 
-duration < 500
+duration < 750
 
 #
 # Account balance descending query
@@ -290,4 +290,4 @@ jsonpath "$.data.accounts[99].timing.cliff_amount" == 1000000000
 jsonpath "$.data.accounts[99].timing.vesting_period" == 1
 jsonpath "$.data.accounts[99].timing.vesting_increment" == 0
 
-duration < 500
+duration < 750

--- a/tests/hurl/feetransfers.hurl
+++ b/tests/hurl/feetransfers.hurl
@@ -48,7 +48,7 @@ jsonpath "$.data.feetransfers[99].blockHeight" == 71
 jsonpath "$.data.feetransfers[99].canonical" == true
 jsonpath "$.data.feetransfers[99].dateTime" == "2021-03-17T04:51:00.000Z"
 
-duration < 500
+duration < 750
 
 #
 # Fee transfers canonical state hash block height descending query
@@ -77,7 +77,7 @@ jsonpath "$.data.feetransfers[0].recipient" == "B62qjWwDxk5nGMXN32ffuMpMSp3wPa7B
 jsonpath "$.data.feetransfers[0].blockStateHash.stateHash" == "3NLNyQC4XgQX2Q9H7fC2UxFZKY4xwwUZop8jVR24SWYNNE93FsnS"
 jsonpath "$.data.feetransfers[0].blockStateHash.total_num_blocks" == 204
 
-duration < 500
+duration < 750
 
 #
 # Fee transfer block height LTE query
@@ -120,7 +120,7 @@ jsonpath "$.data.feetransfers" count == 100
 jsonpath "$.data.feetransfers[0].blockHeight" == 120
 jsonpath "$.data.feetransfers[99].blockHeight" == 71
 
-duration < 500
+duration < 750
 
 #
 # Fee transfer epoch & total internal commands query
@@ -151,7 +151,7 @@ jsonpath "$.data.feetransfers[0].blockStateHash.stateHash" == "3NLyWnjZqUECniE1q
 jsonpath "$.data.feetransfers[0].epoch_num_internal_commands" == 207
 jsonpath "$.data.feetransfers[0].total_num_internal_commands" == 207
 
-duration < 500
+duration < 750
 
 #
 # Fee transfer block state hash & block height LTE query

--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -47,7 +47,7 @@ jsonpath "$.data.snarks[9].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZ
 jsonpath "$.data.snarks[9].fee" == 0
 jsonpath "$.data.snarks[9].block.stateHash" == "3NL33j16AWm3Jhjj1Ud25E54hu7HpUq4WBQcAiijEKMfXqwFJwzK"
 
-duration < 500
+duration < 750
 
 #
 # SNARKs canonical block height query
@@ -120,7 +120,7 @@ jsonpath "$.data.snarks[0].total_num_snarks" == 64
 jsonpath "$.data.snarks[63].blockHeight" == 111
 jsonpath "$.data.snarks[63].block.stateHash" == "3NL33j16AWm3Jhjj1Ud25E54hu7HpUq4WBQcAiijEKMfXqwFJwzK"
 
-duration < 500
+duration < 750
 
 #
 # SNARKs by prover query
@@ -152,7 +152,7 @@ jsonpath "$.data.snarks[63].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15De
 jsonpath "$.data.snarks[63].canonical" == true
 jsonpath "$.data.snarks[63].blockHeight" == 111
 
-duration < 500
+duration < 750
 
 #
 # SNARKs canonical block height lte
@@ -175,7 +175,7 @@ jsonpath "$.data.snarks" count == 64
 jsonpath "$.data.snarks[0].blockHeight" == 111
 jsonpath "$.data.snarks[63].blockHeight" == 111
 
-duration < 500
+duration < 750
 
 # TODO global slot query
 # TODO block height/global slot/date time bounded query

--- a/tests/hurl/transactions.hurl
+++ b/tests/hurl/transactions.hurl
@@ -52,7 +52,7 @@ jsonpath "$.data.transactions[49].canonical" == true
 jsonpath "$.data.transactions[49].memo" == ""
 jsonpath "$.data.transactions[49].hash" == "CkpYsbai6qHEoF53e8pFHdiWqhT34sPhSgbUVdxLmfzAZ8oMpKDuK"
 
-duration < 500
+duration < 750
 
 #
 # Transactions canonical block height descending query
@@ -95,7 +95,7 @@ jsonpath "$.data.transactions[49].canonical" == true
 jsonpath "$.data.transactions[49].memo" == ""
 jsonpath "$.data.transactions[49].hash" == "CkpaJb8GcyrbGYjGeC7aUtwDq3m6yxXSBFhuUVy4Jm8FVvaimbioM"
 
-duration < 500
+duration < 750
 
 #
 # Transactions canonical specific block height query
@@ -155,7 +155,7 @@ jsonpath "$.data.transactions[1].to" == "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY
 jsonpath "$.data.transactions[1].amount" == 1000000000
 jsonpath "$.data.transactions[1].fee" == 10000000
 
-duration < 500
+duration < 750
 
 #
 # Transactions from (sender) query
@@ -208,7 +208,7 @@ jsonpath "$.data.transactions[49].to" == "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAno
 jsonpath "$.data.transactions[49].amount" == 1000
 jsonpath "$.data.transactions[49].fee" == 10000000
 
-duration < 500
+duration < 750
 
 #
 # Transactions to (receiver) query
@@ -261,7 +261,7 @@ jsonpath "$.data.transactions[49].to" == "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAno
 jsonpath "$.data.transactions[49].amount" == 1000
 jsonpath "$.data.transactions[49].fee" == 10000000
 
-duration < 500
+duration < 750
 
 POST {{url}}
 ```graphql
@@ -347,7 +347,7 @@ jsonpath "$.data.transactions[0].canonical" == true
 jsonpath "$.data.transactions[0].hash" == "CkpZreaWRNr1eANhVYLmi8vzRrwkoEwdNyk2FyUa7M4ZQVnA752wL"
 jsonpath "$.data.transactions[0].block.stateHash" == "3NLNyQC4XgQX2Q9H7fC2UxFZKY4xwwUZop8jVR24SWYNNE93FsnS"
 
-duration < 500
+duration < 750
 
 POST {{url}}
 ```graphql
@@ -442,4 +442,4 @@ jsonpath "$.data.transactions[3].blockHeight" == 6
 jsonpath "$.data.transactions[3].canonical" == false
 jsonpath "$.data.transactions[3].hash" == "CkpZrxGwdxH2CL8wGTF3B9BgJcc5xyfiF8iyzNvTYMALccvmNcNSN"
 
-duration < 500
+duration < 750


### PR DESCRIPTION
Fixes Granola-Team/mina-indexer#1134

This may be overkill for some but 750 ms is still pretty fast