### PR TITLE
(test) move quickcheck to be a dev dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,10 +59,10 @@ hex-literal = "0.4.1"
 chrono = "0.4.35"
 csv = "1.3.0"
 notify = "6.1.1"
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
 
 [dev-dependencies]
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 pretty_assertions = "1.4.0"
 wasm-bindgen-test = "0.3.42"
 lazy_static = "1.4.0"

--- a/rust/src/block/parser.rs
+++ b/rust/src/block/parser.rs
@@ -321,6 +321,18 @@ mod tests {
         ffi::OsString,
         path::{Path, PathBuf},
     };
+    impl Arbitrary for Network {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let idx = usize::arbitrary(g) % 4;
+            match idx {
+                0 => Network::Mainnet,
+                1 => Network::Devnet,
+                2 => Network::Testworld,
+                3 => Network::Berkeley,
+                _ => panic!("unknown network {idx}"),
+            }
+        }
+    }
 
     const FILENAMES_VALID: [&str; 23] = [
         "mainnet-113512-3NK9bewd5kDxzB5Kvyt8niqyiccbb365B2tLdEC2u9e8tG36ds5u.json",

--- a/rust/src/chain/mod.rs
+++ b/rust/src/chain/mod.rs
@@ -4,7 +4,6 @@ use crate::constants::*;
 use bincode::{Decode, Encode};
 use clap::builder::OsStr;
 use hex::ToHex;
-use quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter, Result};
 
@@ -56,19 +55,6 @@ pub enum Network {
     Devnet,
     Testworld,
     Berkeley,
-}
-
-impl Arbitrary for Network {
-    fn arbitrary(g: &mut Gen) -> Self {
-        let idx = usize::arbitrary(g) % 4;
-        match idx {
-            0 => Network::Mainnet,
-            1 => Network::Devnet,
-            2 => Network::Testworld,
-            3 => Network::Berkeley,
-            _ => panic!("unknown network {idx}"),
-        }
-    }
 }
 
 impl Network {


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/1142

* Move quickcheck to dev-dependencies