### PR TITLE
fix(gql): adjust Vec creation to avoid over allocation

### DIFF
--- a/rust/src/web/graphql/accounts/mod.rs
+++ b/rust/src/web/graphql/accounts/mod.rs
@@ -140,7 +140,7 @@ impl AccountQueryRoot {
         }
 
         // default query handler use balance-sorted accounts
-        let mut accounts: Vec<Account> = Vec::with_capacity(limit);
+        let mut accounts = Vec::new();
         let best_ledger = db.get_best_ledger()?.expect("best ledger");
         let mode = match sort_by {
             Some(AccountSortByInput::BalanceAsc) => IteratorMode::Start,

--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -203,7 +203,7 @@ impl BlocksQueryRoot {
             total_num_internal_commands,
         ];
 
-        let mut blocks: Vec<Block> = Vec::with_capacity(limit);
+        let mut blocks = Vec::new();
         let sort_by = sort_by.unwrap_or(BlockSortByInput::BlockHeightDesc);
 
         // state hash query

--- a/rust/src/web/graphql/feetransfers/mod.rs
+++ b/rust/src/web/graphql/feetransfers/mod.rs
@@ -182,7 +182,7 @@ impl FeetransferQueryRoot {
                 || q.block_height_lt.is_some()
                 || q.block_height_lte.is_some()
         }) {
-            let mut feetransfers: Vec<FeetransferWithMeta> = Vec::with_capacity(limit);
+            let mut feetransfers = Vec::new();
             let (min, max) = {
                 let FeetransferQueryInput {
                     block_height_gt,
@@ -294,7 +294,7 @@ fn get_fee_transfers(
     epoch_num_internal_commands: u32,
     total_num_internal_commands: u32,
 ) -> Result<Vec<FeetransferWithMeta>> {
-    let mut fee_transfers: Vec<FeetransferWithMeta> = Vec::with_capacity(limit);
+    let mut fee_transfers = Vec::new();
     let mode = if let Some(FeetransferSortByInput::BlockHeightAsc) = sort_by {
         speedb::IteratorMode::Start
     } else {

--- a/rust/src/web/graphql/snarks/mod.rs
+++ b/rust/src/web/graphql/snarks/mod.rs
@@ -100,7 +100,7 @@ impl SnarkQueryRoot {
         #[graphql(default = 100)] limit: usize,
     ) -> Result<Vec<SnarkWithCanonicity>> {
         let db = db(ctx);
-        let mut snarks = Vec::with_capacity(limit);
+        let mut snarks = Vec::new();
         let sort_by = sort_by.unwrap_or(SnarkSortByInput::BlockHeightDesc);
 
         // state hash
@@ -167,7 +167,7 @@ impl SnarkQueryRoot {
                 }
             };
 
-            let mut snarks = Vec::with_capacity(limit);
+            let mut snarks = Vec::new();
             for (key, snark) in db.snark_prover_iterator(mode).flatten() {
                 if key[..PublicKey::LEN] != *prover.as_bytes() {
                     return Ok(snarks);
@@ -208,7 +208,7 @@ impl SnarkQueryRoot {
                 || q.block_height_lt.is_some()
                 || q.block_height_lte.is_some()
         }) {
-            let mut snarks: Vec<SnarkWithCanonicity> = Vec::with_capacity(limit);
+            let mut snarks = Vec::new();
             let (min, max) = {
                 let SnarkQueryInput {
                     block_height_gt,

--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -104,7 +104,7 @@ impl StakeQueryRoot {
         let delegations = db.get_delegations_epoch(epoch, &None)?.unwrap();
 
         // balance- & stake-sorted queries
-        let mut accounts = <Vec<StakesLedgerAccountWithMeta>>::with_capacity(limit);
+        let mut accounts = Vec::new();
         let iter = match sort_by {
             Some(StakeSortByInput::StakeDesc) | None => {
                 db.staking_ledger_stake_iterator(IteratorMode::From(

--- a/rust/src/web/graphql/transactions/mod.rs
+++ b/rust/src/web/graphql/transactions/mod.rs
@@ -155,7 +155,7 @@ impl TransactionsQueryRoot {
             if sort_by == TransactionSortByInput::BlockHeightDesc {
                 block_heights.reverse();
             }
-            let mut transactions: Vec<Transaction> = Vec::with_capacity(limit);
+            let mut transactions = Vec::new();
 
             'outer: for height in block_heights {
                 for block in db.get_blocks_at_height(height)? {
@@ -181,7 +181,7 @@ impl TransactionsQueryRoot {
             return Ok(transactions);
         }
         // iterator mode & direction determined by desired sorting
-        let mut transactions: Vec<Transaction> = Vec::with_capacity(limit);
+        let mut transactions = Vec::new();
         let (start_slot, direction) = match sort_by {
             TransactionSortByInput::BlockHeightAsc | TransactionSortByInput::DateTimeAsc => {
                 (0, Direction::Forward)


### PR DESCRIPTION
Fixes Granola-Team/mina-indexer#1155