### PR TITLE
Correct the filter by prover sort by block height GQL query

### DIFF
--- a/rust/src/store/snark_store_impl.rs
+++ b/rust/src/store/snark_store_impl.rs
@@ -302,13 +302,14 @@ impl SnarkStore for IndexerStore {
         )?)
     }
 
-    /// `{prover}{slot}{index} -> snark`
+    /// `{prover}{height}{index} -> snark`
     /// - prover:         55 pk bytes
     /// - block height:   4 BE bytes
     /// - index:          4 BE bytes
     /// - snark:          serde_json encoded
     fn snark_prover_height_iterator<'a>(&'a self, mode: IteratorMode) -> DBIterator<'a> {
-        self.database.iterator_cf(self.snark_work_prover_cf(), mode)
+        self.database
+            .iterator_cf(self.snark_work_prover_height_cf(), mode)
     }
 
     fn get_snarks_epoch_count(&self, epoch: Option<u32>) -> anyhow::Result<u32> {

--- a/rust/src/web/graphql/snarks/mod.rs
+++ b/rust/src/web/graphql/snarks/mod.rs
@@ -167,45 +167,44 @@ impl SnarkQueryRoot {
                     speedb::IteratorMode::From(&start, speedb::Direction::Forward)
                 }
                 SnarkSortByInput::BlockHeightDesc => {
-                    let mut pk_prefix = PublicKey::PREFIX.as_bytes().to_vec();
-                    *pk_prefix.last_mut().unwrap_or(&mut 0) += 1;
                     start.append(&mut to_be_bytes(block_height_lte));
-                    start.append(&mut pk_prefix);
+                    start.append(&mut to_be_bytes(u32::MAX));
                     speedb::IteratorMode::From(&start, speedb::Direction::Reverse)
                 }
             };
 
             let mut snarks = Vec::new();
-            for (key, snark) in db.snark_prover_height_iterator(mode).flatten() {
+            // key should be typed
+            'outer: for (key, snark) in db.snark_prover_height_iterator(mode).flatten() {
+                // exit if prover isn't the same
                 if key[..PublicKey::LEN] != *prover.as_bytes() {
-                    return Ok(snarks);
+                    break;
                 }
-
                 let block_height = from_be_bytes(key[PublicKey::LEN..PublicKey::LEN + 4].to_vec());
-                let blocks_at_slot = db.get_blocks_at_slot(block_height)?;
-                let state_hash = blocks_at_slot[0].clone();
-                let canonical = get_block_canonicity(db, &state_hash.0);
-                let pcb = db
-                    .get_block(&state_hash)?
-                    .with_context(|| format!("block missing from store {state_hash}"))
-                    .expect("blocks exists");
-                let snark = serde_json::from_slice(&snark)?;
-                let sw = SnarkWithCanonicity {
-                    canonical,
-                    pcb,
-                    snark: (
-                        snark,
-                        state_hash,
-                        db.get_snarks_epoch_count(None).expect("epoch snarks count"),
-                        db.get_snarks_total_count().expect("total snarks count"),
-                    )
-                        .into(),
-                };
-                if query.as_ref().map_or(true, |q| q.matches(&sw)) {
-                    snarks.push(sw);
-
-                    if snarks.len() == limit {
-                        break;
+                let blocks_at_height = db.get_blocks_at_height(block_height)?;
+                for state_hash in blocks_at_height {
+                    let canonical = get_block_canonicity(db, &state_hash.0);
+                    let pcb = db
+                        .get_block(&state_hash)?
+                        .with_context(|| format!("block missing from store {state_hash}"))
+                        .expect("blocks exists");
+                    let snark = serde_json::from_slice(&snark)?;
+                    let sw = SnarkWithCanonicity {
+                        canonical,
+                        pcb,
+                        snark: (
+                            snark,
+                            state_hash,
+                            db.get_snarks_epoch_count(None).expect("epoch snarks count"),
+                            db.get_snarks_total_count().expect("total snarks count"),
+                        )
+                            .into(),
+                    };
+                    if query.as_ref().map_or(true, |q| q.matches(&sw)) {
+                        snarks.push(sw);
+                        if snarks.len() == limit {
+                            break 'outer;
+                        }
                     }
                 }
             }

--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -219,5 +219,41 @@ jsonpath "$.data.snarks[63].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15De
 
 duration < 4000
 
+# Test SNARKs filtered by prover and sorted by block height
+POST {{url}}
+```graphql
+query SnarksQuery($sort_by: SnarkSortByInput, $limit: Int = 10, $query: SnarkQueryInput) {
+  snarks(sortBy: $sort_by, limit: $limit, query: $query) {
+    blockHeight
+    dateTime
+    prover
+    canonical
+    block {
+      stateHash
+    }
+    fee
+  }
+}
+
+variables {
+  "sort_by": "BLOCKHEIGHT_DESC",
+  "limit": 100,
+  "query": {
+    "prover": "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h",
+    "canonical": true,
+    "blockHeight_lte": 111
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+jsonpath "$.data.snarks" count == 64
+
+jsonpath "$.data.snarks[0].blockHeight" == 111
+jsonpath "$.data.snarks[0].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"
+jsonpath "$.data.snarks[63].blockHeight" == 111
+jsonpath "$.data.snarks[63].prover" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"
+
 # TODO global slot query
 # TODO block height/global slot/date time bounded query


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/1197

* Two issues, we were using an incorrect column family for our data and we were missing some SNARKs in our iteration.
