### PR TITLE
(gql) Iterate all blocks at slot height in prover snarks GQL query

### DIFF
--- a/tests/hurl/snarks.hurl
+++ b/tests/hurl/snarks.hurl
@@ -129,7 +129,7 @@ duration < 4000
 POST {{url}}
 ```graphql
 {
-  snarks(query: {prover: "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"}, limit: 100) {
+  snarks(query: {prover: "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h", canonical: true}, limit: 100) {
     prover
     canonical
     blockHeight


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-indexer/issues/1200

* Iterate all blocks at global slot height in prover SNARKs GQL query