### PR TITLE
fix(test): fix CLI shutdown

### DIFF
--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -125,7 +125,6 @@ pub async fn start_indexer(
     )
     .await?;
 
-    subsys.on_shutdown_requested().await;
     Ok(())
 }
 

--- a/rust/src/unix_socket_server.rs
+++ b/rust/src/unix_socket_server.rs
@@ -87,7 +87,6 @@ pub async fn handle_connection(
             bail!("Unable to get a handle on indexer store...");
         };
 
-        let local_addr = &connection.local_addr()?;
         let command = parse_conn_to_cli(&connection).await?;
         let (_, mut writer) = connection.into_split();
 
@@ -978,12 +977,6 @@ pub async fn handle_connection(
                     .write_all(b"Shutting down the Mina Indexer daemon...")
                     .await?;
                 subsys.request_shutdown();
-                remove_unix_socket(
-                    local_addr
-                        .as_pathname()
-                        .expect("Unable to locate Unix domain socket file"),
-                )
-                .expect("Unix domain socket file deleted");
                 return Ok(());
             }
             ClientCli::Summary {
@@ -1242,7 +1235,7 @@ fn try_replace_old_socket(e: io::Error, unix_socket_path: &Path) -> io::Result<U
     }
 }
 
-fn remove_unix_socket(unix_socket_path: &Path) -> io::Result<()> {
+pub fn remove_unix_socket(unix_socket_path: &Path) -> io::Result<()> {
     std::fs::remove_file(unix_socket_path)?;
     debug!("Removed Unix domain socket: {:?}", unix_socket_path);
     Ok(())

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -105,7 +105,7 @@ wait_forever_for_socket() {
 }
 
 idxr_server() {
-    idxr server "$@" &
+    RUST_BACKTRACE=full "$IDXR" --socket ./mina-indexer.sock server "$@" &
     echo $! > ./idxr_pid
 }
 
@@ -1384,8 +1384,8 @@ test_clean_kill() {
         return 1
     fi
 
-    echo "  Sending Mina Indexer a SIGTERM"
     PID="$(cat ./idxr_pid)"
+    echo "  Sending Mina Indexer (PID $PID) a SIGTERM"
     kill "$PID"
 
     # We must give the process a chance to die cleanly.
@@ -1402,12 +1402,11 @@ test_clean_kill() {
         return 1
     fi
 
-    # TODO: robinbb - this is commented out because it does not pass!
-    #    # Check for socket deletion.
-    #    if [ -S ./mina-indexer.sock ]; then
-    #        echo "  The signal handler did not delete the socket. Failure."
-    #        return 1
-    #    fi
+    # Check for socket deletion.
+    if [ -S ./mina-indexer.sock ]; then
+        echo "  The signal handler did not delete the socket. Failure."
+        return 1
+    fi
 }
 
 test_block_children() {


### PR DESCRIPTION
Fixes Granola-Team/mina-indexer#767

The wrong PID was being captured. The PID captured was for a bash process and thus the kill signal wasn't reaching the Indexer itself. 