### PR TITLE
(ingestion) fix watcher when files are hard linked for macs

### DIFF
--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -334,6 +334,7 @@ fn matches_event_kind(kind: EventKind) -> bool {
         EventKind::Modify(notify::event::ModifyKind::Data(
             notify::event::DataChange::Content
         )) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+            | EventKind::Create(notify::event::CreateKind::File)
     )
 }
 


### PR DESCRIPTION
## Describe your changes

The block and staking ledger file watcher wasn't listening on the file create event on macOS. This is the required signal when hard linking files since it never modifies the contents.

## Link issue(s) fixed

Fixes: https://github.com/Granola-Team/mina-indexer/issues/1336
Resolves: https://github.com/Granola-Team/mina-indexer/issues/1333

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
