### PR TITLE
Update account creation fee logic for CoinbaseFeeTransfers: avoid saturation subtraction

### DIFF
--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -216,9 +216,9 @@ impl AccountDiff {
                                     ) => {
                                         if let Some(fee) = cb.t.fee_transfer_receiver_balance {
                                             let fee_transfer_receiver_balance = fee.t.t.t;
-                                            if (*total_fee)
-                                                .saturating_sub(MAINNET_ACCOUNT_CREATION_FEE.0)
-                                                == fee_transfer_receiver_balance
+                                            if *total_fee >= MAINNET_ACCOUNT_CREATION_FEE.0
+                                                && (*total_fee - MAINNET_ACCOUNT_CREATION_FEE.0)
+                                                    == fee_transfer_receiver_balance
                                             {
                                                 res.push(AccountDiff::Payment(PaymentDiff {
                                                     public_key: prover.clone(),


### PR DESCRIPTION
## Describe your changes

There are subtle bugs that can come from using saturating subtraction. When checking to see if the coinbase reward recipient is a new account, do explicit bounds checking to avoid underflow errors.

## Link issue(s) fixed

Fixes: https://github.com/Granola-Team/mina-indexer/issues/1340

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have verified new and existing tests pass locally with my changes.
- [ ] I verified whether it was necessary to increment the database version.
