### PR TITLE
Represent `AccountDiffs::from_block_fees` as a `Vec<Vec<AccountDiff>>`

### DIFF
--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -72,7 +72,10 @@ impl InternalCommand {
     ///
     /// See `LedgerDiff::from_precomputed`
     pub fn from_precomputed(block: &PrecomputedBlock) -> Vec<Self> {
-        let mut account_diff_fees = AccountDiff::from_block_fees(block);
+        let mut account_diff_fees: Vec<AccountDiff> = AccountDiff::from_block_fees(block)
+            .into_iter()
+            .flatten()
+            .collect();
 
         // replace Fee_transfer with Fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(block);

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -218,22 +218,20 @@ impl AccountDiff {
 
         fee_map
             .iter()
-            .flat_map(|(prover, total_fee)| {
+            .map(|(prover, total_fee)| {
                 let mut res = vec![];
                 // No need to issue Debits and Credits if the fee is 0
                 if *total_fee > 0 {
-                    res.push(vec![
-                        AccountDiff::FeeTransfer(PaymentDiff {
-                            public_key: prover.clone(),
-                            amount: (*total_fee).into(),
-                            update_type: UpdateType::Credit,
-                        }),
-                        AccountDiff::FeeTransfer(PaymentDiff {
-                            public_key: precomputed_block.coinbase_receiver(),
-                            amount: (*total_fee).into(),
-                            update_type: UpdateType::Debit(None),
-                        }),
-                    ]);
+                    res.push(AccountDiff::FeeTransfer(PaymentDiff {
+                        public_key: prover.clone(),
+                        amount: (*total_fee).into(),
+                        update_type: UpdateType::Credit,
+                    }));
+                    res.push(AccountDiff::FeeTransfer(PaymentDiff {
+                        public_key: precomputed_block.coinbase_receiver(),
+                        amount: (*total_fee).into(),
+                        update_type: UpdateType::Debit(None),
+                    }));
 
                     // Check if the coinbase recipient account is new and deduct the account
                     // creation fee if it is
@@ -253,9 +251,9 @@ impl AccountDiff {
                                                 && (*total_fee - MAINNET_ACCOUNT_CREATION_FEE.0)
                                                     == fee_transfer_receiver_balance
                                             {
-                                                res.push(vec![AccountDiff::CreateAccount(
+                                                res.push(AccountDiff::CreateAccount(
                                                     prover.clone(),
-                                                )]);
+                                                ));
                                             }
                                         }
                                     }

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -222,15 +222,18 @@ impl AccountDiff {
                 let mut res = vec![];
                 // No need to issue Debits and Credits if the fee is 0
                 if *total_fee > 0 {
-                    res.push(vec![AccountDiff::FeeTransfer(PaymentDiff {
-                        public_key: prover.clone(),
-                        amount: (*total_fee).into(),
-                        update_type: UpdateType::Credit,
-                    }),AccountDiff::FeeTransfer(PaymentDiff {
-                        public_key: precomputed_block.coinbase_receiver(),
-                        amount: (*total_fee).into(),
-                        update_type: UpdateType::Debit(None),
-                    })]);
+                    res.push(vec![
+                        AccountDiff::FeeTransfer(PaymentDiff {
+                            public_key: prover.clone(),
+                            amount: (*total_fee).into(),
+                            update_type: UpdateType::Credit,
+                        }),
+                        AccountDiff::FeeTransfer(PaymentDiff {
+                            public_key: precomputed_block.coinbase_receiver(),
+                            amount: (*total_fee).into(),
+                            update_type: UpdateType::Debit(None),
+                        }),
+                    ]);
 
                     // Check if the coinbase recipient account is new and deduct the account
                     // creation fee if it is

--- a/rust/src/ledger/diff/mod.rs
+++ b/rust/src/ledger/diff/mod.rs
@@ -37,7 +37,10 @@ pub struct LedgerDiff {
 impl LedgerDiff {
     /// Compute a ledger diff from the given precomputed block
     pub fn from_precomputed(precomputed_block: &PrecomputedBlock) -> Self {
-        let mut account_diff_fees = AccountDiff::from_block_fees(precomputed_block);
+        let mut account_diff_fees: Vec<AccountDiff> = AccountDiff::from_block_fees(precomputed_block)
+            .into_iter()
+            .flatten()
+            .collect();
         // applied user commands
         let mut account_diff_txns: Vec<Command> = precomputed_block
             .commands()

--- a/rust/src/ledger/diff/mod.rs
+++ b/rust/src/ledger/diff/mod.rs
@@ -37,10 +37,11 @@ pub struct LedgerDiff {
 impl LedgerDiff {
     /// Compute a ledger diff from the given precomputed block
     pub fn from_precomputed(precomputed_block: &PrecomputedBlock) -> Self {
-        let mut account_diff_fees: Vec<AccountDiff> = AccountDiff::from_block_fees(precomputed_block)
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut account_diff_fees: Vec<AccountDiff> =
+            AccountDiff::from_block_fees(precomputed_block)
+                .into_iter()
+                .flatten()
+                .collect();
         // applied user commands
         let mut account_diff_txns: Vec<Command> = precomputed_block
             .commands()


### PR DESCRIPTION
## Describe your changes
All account diffs are represented as an vector of all account diffs at the top level, while each inner vector represents accounts diffs that sum to zero (debits and credits). This will greatly simplify the identification of related `AccountDiff`s downstream.

## Link issue(s) fixed
Relates to (but does not close) #1352 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
