### PR TITLE
Process transfers as debit/credit pairs in `InternalCommand::from_precomputed` function 

### DIFF
--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     ledger::{coinbase::Coinbase, diff::account::*, public_key::PublicKey},
 };
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum InternalCommandKind {
@@ -67,104 +67,92 @@ pub enum InternalCommandWithData {
     },
 }
 
+trait AccountDiffAggregator {
+    fn aggregate(&self, diff: AccountDiff) -> InternalCommand;
+    fn initialize(diff: AccountDiff) -> InternalCommand;
+}
+
 impl InternalCommand {
     /// Compute the internal commands for the given precomputed block
     ///
     /// See `LedgerDiff::from_precomputed`
     pub fn from_precomputed(block: &PrecomputedBlock) -> Vec<Self> {
-        let mut account_diff_fees: Vec<AccountDiff> = AccountDiff::from_block_fees(block)
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut all_account_diff_fees: Vec<Vec<AccountDiff>> = AccountDiff::from_block_fees(block);
 
         // replace Fee_transfer with Fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(block);
         if coinbase.has_fee_transfer() {
             let fee_transfer = coinbase.fee_transfer();
-            let idx = account_diff_fees
-                .iter()
-                .enumerate()
-                .position(|(n, diff)| match diff {
-                    AccountDiff::FeeTransfer(fee) => {
-                        *fee == fee_transfer[0]
-                            && match &account_diff_fees[n + 1] {
-                                AccountDiff::FeeTransfer(fee) => *fee == fee_transfer[1],
-                                _ => false,
-                            }
-                    }
-                    _ => false,
-                });
-            idx.iter().for_each(|i| {
-                account_diff_fees[*i] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone());
-                account_diff_fees[*i + 1] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone());
-            });
+            if let [_, _] = &all_account_diff_fees[0][..] {
+                all_account_diff_fees[0] = vec![
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
+                ]
+            }
         }
 
-        let mut internal_cmds = vec![];
-        for n in (0..account_diff_fees.len()).step_by(2) {
-            match &account_diff_fees[n] {
-                AccountDiff::FeeTransfer(f) => {
-                    let (ic_sender, ic_receiver) = if f.update_type == UpdateType::Credit {
-                        (account_diff_fees[n + 1].public_key(), f.public_key.clone())
-                    } else {
-                        (f.public_key.clone(), account_diff_fees[n + 1].public_key())
-                    };
+        let mut internal_cmds: Vec<Self> = Vec::new();
+        for account_diff_pairs in all_account_diff_fees {
+            let mut unique_fee_transfer_map: HashMap<String, usize> = HashMap::new();
+            if let [credit, debit] = &account_diff_pairs[..] {
+                // assert!(
+                //     credit.amount() - debit.amount() == 0,
+                //     "Credit/Debit pairs do no sum to zero"
+                // );
+                match (credit, debit) {
+                    (
+                        AccountDiff::FeeTransfer(fee_transfer_receiver),
+                        AccountDiff::FeeTransfer(fee_transfer_sender),
+                    ) => {
+                        let key = fee_transfer_sender.public_key.0.to_string()
+                            + &fee_transfer_receiver.public_key.0;
 
-                    // aggregate
-                    if let Some((idx, cmd)) =
-                        internal_cmds
-                            .iter()
-                            .enumerate()
-                            .find_map(|(m, cmd)| match cmd {
-                                Self::FeeTransfer {
-                                    sender,
-                                    receiver,
-                                    amount,
-                                } => {
-                                    if *sender == ic_sender && *receiver == ic_receiver {
-                                        return Some((
-                                            m,
-                                            Self::FeeTransfer {
-                                                sender: ic_sender.clone(),
-                                                receiver: ic_receiver.clone(),
-                                                amount: f.amount.0 + *amount,
-                                            },
-                                        ));
-                                    }
-                                    None
+                        if !unique_fee_transfer_map.contains_key(&key) {
+                            internal_cmds.push(Self::FeeTransfer {
+                                sender: fee_transfer_sender.public_key.clone(),
+                                receiver: fee_transfer_receiver.public_key.clone(),
+                                amount: fee_transfer_sender.amount.0,
+                            });
+                            unique_fee_transfer_map
+                                .entry(key)
+                                .or_insert(internal_cmds.len() - 1);
+                        } else {
+                            let internal_commands_i =
+                                unique_fee_transfer_map.get(&key).cloned().unwrap();
+                            if let Self::FeeTransfer {
+                                amount,
+                                sender,
+                                receiver,
+                            } = &internal_cmds[internal_commands_i]
+                            {
+                                internal_cmds[internal_commands_i] = Self::FeeTransfer {
+                                    sender: sender.clone(),
+                                    receiver: receiver.clone(),
+                                    amount: amount + fee_transfer_sender.amount.0,
                                 }
-                                _ => None,
-                            })
-                    {
-                        internal_cmds.push(cmd);
-                        internal_cmds.swap_remove(idx);
-                    } else {
-                        internal_cmds.push(Self::FeeTransfer {
-                            sender: ic_sender.clone(),
-                            receiver: ic_receiver.clone(),
-                            amount: f.amount.0,
-                        });
+                            }
+                        }
                     }
+                    (
+                        AccountDiff::FeeTransferViaCoinbase(fee_transfer_receiver),
+                        AccountDiff::FeeTransferViaCoinbase(fee_transfer_sender),
+                    ) => internal_cmds.push(Self::FeeTransferViaCoinbase {
+                        sender: fee_transfer_sender.public_key.clone(),
+                        receiver: fee_transfer_receiver.public_key.clone(),
+                        amount: fee_transfer_sender.amount.0,
+                    }),
+                    (_, _) => panic!("Unrecognized credit/debit comination"),
                 }
-                AccountDiff::FeeTransferViaCoinbase(f) => {
-                    let (sender, receiver) = if f.update_type == UpdateType::Credit {
-                        (account_diff_fees[n + 1].public_key(), f.public_key.clone())
-                    } else {
-                        (f.public_key.clone(), account_diff_fees[n + 1].public_key())
-                    };
-                    internal_cmds.push(Self::FeeTransferViaCoinbase {
-                        sender,
-                        receiver,
-                        amount: f.amount.0,
-                    });
-                }
-                AccountDiff::Coinbase(c) => internal_cmds.push(Self::Coinbase {
-                    receiver: c.public_key.clone(),
-                    amount: c.amount.0,
-                }),
-                _ => (),
+            } else if let [unbalanced_pair] = &account_diff_pairs[..] {
+                match unbalanced_pair {
+                    AccountDiff::Coinbase(coinbase) => internal_cmds.push(Self::Coinbase {
+                        receiver: coinbase.public_key.clone(),
+                        amount: coinbase.amount.0,
+                    }),
+                    _ => panic!("Unrecognized unbalanced credit/debit pair"),
+                };
+            } else {
+                panic!("Unrecognized accounting arrangement")
             }
         }
 

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -140,7 +140,11 @@ impl InternalCommand {
                         receiver: fee_transfer_receiver.public_key.clone(),
                         amount: fee_transfer_sender.amount.0,
                     }),
-                    (_, _) => panic!("Unrecognized credit/debit comination"),
+                    (_, _) => panic!(
+                        "Unrecognized credit/debit comination. Block: {:#?}, hash: {:#?}",
+                        block.blockchain_length(),
+                        block.state_hash(),
+                    ),
                 }
             } else if let [unbalanced_pair] = &account_diff_pairs[..] {
                 match unbalanced_pair {
@@ -149,18 +153,19 @@ impl InternalCommand {
                         amount: coinbase.amount.0,
                     }),
                     _ => {
-                        println!("*************************");
-                        println!(
-                            "Block: {:#?}, hash: {:#?}, {:#?}",
+                        panic!(
+                            "Unrecognized unbalanced credit/debit pair. Block: {:#?}, hash: {:#?}, {:#?}",
                             block.blockchain_length(),
                             block.state_hash(),
                             unbalanced_pair
                         );
-                        panic!("Unrecognized unbalanced credit/debit pair")
                     }
                 };
             } else {
-                panic!("Unrecognized accounting arrangement")
+                panic!(
+                    "Unrecognized accounting arrangement. {:#?}",
+                    &account_diff_pairs[..]
+                );
             }
         }
 

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -92,11 +92,9 @@ impl InternalCommand {
         }
 
         let mut internal_cmds: Vec<Self> = Vec::new();
+        let mut unique_fee_transfer_map: HashMap<String, usize> = HashMap::new();
         for account_diff_pairs in all_account_diff_fees {
-            let mut unique_fee_transfer_map: HashMap<String, usize> = HashMap::new();
             if let [credit, debit] = &account_diff_pairs[..] {
-                println!("{:#?} + {:#?}", credit.amount(), debit.amount());
-                println!("{:#?}", block.blockchain_length());
                 assert!(
                     debit.amount() + credit.amount() == 0,
                     "Credit/Debit pairs do no sum to zero"
@@ -150,7 +148,16 @@ impl InternalCommand {
                         receiver: coinbase.public_key.clone(),
                         amount: coinbase.amount.0,
                     }),
-                    _ => panic!("Unrecognized unbalanced credit/debit pair"),
+                    _ => {
+                        println!("*************************");
+                        println!(
+                            "Block: {:#?}, hash: {:#?}, {:#?}",
+                            block.blockchain_length(),
+                            block.state_hash(),
+                            unbalanced_pair
+                        );
+                        panic!("Unrecognized unbalanced credit/debit pair")
+                    }
                 };
             } else {
                 panic!("Unrecognized accounting arrangement")

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -86,7 +86,7 @@ impl InternalCommand {
             if let [_, _] = &all_account_diff_fees[0][..] {
                 all_account_diff_fees[0] = vec![
                     AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone()),
                 ]
             }
         }
@@ -95,17 +95,18 @@ impl InternalCommand {
         for account_diff_pairs in all_account_diff_fees {
             let mut unique_fee_transfer_map: HashMap<String, usize> = HashMap::new();
             if let [credit, debit] = &account_diff_pairs[..] {
-                // assert!(
-                //     credit.amount() - debit.amount() == 0,
-                //     "Credit/Debit pairs do no sum to zero"
-                // );
+                println!("{:#?} + {:#?}", credit.amount(), debit.amount());
+                println!("{:#?}", block.blockchain_length());
+                assert!(
+                    debit.amount() + credit.amount() == 0,
+                    "Credit/Debit pairs do no sum to zero"
+                );
                 match (credit, debit) {
                     (
                         AccountDiff::FeeTransfer(fee_transfer_receiver),
                         AccountDiff::FeeTransfer(fee_transfer_sender),
                     ) => {
-                        let key = fee_transfer_sender.public_key.0.to_string()
-                            + &fee_transfer_receiver.public_key.0;
+                        let key = fee_transfer_receiver.public_key.0.to_string();
 
                         if !unique_fee_transfer_map.contains_key(&key) {
                             internal_cmds.push(Self::FeeTransfer {

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -82,24 +82,6 @@ pub enum AccountDiffType {
     FeeTransferViaCoinbase,
 }
 
-pub trait Keyable {
-    fn get_key(&self) -> &'static str;
-}
-
-impl Keyable for AccountDiff {
-    fn get_key(&self) -> &'static str {
-        match self {
-            AccountDiff::Payment(_) => "Payment",
-            AccountDiff::Coinbase(_) => "Coinbase",
-            AccountDiff::FeeTransferViaCoinbase(_) => "FeeTransferViaCoinbase",
-            AccountDiff::CreateAccount(_) => "CreateAccount",
-            AccountDiff::Delegation(_) => "Delegation",
-            AccountDiff::FeeTransfer(_) => "FeeTransfer",
-            AccountDiff::FailedTransactionNonce(_) => "FailedTransactionNonce",
-        }
-    }
-}
-
 impl AccountDiff {
     pub fn from_command(command: Command) -> Vec<Self> {
         match command {

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 9;
-    pub const PATCH: u32 = 2;
+    pub const PATCH: u32 = 4;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {

--- a/tests/hurl/accounts.hurl
+++ b/tests/hurl/accounts.hurl
@@ -182,8 +182,8 @@ jsonpath "$.data.accounts" count == 1
 
 # block production info
 jsonpath "$.data.accounts[0].publicKey" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"
-jsonpath "$.data.accounts[0].pk_epoch_num_internal_commands" == 196
-jsonpath "$.data.accounts[0].pk_total_num_internal_commands" == 196
+jsonpath "$.data.accounts[0].pk_epoch_num_internal_commands" == 190
+jsonpath "$.data.accounts[0].pk_total_num_internal_commands" == 190
 
 duration < 750
 

--- a/tests/hurl/feetransfers.hurl
+++ b/tests/hurl/feetransfers.hurl
@@ -42,8 +42,8 @@ jsonpath "$.data.feetransfers[0].dateTime" == "2021-03-17T08:39:00.000Z"
 # last datum
 jsonpath "$.data.feetransfers[99].stateHash" == "3NK6gZY6xoC98wTJdmfprmfWxeEU2o1mtFgKN9vh8z27LjnowLrz"
 jsonpath "$.data.feetransfers[99].recipient" == "B62qkHM9NT3nDefqUvSMe8qnfEfeXipqkzZrvoBXpfaC9m2BdYjWVJA"
-jsonpath "$.data.feetransfers[99].fee" == 720000000000
-jsonpath "$.data.feetransfers[99].type" == "Coinbase"
+jsonpath "$.data.feetransfers[99].fee" == 10000000
+jsonpath "$.data.feetransfers[99].type" == "Fee_transfer"
 jsonpath "$.data.feetransfers[99].blockHeight" == 70
 jsonpath "$.data.feetransfers[99].canonical" == true
 jsonpath "$.data.feetransfers[99].dateTime" == "2021-03-17T04:48:00.000Z"
@@ -120,7 +120,7 @@ HTTP 200
 jsonpath "$.data.feetransfers" count == 100
 
 jsonpath "$.data.feetransfers[0].blockHeight" == 120
-jsonpath "$.data.feetransfers[99].blockHeight" == 71
+jsonpath "$.data.feetransfers[99].blockHeight" == 70
 
 duration < 2000
 

--- a/tests/hurl/feetransfers.hurl
+++ b/tests/hurl/feetransfers.hurl
@@ -40,13 +40,13 @@ jsonpath "$.data.feetransfers[0].canonical" == true
 jsonpath "$.data.feetransfers[0].dateTime" == "2021-03-17T08:39:00.000Z"
 
 # last datum
-jsonpath "$.data.feetransfers[99].stateHash" == "3NKKJqqZovA2TnivikmkZjMtgcewSPBkXsJz5UqvwrFttMhRsztJ"
-jsonpath "$.data.feetransfers[99].recipient" == "B62qrdhG66vK71Jbdz6Xs7cnDxQ8f6jZUFvefkp3pje4EejYUTvotGP"
-jsonpath "$.data.feetransfers[99].fee" == 1440000000000
+jsonpath "$.data.feetransfers[99].stateHash" == "3NK6gZY6xoC98wTJdmfprmfWxeEU2o1mtFgKN9vh8z27LjnowLrz"
+jsonpath "$.data.feetransfers[99].recipient" == "B62qkHM9NT3nDefqUvSMe8qnfEfeXipqkzZrvoBXpfaC9m2BdYjWVJA"
+jsonpath "$.data.feetransfers[99].fee" == 720000000000
 jsonpath "$.data.feetransfers[99].type" == "Coinbase"
-jsonpath "$.data.feetransfers[99].blockHeight" == 71
+jsonpath "$.data.feetransfers[99].blockHeight" == 70
 jsonpath "$.data.feetransfers[99].canonical" == true
-jsonpath "$.data.feetransfers[99].dateTime" == "2021-03-17T04:51:00.000Z"
+jsonpath "$.data.feetransfers[99].dateTime" == "2021-03-17T04:48:00.000Z"
 
 duration < 2000
 

--- a/tests/hurl/feetransfers.hurl
+++ b/tests/hurl/feetransfers.hurl
@@ -150,8 +150,8 @@ jsonpath "$.data.feetransfers" count == 100
 # first datum
 jsonpath "$.data.feetransfers[0].blockHeight" == 2
 jsonpath "$.data.feetransfers[0].blockStateHash.stateHash" == "3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH"
-jsonpath "$.data.feetransfers[0].epoch_num_internal_commands" == 205
-jsonpath "$.data.feetransfers[0].total_num_internal_commands" == 205
+jsonpath "$.data.feetransfers[0].epoch_num_internal_commands" == 196
+jsonpath "$.data.feetransfers[0].total_num_internal_commands" == 196
 
 duration < 1000
 

--- a/tests/hurl/stakes.hurl
+++ b/tests/hurl/stakes.hurl
@@ -169,16 +169,16 @@ jsonpath "$.data.stakes[0].pk_epoch_num_snarks" == 0
 jsonpath "$.data.stakes[0].pk_total_num_snarks" == 0
 jsonpath "$.data.stakes[0].pk_epoch_num_user_commands" == 294
 jsonpath "$.data.stakes[0].pk_total_num_user_commands" == 294
-jsonpath "$.data.stakes[0].pk_epoch_num_internal_commands" == 196
-jsonpath "$.data.stakes[0].pk_total_num_internal_commands" == 196
+jsonpath "$.data.stakes[0].pk_epoch_num_internal_commands" == 190
+jsonpath "$.data.stakes[0].pk_total_num_internal_commands" == 190
 jsonpath "$.data.stakes[0].epoch_num_blocks" == 204
 jsonpath "$.data.stakes[0].total_num_blocks" == 204
 jsonpath "$.data.stakes[0].epoch_num_snarks" == 64
 jsonpath "$.data.stakes[0].total_num_snarks" == 64
 jsonpath "$.data.stakes[0].epoch_num_user_commands" == 303
 jsonpath "$.data.stakes[0].total_num_user_commands" == 303
-jsonpath "$.data.stakes[0].epoch_num_internal_commands" == 205
-jsonpath "$.data.stakes[0].total_num_internal_commands" == 205
+jsonpath "$.data.stakes[0].epoch_num_internal_commands" == 196
+jsonpath "$.data.stakes[0].total_num_internal_commands" == 196
 
 duration < 10000
 


### PR DESCRIPTION
## Describe your changes
* The main algorithm is now `O(n)` instead of `O(n * log(n))` 
* It is easier to read as transfers are now processed in debit/credit pairs
* For balanced pairs, runtime asserts that debits and credits sum to zero
* A duplicate was found in the feetransfers GQL for the first 120 blocks. This was fixed as a result of the rewrite.

## Link issue(s) fixed
Closes: #1352

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
