### PR TITLE
Refactorings that move codebase closer to double entry accounting principles

### DIFF
--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -77,13 +77,7 @@ impl InternalCommand {
         // replace Fee_transfer with Fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(block);
         if coinbase.has_fee_transfer() {
-            let fee_transfer = coinbase.fee_transfer();
-            if let [_, _] = &all_account_diff_fees[0][..] {
-                all_account_diff_fees[0] = vec![
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][0].clone()),
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][1].clone()),
-                ]
-            }
+            coinbase.account_diffs_coinbase_mut(&mut all_account_diff_fees);
         }
 
         let mut internal_cmds: Vec<Self> = Vec::new();

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -80,8 +80,8 @@ impl InternalCommand {
             let fee_transfer = coinbase.fee_transfer();
             if let [_, _] = &all_account_diff_fees[0][..] {
                 all_account_diff_fees[0] = vec![
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][0].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][1].clone()),
                 ]
             }
         }

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -89,6 +89,14 @@ impl InternalCommand {
                 );
                 match (credit, debit) {
                     (
+                        AccountDiff::CreateAccount(account_credit),
+                        AccountDiff::CreateAccount(account_debit),
+                    ) => {
+                        println!(
+                            "AccountDiff::CreateAccount credit and debit pairs are present but unhandled"
+                        );
+                    }
+                    (
                         AccountDiff::FeeTransfer(fee_transfer_receiver),
                         AccountDiff::FeeTransfer(fee_transfer_sender),
                     ) => {
@@ -132,12 +140,6 @@ impl InternalCommand {
                         receiver: coinbase.public_key.clone(),
                         amount: coinbase.amount.0,
                     }),
-                    AccountDiff::CreateAccount(create_acct) => {
-                        println!(
-                            "InternalCommand::from_precomputed skipped processing of AccountDiff::{:#?}",
-                            create_acct
-                        );
-                    }
                     _ => {
                         panic!(
                             "Unmatched AccountDiff::{:#?}. (Block: {:#?}, hash: {:#?})",

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -88,10 +88,7 @@ impl InternalCommand {
                     "Credit/Debit pairs do no sum to zero"
                 );
                 match (credit, debit) {
-                    (
-                        AccountDiff::CreateAccount(account_credit),
-                        AccountDiff::CreateAccount(account_debit),
-                    ) => {
+                    (AccountDiff::CreateAccount(_), AccountDiff::CreateAccount(_)) => {
                         println!(
                             "AccountDiff::CreateAccount credit and debit pairs are present but unhandled"
                         );

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -3,8 +3,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 
 // version
 
-pub const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
-pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_COMMIT_HASH"));
+pub const GIT_COMMIT_HASH: &str = "test"; // env!("GIT_COMMIT_HASH");
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", "test");
 
 // indexer constants
 

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -3,8 +3,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 
 // version
 
-pub const GIT_COMMIT_HASH: &str = "test"; // env!("GIT_COMMIT_HASH");
-pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", "test");
+pub const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
+pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_COMMIT_HASH"));
 
 // indexer constants
 

--- a/rust/src/ledger/coinbase.rs
+++ b/rust/src/ledger/coinbase.rs
@@ -124,7 +124,7 @@ impl Coinbase {
             .collect()
     }
 
-    pub fn account_diffs_coinbase_mut(&self, account_diffs: &mut Vec<Vec<AccountDiff>>) {
+    pub fn account_diffs_coinbase_mut(&self, account_diffs: &mut [Vec<AccountDiff>]) {
         let fee_transfer = self.fee_transfer();
         if let Some(fee_transfer_pair) = account_diffs.iter_mut().find(|pair| {
             matches!(pair.as_slice(),

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -87,13 +87,13 @@ impl AccountDiff {
         let public_key = new_account.clone();
         vec![
             AccountDiff::CreateAccount(PaymentDiff {
-                public_key,
-                update_type: UpdateType::Debit(None),
+                public_key: PublicKey("void".to_string()),
+                update_type: UpdateType::Credit,
                 amount: Amount(MAINNET_ACCOUNT_CREATION_FEE.0),
             }),
             AccountDiff::CreateAccount(PaymentDiff {
-                public_key: PublicKey("void".to_string()),
-                update_type: UpdateType::Credit,
+                public_key,
+                update_type: UpdateType::Debit(None),
                 amount: Amount(MAINNET_ACCOUNT_CREATION_FEE.0),
             }),
         ]

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -87,7 +87,9 @@ impl AccountDiff {
         let public_key = new_account.clone();
         vec![
             AccountDiff::CreateAccount(PaymentDiff {
-                public_key: PublicKey("void".to_string()),
+                public_key: PublicKey(
+                    "B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X".to_string(),
+                ),
                 update_type: UpdateType::Credit,
                 amount: Amount(MAINNET_ACCOUNT_CREATION_FEE.0),
             }),

--- a/rust/src/ledger/diff/mod.rs
+++ b/rust/src/ledger/diff/mod.rs
@@ -59,13 +59,7 @@ impl LedgerDiff {
         // replace fee_transfer with fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(precomputed_block);
         if coinbase.has_fee_transfer() {
-            let fee_transfer = coinbase.fee_transfer();
-            if let [_, _] = &account_diff_fees[0][..] {
-                account_diff_fees[0] = vec![
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][0].clone()),
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][1].clone()),
-                ]
-            }
+            coinbase.account_diffs_coinbase_mut(&mut account_diff_fees);
         }
 
         let mut account_diffs = Vec::new();
@@ -1120,7 +1114,13 @@ mod tests {
         ]);
         ledger_diff.account_diffs.sort();
         expect_diffs.sort();
-        assert_eq!(ledger_diff.account_diffs, expect_diffs);
+        for (i, diff) in ledger_diff.account_diffs.iter().enumerate() {
+            assert_eq!(
+                *diff, expect_diffs[i],
+                "{i}th diff mismatch\n{:#?}\n{:#?}",
+                ledger_diff.account_diffs, expect_diffs,
+            );
+        }
         Ok(())
     }
 }

--- a/rust/src/ledger/diff/mod.rs
+++ b/rust/src/ledger/diff/mod.rs
@@ -31,57 +31,41 @@ pub struct LedgerDiff {
     pub new_pk_balances: BTreeMap<PublicKey, u64>,
 
     /// Account updates
-    pub account_diffs: Vec<AccountDiff>,
+    pub account_diffs: Vec<Vec<AccountDiff>>,
 }
 
 impl LedgerDiff {
     /// Compute a ledger diff from the given precomputed block
     pub fn from_precomputed(precomputed_block: &PrecomputedBlock) -> Self {
-        let mut account_diff_fees: Vec<AccountDiff> =
-            AccountDiff::from_block_fees(precomputed_block)
-                .into_iter()
-                .flatten()
-                .collect();
+        let mut account_diff_fees: Vec<Vec<AccountDiff>> =
+            AccountDiff::from_block_fees(precomputed_block);
         // applied user commands
-        let mut account_diff_txns: Vec<AccountDiff> = precomputed_block
+        let mut account_diff_txns: Vec<Vec<AccountDiff>> = precomputed_block
             .commands()
             .into_iter()
             .flat_map(|user_cmd_with_status| {
                 if user_cmd_with_status.is_applied() {
                     AccountDiff::from_command(user_cmd_with_status.to_command())
                 } else {
-                    vec![AccountDiff::FailedTransactionNonce(
+                    vec![vec![AccountDiff::FailedTransactionNonce(
                         FailedTransactionNonceDiff {
                             public_key: user_cmd_with_status.sender(),
                             nonce: user_cmd_with_status.nonce() + 1,
                         },
-                    )]
+                    )]]
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
         // replace fee_transfer with fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(precomputed_block);
         if coinbase.has_fee_transfer() {
             let fee_transfer = coinbase.fee_transfer();
-            let idx = account_diff_fees
-                .iter()
-                .enumerate()
-                .position(|(n, diff)| match diff {
-                    AccountDiff::FeeTransfer(fee) => {
-                        *fee == fee_transfer[0]
-                            && match &account_diff_fees[n + 1] {
-                                AccountDiff::FeeTransfer(fee) => *fee == fee_transfer[1],
-                                _ => false,
-                            }
-                    }
-                    _ => false,
-                });
-            idx.iter().for_each(|i| {
-                account_diff_fees[*i] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone());
-                account_diff_fees[*i + 1] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone());
-            });
+            if let [_, _] = &account_diff_fees[0][..] {
+                account_diff_fees[0] = vec![
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][0].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0][1].clone()),
+                ]
+            }
         }
 
         let mut account_diffs = Vec::new();
@@ -136,7 +120,7 @@ impl LedgerDiff {
         acc
     }
 
-    pub fn from(value: &[(&str, &str, AccountDiffType, u64)]) -> Vec<AccountDiff> {
+    pub fn from(value: &[(&str, &str, AccountDiffType, u64)]) -> Vec<Vec<AccountDiff>> {
         value
             .iter()
             .flat_map(|(s, r, t, a)| AccountDiff::from(s, r, t.clone(), *a))

--- a/rust/src/ledger/mod.rs
+++ b/rust/src/ledger/mod.rs
@@ -114,6 +114,7 @@ impl Ledger {
         let keys: Vec<PublicKey> = diff
             .account_diffs
             .iter()
+            .flatten()
             .map(|diff| diff.public_key())
             .collect();
         keys.iter().for_each(|public_key| {
@@ -123,7 +124,7 @@ impl Ledger {
             }
         });
 
-        for diff in diff.account_diffs.iter() {
+        for diff in diff.account_diffs.iter().flatten() {
             match self.accounts.remove(&diff.public_key()) {
                 Some(account_before) => {
                     self.accounts.insert(
@@ -195,6 +196,7 @@ impl Ledger {
         let keys: Vec<PublicKey> = diff
             .account_diffs
             .iter()
+            .flatten()
             .map(|diff| diff.public_key())
             .collect();
         keys.into_iter().for_each(|public_key| {
@@ -204,7 +206,7 @@ impl Ledger {
             }
         });
 
-        for diff in diff.account_diffs.iter() {
+        for diff in diff.account_diffs.iter().flatten() {
             match self.accounts.remove(&diff.public_key()) {
                 Some(account_before) => {
                     self.accounts.insert(
@@ -460,11 +462,11 @@ mod tests {
             new_coinbase_receiver: None,
             staged_ledger_hash: LedgerHash::default(),
             public_keys_seen: vec![],
-            account_diffs: vec![AccountDiff::Payment(PaymentDiff {
+            account_diffs: vec![vec![AccountDiff::Payment(PaymentDiff {
                 public_key: public_key.clone(),
                 amount: diff_amount,
                 update_type: UpdateType::Credit,
-            })],
+            })]],
         };
         let ledger = Ledger { accounts }
             .apply_diff(&ledger_diff)
@@ -492,11 +494,11 @@ mod tests {
             new_coinbase_receiver: None,
             staged_ledger_hash: LedgerHash::default(),
             public_keys_seen: vec![],
-            account_diffs: vec![AccountDiff::Delegation(DelegationDiff {
+            account_diffs: vec![vec![AccountDiff::Delegation(DelegationDiff {
                 delegator: public_key.clone(),
                 delegate: delegate_key.clone(),
                 nonce: prev_nonce + 1,
-            })],
+            })]],
         };
         let ledger = Ledger { accounts }
             .apply_diff(&ledger_diff)

--- a/rust/src/ledger/store/best.rs
+++ b/rust/src/ledger/store/best.rs
@@ -324,7 +324,7 @@ impl DBAccountUpdate {
                 .accounts_created()
                 .0
                 .keys()
-                .map(AccountDiff::account_creation_payment_diff)
+                .flat_map(AccountDiff::account_creation_payment_diff)
                 .collect(),
         );
         res

--- a/rust/src/store/block_store_impl.rs
+++ b/rust/src/store/block_store_impl.rs
@@ -303,7 +303,7 @@ impl BlockStore for IndexerStore {
         trace!("Getting block account diffs for {state_hash}");
         Ok(self
             .get_block_ledger_diff(state_hash)?
-            .map(|diff| diff.account_diffs))
+            .map(|diff| diff.account_diffs.into_iter().flatten().collect::<Vec<_>>()))
     }
 
     fn get_block_ledger_diff(&self, state_hash: &BlockHash) -> anyhow::Result<Option<LedgerDiff>> {

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 9;
-    pub const PATCH: u32 = 5;
+    pub const PATCH: u32 = 6;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {

--- a/rust/tests/state/ledger/apply_diff.rs
+++ b/rust/tests/state/ledger/apply_diff.rs
@@ -71,6 +71,12 @@ async fn account_diffs() -> anyhow::Result<()> {
     let ledger = ledger.apply_diff(&diff)?;
     let expected = Ledger::from(vec![
         (
+            "B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X",
+            0, // TODO: probably this address should be credited the account creation fee
+            None,
+            None,
+        ),
+        (
             "B62qrusueb8gq1RbZWyZG9EN1eCKjbByTQ39fgiGigkvg7nJR3VdGwX",
             1000000000000,
             None,

--- a/rust/tests/state/ledger/diff_from_precomputed.rs
+++ b/rust/tests/state/ledger/diff_from_precomputed.rs
@@ -56,7 +56,7 @@ async fn account_diffs() {
     let initial_ledger = ledger.clone();
 
     println!("=== Account diffs ===");
-    for diff in diff.account_diffs {
+    for diff in diff.account_diffs.iter().flatten() {
         match diff {
             AccountDiff::Payment(PaymentDiff {
                 public_key,
@@ -96,7 +96,7 @@ async fn account_diffs() {
                         if let Some((balance, _)) = ledger.get_mut(&public_key) {
                             *balance += amount.0 as i64;
                         } else {
-                            ledger.insert(public_key, (amount.0 as i64, 0));
+                            ledger.insert(public_key.clone(), (amount.0 as i64, 0));
                         }
                     }
                 }
@@ -121,7 +121,7 @@ async fn account_diffs() {
                 if let Some((balance, _)) = ledger.get_mut(&public_key) {
                     *balance += amount.0 as i64;
                 } else {
-                    ledger.insert(public_key, (amount.0 as i64, 0));
+                    ledger.insert(public_key.clone(), (amount.0 as i64, 0));
                 }
             }
             AccountDiff::FailedTransactionNonce(FailedTransactionNonceDiff {

--- a/rust/tests/state/ledger/diff_from_precomputed.rs
+++ b/rust/tests/state/ledger/diff_from_precomputed.rs
@@ -80,7 +80,7 @@ async fn account_diffs() {
 
                 match update_type {
                     UpdateType::Debit(new_nonce) => {
-                        if let Some((balance, nonce)) = ledger.get_mut(&public_key) {
+                        if let Some((balance, nonce)) = ledger.get_mut(public_key) {
                             if amount.0 as i64 > *balance {
                                 println!("Debit amount exceeded balance");
                                 panic!();
@@ -93,7 +93,7 @@ async fn account_diffs() {
                         }
                     }
                     UpdateType::Credit => {
-                        if let Some((balance, _)) = ledger.get_mut(&public_key) {
+                        if let Some((balance, _)) = ledger.get_mut(public_key) {
                             *balance += amount.0 as i64;
                         } else {
                             ledger.insert(public_key.clone(), (amount.0 as i64, 0));
@@ -118,7 +118,7 @@ async fn account_diffs() {
                 println!("\n* Coinbase");
                 println!("public_key: {public_key}");
                 println!("amount:     {}", amount.0);
-                if let Some((balance, _)) = ledger.get_mut(&public_key) {
+                if let Some((balance, _)) = ledger.get_mut(public_key) {
                     *balance += amount.0 as i64;
                 } else {
                     ledger.insert(public_key.clone(), (amount.0 as i64, 0));
@@ -131,7 +131,7 @@ async fn account_diffs() {
                 println!("\n* Failed transaction");
                 println!("public_key: {public_key}");
                 println!("nonce:      {new_nonce}");
-                if let Some((_, nonce)) = ledger.get_mut(&public_key) {
+                if let Some((_, nonce)) = ledger.get_mut(public_key) {
                     *nonce += new_nonce.0;
                 }
             }


### PR DESCRIPTION
## Describe your changes
* Starting with `AccountDiff::from_command`, the rest of the code is refactored to support returning a list of double entries of debits and credits

## Link issue(s) fixed
* Closes #1366 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
