### PR TITLE
Process transfers as debit/credit pairs in `InternalCommand::from_precomputed` function

### DIFF
--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -139,7 +139,10 @@ impl InternalCommand {
                         amount: coinbase.amount.0,
                     }),
                     AccountDiff::CreateAccount(create_acct) => {
-                        println!("Ignored AccountDiff: {:#?}", create_acct);
+                        println!(
+                            "InternalCommand::from_precomputed skipped processing of AccountDiff::{:#?}",
+                            create_acct
+                        );
                     }
                     _ => {
                         panic!(

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -72,99 +72,86 @@ impl InternalCommand {
     ///
     /// See `LedgerDiff::from_precomputed`
     pub fn from_precomputed(block: &PrecomputedBlock) -> Vec<Self> {
-        let mut account_diff_fees: Vec<AccountDiff> = AccountDiff::from_block_fees(block)
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut all_account_diff_fees: Vec<Vec<AccountDiff>> = AccountDiff::from_block_fees(block);
 
         // replace Fee_transfer with Fee_transfer_via_coinbase, if any
         let coinbase = Coinbase::from_precomputed(block);
         if coinbase.has_fee_transfer() {
             let fee_transfer = coinbase.fee_transfer();
-            let idx = account_diff_fees
-                .iter()
-                .enumerate()
-                .position(|(n, diff)| match diff {
-                    AccountDiff::FeeTransfer(fee) => {
-                        *fee == fee_transfer[0]
-                            && match &account_diff_fees[n + 1] {
-                                AccountDiff::FeeTransfer(fee) => *fee == fee_transfer[1],
-                                _ => false,
-                            }
-                    }
-                    _ => false,
-                });
-            idx.iter().for_each(|i| {
-                account_diff_fees[*i] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone());
-                account_diff_fees[*i + 1] =
-                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone());
-            });
+            if let [_, _] = &all_account_diff_fees[0][..] {
+                all_account_diff_fees[0] = vec![
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[0].clone()),
+                    AccountDiff::FeeTransferViaCoinbase(fee_transfer[1].clone()),
+                ]
+            }
         }
 
-        let mut internal_cmds = vec![];
-        for n in (0..account_diff_fees.len()).step_by(2) {
-            match &account_diff_fees[n] {
-                AccountDiff::FeeTransfer(f) => {
-                    let (ic_sender, ic_receiver) = if f.update_type == UpdateType::Credit {
-                        (account_diff_fees[n + 1].public_key(), f.public_key.clone())
-                    } else {
-                        (f.public_key.clone(), account_diff_fees[n + 1].public_key())
-                    };
-
-                    // aggregate
-                    if let Some((idx, cmd)) =
-                        internal_cmds
-                            .iter()
-                            .enumerate()
-                            .find_map(|(m, cmd)| match cmd {
+        let mut internal_cmds: Vec<Self> = Vec::new();
+        for account_diff_pairs in all_account_diff_fees {
+            if let [credit, debit] = &account_diff_pairs[..] {
+                assert!(
+                    debit.amount() + credit.amount() == 0,
+                    "Credit/Debit pairs do no sum to zero"
+                );
+                match (credit, debit) {
+                    (
+                        AccountDiff::FeeTransfer(fee_transfer_receiver),
+                        AccountDiff::FeeTransfer(fee_transfer_sender),
+                    ) => {
+                        if let Some(Self::FeeTransfer { amount, .. }) =
+                            internal_cmds.iter_mut().find(|cmd| match cmd {
                                 Self::FeeTransfer {
-                                    sender,
-                                    receiver,
-                                    amount,
+                                    sender, receiver, ..
                                 } => {
-                                    if *sender == ic_sender && *receiver == ic_receiver {
-                                        return Some((
-                                            m,
-                                            Self::FeeTransfer {
-                                                sender: ic_sender.clone(),
-                                                receiver: ic_receiver.clone(),
-                                                amount: f.amount.0 + *amount,
-                                            },
-                                        ));
-                                    }
-                                    None
+                                    sender.0 == fee_transfer_sender.public_key.0
+                                        && receiver.0 == fee_transfer_receiver.public_key.0
                                 }
-                                _ => None,
+                                _ => false,
                             })
-                    {
-                        internal_cmds.push(cmd);
-                        internal_cmds.swap_remove(idx);
-                    } else {
-                        internal_cmds.push(Self::FeeTransfer {
-                            sender: ic_sender.clone(),
-                            receiver: ic_receiver.clone(),
-                            amount: f.amount.0,
-                        });
+                        {
+                            *amount += fee_transfer_receiver.amount.0;
+                        } else {
+                            internal_cmds.push(Self::FeeTransfer {
+                                sender: fee_transfer_sender.public_key.clone(),
+                                receiver: fee_transfer_receiver.public_key.clone(),
+                                amount: fee_transfer_sender.amount.0,
+                            })
+                        }
                     }
+                    (
+                        AccountDiff::FeeTransferViaCoinbase(fee_transfer_receiver),
+                        AccountDiff::FeeTransferViaCoinbase(fee_transfer_sender),
+                    ) => internal_cmds.push(Self::FeeTransferViaCoinbase {
+                        sender: fee_transfer_sender.public_key.clone(),
+                        receiver: fee_transfer_receiver.public_key.clone(),
+                        amount: fee_transfer_sender.amount.0,
+                    }),
+                    (_, _) => panic!(
+                        "Unrecognized credit/debit comination. Block: {:#?}, hash: {:#?}",
+                        block.blockchain_length(),
+                        block.state_hash(),
+                    ),
                 }
-                AccountDiff::FeeTransferViaCoinbase(f) => {
-                    let (sender, receiver) = if f.update_type == UpdateType::Credit {
-                        (account_diff_fees[n + 1].public_key(), f.public_key.clone())
-                    } else {
-                        (f.public_key.clone(), account_diff_fees[n + 1].public_key())
-                    };
-                    internal_cmds.push(Self::FeeTransferViaCoinbase {
-                        sender,
-                        receiver,
-                        amount: f.amount.0,
-                    });
-                }
-                AccountDiff::Coinbase(c) => internal_cmds.push(Self::Coinbase {
-                    receiver: c.public_key.clone(),
-                    amount: c.amount.0,
-                }),
-                _ => (),
+            } else if let [unbalanced_pair] = &account_diff_pairs[..] {
+                match unbalanced_pair {
+                    AccountDiff::Coinbase(coinbase) => internal_cmds.push(Self::Coinbase {
+                        receiver: coinbase.public_key.clone(),
+                        amount: coinbase.amount.0,
+                    }),
+                    _ => {
+                        panic!(
+                            "Unrecognized unbalanced credit/debit pair. Block: {:#?}, hash: {:#?}, {:#?}",
+                            block.blockchain_length(),
+                            block.state_hash(),
+                            unbalanced_pair
+                        );
+                    }
+                };
+            } else {
+                panic!(
+                    "Unrecognized accounting arrangement. {:#?}",
+                    &account_diff_pairs[..]
+                );
             }
         }
 

--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -132,18 +132,21 @@ impl InternalCommand {
                         block.state_hash(),
                     ),
                 }
-            } else if let [unbalanced_pair] = &account_diff_pairs[..] {
-                match unbalanced_pair {
+            } else if let [imbalanced_diff] = &account_diff_pairs[..] {
+                match imbalanced_diff {
                     AccountDiff::Coinbase(coinbase) => internal_cmds.push(Self::Coinbase {
                         receiver: coinbase.public_key.clone(),
                         amount: coinbase.amount.0,
                     }),
+                    AccountDiff::CreateAccount(create_acct) => {
+                        println!("Ignored AccountDiff: {:#?}", create_acct);
+                    }
                     _ => {
                         panic!(
-                            "Unrecognized unbalanced credit/debit pair. Block: {:#?}, hash: {:#?}, {:#?}",
+                            "Unmatched AccountDiff::{:#?}. (Block: {:#?}, hash: {:#?})",
+                            imbalanced_diff,
                             block.blockchain_length(),
                             block.state_hash(),
-                            unbalanced_pair
                         );
                     }
                 };

--- a/rust/src/ledger/diff/account.rs
+++ b/rust/src/ledger/diff/account.rs
@@ -218,20 +218,22 @@ impl AccountDiff {
 
         fee_map
             .iter()
-            .map(|(prover, total_fee)| {
+            .flat_map(|(prover, total_fee)| {
                 let mut res = vec![];
                 // No need to issue Debits and Credits if the fee is 0
                 if *total_fee > 0 {
-                    res.push(AccountDiff::FeeTransfer(PaymentDiff {
-                        public_key: prover.clone(),
-                        amount: (*total_fee).into(),
-                        update_type: UpdateType::Credit,
-                    }));
-                    res.push(AccountDiff::FeeTransfer(PaymentDiff {
-                        public_key: precomputed_block.coinbase_receiver(),
-                        amount: (*total_fee).into(),
-                        update_type: UpdateType::Debit(None),
-                    }));
+                    res.push(vec![
+                        AccountDiff::FeeTransfer(PaymentDiff {
+                            public_key: prover.clone(),
+                            amount: (*total_fee).into(),
+                            update_type: UpdateType::Credit,
+                        }),
+                        AccountDiff::FeeTransfer(PaymentDiff {
+                            public_key: precomputed_block.coinbase_receiver(),
+                            amount: (*total_fee).into(),
+                            update_type: UpdateType::Debit(None),
+                        }),
+                    ]);
 
                     // Check if the coinbase recipient account is new and deduct the account
                     // creation fee if it is
@@ -251,9 +253,9 @@ impl AccountDiff {
                                                 && (*total_fee - MAINNET_ACCOUNT_CREATION_FEE.0)
                                                     == fee_transfer_receiver_balance
                                             {
-                                                res.push(AccountDiff::CreateAccount(
+                                                res.push(vec![AccountDiff::CreateAccount(
                                                     prover.clone(),
-                                                ));
+                                                )]);
                                             }
                                         }
                                     }
@@ -267,7 +269,7 @@ impl AccountDiff {
                 }
                 res
             })
-            .collect()
+            .collect::<Vec<_>>()
     }
 
     /// User command + SNARK work fees, aggregated per public key

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 9;
-    pub const PATCH: u32 = 4;
+    pub const PATCH: u32 = 5;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
* Reapplied the reverted PR
* Added a match statement to handle `AccountDiff::CreateAccount` (commit: https://github.com/Granola-Team/mina-indexer/commit/c28487fa37255e5a6c7e06fa8b94fb94d5232097)

## Link issue(s) fixed
Closes: #1352 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
