### PR TITLE
Ensure that debit and credit amounts are properly issued when creating accounts

### DIFF
--- a/rust/src/command/internal/mod.rs
+++ b/rust/src/command/internal/mod.rs
@@ -84,13 +84,12 @@ impl InternalCommand {
         let mut internal_cmds: Vec<Self> = Vec::new();
         for account_diff_pairs in all_account_diff_fees {
             if let [credit, debit] = &account_diff_pairs[..] {
-                // assert!(
-                //     debit.amount() + credit.amount() == 0,
-                //     "Credit/Debit pairs do no sum to zero\nBlock:  {}\nCredit: {:?}\nDebit:
-                // {:?}",     block.summary(),
-                //     credit,
-                //     debit,
-                // );
+                if debit.amount() + credit.amount() != 0 {
+                    panic!(
+                        "Credit/Debit pairs do not sum to zero.\nDebit: {:#?}\nCredit: {:#?}\nBlock Height: {:#?}",
+                        debit, credit, block.blockchain_length()
+                    )
+                }
                 match (credit, debit) {
                     (AccountDiff::CreateAccount(_), AccountDiff::CreateAccount(_)) => {
                         debug!(

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 9;
-    pub const PATCH: u32 = 7;
+    pub const PATCH: u32 = 8;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
* Debits and Credits for account creation were `u64` (positive). Now they are `i64` as debits are negative, and credits are positive.

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
