### PR TITLE
Confidently parse block filenames without fallbacks

### DIFF
--- a/rust/src/block/parser.rs
+++ b/rust/src/block/parser.rs
@@ -122,12 +122,12 @@ impl BlockParser {
                 .iter()
                 .fold(0, |acc, p| acc + p.metadata().unwrap().len());
 
-            if min_length.is_some() {
-                paths.retain(|p| extract_block_height(p) > min_length.unwrap())
+            if let Some(min) = min_length {
+                paths.retain(|p| extract_block_height(p) > min)
             }
 
-            if max_length.is_some() {
-                paths.retain(|p| extract_block_height(p) < max_length.unwrap())
+            if let Some(max) = max_length {
+                paths.retain(|p| extract_block_height(p) < max)
             }
 
             paths.sort_by_cached_key(|path| extract_block_height(path));

--- a/rust/src/block/parser.rs
+++ b/rust/src/block/parser.rs
@@ -123,11 +123,11 @@ impl BlockParser {
                 .fold(0, |acc, p| acc + p.metadata().unwrap().len());
 
             if min_length.is_some() {
-                paths.retain(|p| extract_block_height(p) > min_length)
+                paths.retain(|p| extract_block_height(p) > min_length.unwrap())
             }
 
             if max_length.is_some() {
-                paths.retain(|p| extract_block_height(p) < max_length)
+                paths.retain(|p| extract_block_height(p) < max_length.unwrap())
             }
 
             paths.sort_by_cached_key(|path| extract_block_height(path));

--- a/rust/src/block/precomputed.rs
+++ b/rust/src/block/precomputed.rs
@@ -187,7 +187,7 @@ impl PrecomputedBlock {
     /// Parses the precomputed block if the path is a valid block file
     pub fn parse_file(path: &Path, version: PcbVersion) -> anyhow::Result<Self> {
         let network = extract_network(path);
-        let blockchain_length = extract_block_height(path).expect("length in filename");
+        let blockchain_length = extract_block_height(path);
         let state_hash = extract_state_hash(path);
         let contents = std::fs::read(path)?;
         let precomputed_block = PrecomputedBlock::from_file_contents(

--- a/rust/src/canonicity/canonical_chain_discovery.rs
+++ b/rust/src/canonicity/canonical_chain_discovery.rs
@@ -198,7 +198,7 @@ pub fn discovery(
 
     let max_canonical_length = deep_canonical_paths
         .last()
-        .and_then(|p| Some(extract_block_height(p)))
+        .map(|p| extract_block_height(p))
         .unwrap_or(1);
     let orphaned_paths: Vec<PathBuf> = paths
         .into_iter()

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 1;
+    pub const PATCH: u32 = 2;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
* instead of falling back to `u32::MAX` when parsing filenames for block height, we panic. 

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
