### PR TITLE
Feat: GQL staged ledger accounts public key query input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ database/
 
 # Emacs project preferences
 .dir-locals.el
+
+# tier3 blocks
+files-to-fetch.list

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 4;
+    pub const PATCH: u32 = 5;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {

--- a/rust/src/web/graphql/accounts/mod.rs
+++ b/rust/src/web/graphql/accounts/mod.rs
@@ -10,6 +10,37 @@ use crate::{
 use async_graphql::{Context, Enum, InputObject, Object, Result, SimpleObject};
 use speedb::IteratorMode;
 
+#[derive(InputObject)]
+pub struct AccountQueryInput {
+    public_key: Option<String>,
+    username: Option<String>,
+    balance: Option<u64>,
+
+    #[graphql(name = "balance_gt")]
+    balance_gt: Option<u64>,
+
+    #[graphql(name = "balance_gte")]
+    balance_gte: Option<u64>,
+
+    #[graphql(name = "balance_lt")]
+    balance_lt: Option<u64>,
+
+    #[graphql(name = "balance_lte")]
+    balance_lte: Option<u64>,
+
+    #[graphql(name = "balance_ne")]
+    balance_ne: Option<u64>,
+}
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum AccountSortByInput {
+    BalanceAsc,
+    BalanceDesc,
+}
+
+#[derive(Default)]
+pub struct AccountQueryRoot;
+
 #[derive(SimpleObject)]
 pub struct Account {
     public_key: String,
@@ -47,39 +78,6 @@ pub struct Account {
     #[graphql(name = "pk_total_num_internal_commands")]
     pk_total_num_internal_commands: u32,
 }
-
-#[derive(InputObject)]
-pub struct AccountQueryInput {
-    public_key: Option<String>,
-
-    username: Option<String>,
-
-    balance: Option<u64>,
-
-    #[graphql(name = "balance_gt")]
-    balance_gt: Option<u64>,
-
-    #[graphql(name = "balance_gte")]
-    balance_gte: Option<u64>,
-
-    #[graphql(name = "balance_lt")]
-    balance_lt: Option<u64>,
-
-    #[graphql(name = "balance_lte")]
-    balance_lte: Option<u64>,
-
-    #[graphql(name = "balance_ne")]
-    balance_ne: Option<u64>,
-}
-
-#[derive(Enum, Copy, Clone, Eq, PartialEq)]
-pub enum AccountSortByInput {
-    BalanceAsc,
-    BalanceDesc,
-}
-
-#[derive(Default)]
-pub struct AccountQueryRoot;
 
 #[Object]
 impl AccountQueryRoot {

--- a/tests/hurl/staged_ledger_accounts.hurl
+++ b/tests/hurl/staged_ledger_accounts.hurl
@@ -30,14 +30,14 @@ HTTP 200
 jsonpath "$.data.stagedLedgerAccounts" count == 100
 
 jsonpath "$.data.stagedLedgerAccounts[0].balance" == 75000000.0
-jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 75000000
+jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 75000000000000000
 jsonpath "$.data.stagedLedgerAccounts[0].delegate" == "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB"
 jsonpath "$.data.stagedLedgerAccounts[0].nonce" == 0
 jsonpath "$.data.stagedLedgerAccounts[0].public_key" == "B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3"
 jsonpath "$.data.stagedLedgerAccounts[0].username" == null
 
 jsonpath "$.data.stagedLedgerAccounts[99].balance" == 1693980.63775165
-jsonpath "$.data.stagedLedgerAccounts[99].balance_nanomina" == 1693980
+jsonpath "$.data.stagedLedgerAccounts[99].balance_nanomina" == 1693980637751650
 jsonpath "$.data.stagedLedgerAccounts[99].delegate" == "B62qnvzUAvwnAiK3eMVQooshDA5AmEF9jKRrUTt5cwbCvVFiF47vdqp"
 jsonpath "$.data.stagedLedgerAccounts[99].nonce" == 0
 jsonpath "$.data.stagedLedgerAccounts[99].public_key" == "B62qmKJxgh6h4i56hTXmkDL2Xpesm94NNm2Ev4ySSA4rCE2Z3JbfZhc"
@@ -77,17 +77,122 @@ HTTP 200
 jsonpath "$.data.stagedLedgerAccounts" count == 100
 
 jsonpath "$.data.stagedLedgerAccounts[0].balance" == 75000000.0
-jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 75000000
+jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 75000000000000000
 jsonpath "$.data.stagedLedgerAccounts[0].delegate" == "B62qqhURJQo3CvWC3WFo9LhUhtcaJWLBcJsaA3DXaU2GH5KgXujZiwB"
 jsonpath "$.data.stagedLedgerAccounts[0].nonce" == 0
 jsonpath "$.data.stagedLedgerAccounts[0].public_key" == "B62qpbZkvpHZ1a5nsTbANuRtrdw4YraTyA4nvJDm6HpP1YMC9QStxX3"
 jsonpath "$.data.stagedLedgerAccounts[0].username" == null
 
 jsonpath "$.data.stagedLedgerAccounts[99].balance" == 1693980.63775165
-jsonpath "$.data.stagedLedgerAccounts[99].balance_nanomina" == 1693980
+jsonpath "$.data.stagedLedgerAccounts[99].balance_nanomina" == 1693980637751650
 jsonpath "$.data.stagedLedgerAccounts[99].delegate" == "B62qnvzUAvwnAiK3eMVQooshDA5AmEF9jKRrUTt5cwbCvVFiF47vdqp"
 jsonpath "$.data.stagedLedgerAccounts[99].nonce" == 0
 jsonpath "$.data.stagedLedgerAccounts[99].public_key" == "B62qmKJxgh6h4i56hTXmkDL2Xpesm94NNm2Ev4ySSA4rCE2Z3JbfZhc"
 jsonpath "$.data.stagedLedgerAccounts[99].username" == null
+
+duration < 1000
+
+# 
+# Public key & state hash query
+# 
+
+POST {{url}}
+```graphql
+query StagedLedgerAccounts($limit: Int, $query: StagedLedgerQueryInput!) {
+  stagedLedgerAccounts(limit: $limit, query: $query) {
+    balance
+    balance_nanomina
+    nonce
+    public_key
+  }
+}
+
+variables {
+  "limit": 10,
+  "query": {
+    "publicKey": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
+    "stateHash": "3NKkJDmNZGYdKVDDJkkamGdvNzASia2SXxKpu18imps7KqbNXENY"
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# account
+jsonpath "$.data.stagedLedgerAccounts" count == 1
+jsonpath "$.data.stagedLedgerAccounts[0].balance" == 1438.69
+jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 1438690000000
+jsonpath "$.data.stagedLedgerAccounts[0].public_key" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"
+jsonpath "$.data.stagedLedgerAccounts[0].nonce" == 15
+
+duration < 1000
+
+# 
+# Public key & block height query
+# 
+
+POST {{url}}
+```graphql
+query StagedLedgerAccounts($limit: Int, $query: StagedLedgerQueryInput!) {
+  stagedLedgerAccounts(limit: $limit, query: $query) {
+    balance
+    balance_nanomina
+    nonce
+    public_key
+  }
+}
+
+variables {
+  "limit": 10,
+  "query": {
+    "publicKey": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
+    "blockchain_length": 12
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# account
+jsonpath "$.data.stagedLedgerAccounts" count == 1
+jsonpath "$.data.stagedLedgerAccounts[0].balance" == 1438.69
+jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 1438690000000
+jsonpath "$.data.stagedLedgerAccounts[0].public_key" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"
+jsonpath "$.data.stagedLedgerAccounts[0].nonce" == 15
+
+duration < 1000
+
+# 
+# Public key & staged ledger hash query
+# 
+
+POST {{url}}
+```graphql
+query StagedLedgerAccounts($limit: Int, $query: StagedLedgerQueryInput!) {
+  stagedLedgerAccounts(limit: $limit, query: $query) {
+    balance
+    balance_nanomina
+    nonce
+    public_key
+  }
+}
+
+variables {
+  "limit": 10,
+  "query": {
+    "publicKey": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
+    "ledgerHash": "jwVZUkFNgb5fBf6ZRBtYXrwWs32erEyPTLXzdduGNhH6F71wjan"
+  }
+}
+```
+HTTP 200
+[Asserts]
+
+# account
+jsonpath "$.data.stagedLedgerAccounts" count == 1
+jsonpath "$.data.stagedLedgerAccounts[0].balance" == 1438.69
+jsonpath "$.data.stagedLedgerAccounts[0].balance_nanomina" == 1438690000000
+jsonpath "$.data.stagedLedgerAccounts[0].public_key" == "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy"
+jsonpath "$.data.stagedLedgerAccounts[0].nonce" == 15
 
 duration < 1000


### PR DESCRIPTION
## Describe your changes

Adds a `publicKey` query input to the GQL `stagedLedgerAccounts` endpoint. This is a new feature and will allow us to further investigate our ledger diff mismatch.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
