### PR TITLE
Separate block iteration from block parsing

### DIFF
--- a/rust/src/block/parser.rs
+++ b/rust/src/block/parser.rs
@@ -221,7 +221,7 @@ impl BlockParser {
         }
     }
 
-    fn consume_block(
+    pub fn consume_block(
         &mut self,
         path: &Path,
         designation: &dyn Fn(PrecomputedBlock) -> ParsedBlock,

--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -501,7 +501,7 @@ impl IndexerState {
                         "Finished ingesting and applying {} blocks ({}) to the witness tree in {:?}",
                         self.blocks_processed,
                         bytesize::ByteSize::b(self.bytes_processed),
-                        total_time.elapsed() + offset,
+                        pretty_print_duration(total_time.elapsed() + offset),
                     );
                     break;
                 }

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 14;
+    pub const PATCH: u32 = 15;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {

--- a/rust/tests/block/parser.rs
+++ b/rust/tests/block/parser.rs
@@ -12,7 +12,7 @@ async fn representative_benches() -> anyhow::Result<()> {
     let mut block_parser0 = BlockParser::new_testing(&sample_dir0).unwrap();
     let mut logs_processed = 0;
 
-    while let Some((block, _)) = block_parser0.next_block().await? {
+    while let Some((block, _)) = block_parser0.next_block()? {
         let block: PrecomputedBlock = block.into();
         logs_processed += 1;
         dbg!(block.state_hash());
@@ -28,7 +28,7 @@ async fn representative_benches() -> anyhow::Result<()> {
     let mut block_parser1 = BlockParser::new_testing(&sample_dir1).unwrap();
 
     logs_processed = 0;
-    while let Some((block, _)) = block_parser1.next_block().await? {
+    while let Some((block, _)) = block_parser1.next_block()? {
         let block: PrecomputedBlock = block.into();
         logs_processed += 1;
         dbg!(block.state_hash());

--- a/rust/tests/block/store/blocks.rs
+++ b/rust/tests/block/store/blocks.rs
@@ -28,7 +28,7 @@ async fn add_and_get() -> anyhow::Result<()> {
 
     let mut n = 0;
     let adding = Instant::now();
-    while let Some((block, block_bytes)) = bp.next_block().await? {
+    while let Some((block, block_bytes)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         let state_hash = block.state_hash();
 

--- a/rust/tests/block/store/blocks_at_height.rs
+++ b/rust/tests/block/store/blocks_at_height.rs
@@ -25,7 +25,7 @@ async fn add_and_get() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, block_bytes)) = bp.next_block().await? {
+    while let Some((block, block_bytes)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         db.add_block(&block, block_bytes)?;
         println!("{}", block.summary());

--- a/rust/tests/block/store/blocks_at_slot.rs
+++ b/rust/tests/block/store/blocks_at_slot.rs
@@ -25,7 +25,7 @@ async fn add_and_get() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, block_bytes)) = bp.next_block().await? {
+    while let Some((block, block_bytes)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         db.add_block(&block, block_bytes)?;
     }

--- a/rust/tests/canonicity/chain_discovery.rs
+++ b/rust/tests/canonicity/chain_discovery.rs
@@ -21,7 +21,7 @@ async fn gaps() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, _)) = block_parser.next_block().await? {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!("{}", block.summary());
     }
@@ -44,7 +44,7 @@ async fn contiguous() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, _)) = block_parser.next_block().await? {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!("{}", block.summary());
     }
@@ -67,7 +67,7 @@ async fn missing_parent() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, _)) = block_parser.next_block().await? {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!("{}", block.summary());
     }
@@ -119,7 +119,7 @@ async fn canonical_threshold() -> anyhow::Result<()> {
     )
     .await?;
 
-    while let Some((block, _)) = block_parser.next_block().await? {
+    while let Some((block, _)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         println!("{}", block.summary());
     }

--- a/rust/tests/command/store.rs
+++ b/rust/tests/command/store.rs
@@ -46,7 +46,7 @@ async fn add_and_get() -> anyhow::Result<()> {
     .await?;
 
     // add the first block to the store
-    if let Some((block, block_bytes)) = bp.next_block().await? {
+    if let Some((block, block_bytes)) = bp.next_block()? {
         let block: PrecomputedBlock = block.into();
         indexer.add_block_to_store(&block, block_bytes, true)?;
     }

--- a/rust/tests/event/log.rs
+++ b/rust/tests/event/log.rs
@@ -69,7 +69,7 @@ async fn test() -> anyhow::Result<()> {
     // - add block to witness tree
     // - update best tip
     // - update canonicities
-    while let Some((block, block_bytes)) = block_parser1.next_block().await? {
+    while let Some((block, block_bytes)) = block_parser1.next_block()? {
         let block: PrecomputedBlock = block.into();
         if let Some(db_event) = state1
             .indexer_store

--- a/rust/tests/state/dangling_branches/add_all_blocks.rs
+++ b/rust/tests/state/dangling_branches/add_all_blocks.rs
@@ -15,13 +15,13 @@ async fn extension() -> anyhow::Result<()> {
     let mut block_parser = BlockParser::new_testing(&blocks_dir)?;
 
     let mut n = 0;
-    if let Some((block, block_bytes)) = block_parser.next_block().await? {
+    if let Some((block, block_bytes)) = block_parser.next_block()? {
         let block: PrecomputedBlock = block.into();
         let mut state =
             IndexerState::new_testing(&block, block_bytes, None, None, None, None, None)?;
         n += 1;
 
-        while let Some((block, _)) = block_parser.next_block().await? {
+        while let Some((block, _)) = block_parser.next_block()? {
             let block: PrecomputedBlock = block.into();
             state.add_block_to_witness_tree(&block, true)?;
             n += 1;


### PR DESCRIPTION
## Describe your changes
* Block iteration and block parsing are currently entwined concepts.
* Currently, each iteration of the block paths results in parsing the file contents into a `PrecomputedBlock`. 
* This means that entire JSON of each block is serialized into memory upon each iteration, making ingestion slow. 
* In the future, we may want to avoid serializing the entire file into memory when ingesting. This helps.

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
