### PR TITLE
Use memory on stack when extracting height and state hash from filename

### DIFF
--- a/rust/src/block/mod.rs
+++ b/rust/src/block/mod.rs
@@ -385,30 +385,16 @@ pub fn extract_height_and_hash(path: &std::path::Path) -> (u32, &str) {
                 .expect("Failed to parse the hash");
             (block_height, hash)
         }
-        _ => panic!("Filename format is invalid"),
+        _ => panic!("Filename format is invalid {}", filename),
     }
 }
 
 pub fn extract_block_height(path: &Path) -> u32 {
-    let filename = path
-        .file_name()
-        .and_then(|x| x.to_str())
-        .expect("Failed to extract filename from path");
-
-    let parts: Vec<&str> = filename.split('-').collect();
-
-    parts
-        .get(1)
-        .expect("Failed to find the second part of the filename")
-        .parse::<u32>()
-        .expect("Failed to parse block height as u32")
+    extract_height_and_hash(path).0
 }
 
-pub fn extract_state_hash(path: &Path) -> String {
-    let name = path.file_stem().and_then(|x| x.to_str()).unwrap();
-    let dash_pos = name.rfind('-').unwrap();
-    let state_hash = &name[dash_pos + 1..];
-    state_hash.to_owned()
+pub fn extract_state_hash(path: &Path) -> &str {
+    extract_height_and_hash(path).1
 }
 
 pub fn extract_network(path: &Path) -> Network {
@@ -431,8 +417,6 @@ mod block_tests {
 
     #[test]
     fn extract_state_hash_test() {
-        let filename1 =
-            &Path::new("mainnet-3NK2upcz2s6BmmoD6btjtJqSw1wNdyM9H5tXSD9nmN91mQMe4vH8.json");
         let filename2 =
             &Path::new("mainnet-2-3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH.json");
         let filename3 = &Path::new(
@@ -440,15 +424,11 @@ mod block_tests {
         );
 
         assert_eq!(
-            "3NK2upcz2s6BmmoD6btjtJqSw1wNdyM9H5tXSD9nmN91mQMe4vH8".to_owned(),
-            extract_state_hash(filename1)
-        );
-        assert_eq!(
-            "3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH".to_owned(),
+            "3NLyWnjZqUECniE1q719CoLmes6WDQAod4vrTeLfN7XXJbHv6EHH",
             extract_state_hash(filename2)
         );
         assert_eq!(
-            "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R".to_owned(),
+            "3NKd5So3VNqGZtRZiWsti4yaEe1fX79yz5TbfG6jBZqgMnCQQp3R",
             extract_state_hash(filename3)
         );
     }

--- a/rust/src/canonicity/canonical_chain_discovery.rs
+++ b/rust/src/canonicity/canonical_chain_discovery.rs
@@ -90,7 +90,7 @@ fn find_best_tip(
                 if let Ok(prev_hash) = PreviousStateHash::from_path(possible_next_tip) {
                     if prev_hash.0 == state_hash {
                         parent_hash_map.insert(
-                            extract_state_hash(possible_next_tip),
+                            extract_state_hash(possible_next_tip).to_string(),
                             state_hash.to_string(),
                         );
                         best_tip = possible_next_tip;
@@ -129,7 +129,7 @@ fn canonical_branch_from_best_tip<'a>(
             let path_str = path.to_str().unwrap();
             if path_str.contains(parent_state_hash.as_str()) {
                 next_height -= 1;
-                opt_parent_state_hash = parent_hash_map.get(extract_state_hash(path).as_str());
+                opt_parent_state_hash = parent_hash_map.get(extract_state_hash(path));
                 canonical_branch.push(path); // Push reference, not clone
                 i = Some(j);
                 break;

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 18;
+    pub const PATCH: u32 = 19;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
Allocates memory on the stack (not the heap) when parsing height and state hash from fn.

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
