### PR TITLE
Allocate memory on the stack for `parent_hash_map` hashes in `discovery` algorithm

### DIFF
--- a/rust/src/canonicity/canonical_chain_discovery.rs
+++ b/rust/src/canonicity/canonical_chain_discovery.rs
@@ -24,7 +24,7 @@ pub fn discovery(
 
     let time = std::time::Instant::now();
     let mut tree_map: BTreeMap<u32, Vec<&PathBuf>> = BTreeMap::new();
-    let mut parent_hash_map: HashMap<String, String> = HashMap::new();
+    let mut parent_hash_map: HashMap<&str, &str> = HashMap::new();
 
     for path in paths {
         let height = extract_block_height(path);
@@ -33,7 +33,8 @@ pub fn discovery(
     }
 
     // find the best tip
-    let best_tip: PathBuf = find_best_tip(&tree_map, &mut parent_hash_map, reporting_freq);
+    let best_tip: PathBuf =
+        find_best_tip(&tree_map, &mut parent_hash_map, reporting_freq).to_owned();
 
     // walk back from tip to root of tree
     let mut canonical_branch =
@@ -61,80 +62,82 @@ pub fn discovery(
     ))
 }
 
-fn find_best_tip(
-    tree_map: &BTreeMap<u32, Vec<&PathBuf>>,
-    parent_hash_map: &mut HashMap<String, String>,
+fn find_best_tip<'a>(
+    tree_map: &BTreeMap<u32, Vec<&'a PathBuf>>,
+    parent_hash_map: &mut HashMap<&'a str, &'a str>,
     reporting_freq: u32,
-) -> PathBuf {
+) -> &'a PathBuf {
     let time = std::time::Instant::now();
 
     let mut queue: VecDeque<&PathBuf> = VecDeque::new();
-    let mut best_tip: &PathBuf = &PathBuf::new();
+    let mut best_tip: Option<&PathBuf> = None;
+
     if let Some((_, root_files)) = tree_map.first_key_value() {
         for root_file in root_files {
-            best_tip = root_file.to_owned();
-            queue.push_back(best_tip);
+            best_tip = Some(root_file);
+            queue.push_back(root_file);
         }
     }
 
-    while let Some(best_tip_canidate) = queue.pop_front() {
+    while let Some(best_tip_candidate) = queue.pop_front() {
         log_progress(
-            extract_block_height(best_tip_canidate),
+            extract_block_height(best_tip_candidate),
             reporting_freq,
             &time,
         );
-        let (height, state_hash) = extract_height_and_hash(best_tip_canidate);
+        let (height, state_hash) = extract_height_and_hash(best_tip_candidate);
         let next_height = height + 1;
-        if let Some(next_tips) = tree_map.get(&(next_height)) {
+        if let Some(next_tips) = tree_map.get(&next_height) {
             for possible_next_tip in next_tips {
                 if let Ok(prev_hash) = PreviousStateHash::from_path(possible_next_tip) {
                     if prev_hash.0 == state_hash {
-                        parent_hash_map.insert(
-                            extract_state_hash(possible_next_tip).to_string(),
-                            state_hash.to_string(),
-                        );
-                        best_tip = possible_next_tip;
-                        queue.push_back(best_tip);
+                        parent_hash_map.insert(extract_state_hash(possible_next_tip), state_hash);
+                        best_tip = Some(possible_next_tip);
+                        queue.push_back(possible_next_tip);
                     }
                 }
             }
         }
     }
+
+    let best_tip = best_tip.expect("No valid best tip found");
     info!(
         "Found best tip at block height {:?} in {:?}",
         extract_block_height(best_tip),
         pretty_print_duration(time.elapsed())
     );
-    best_tip.to_owned()
+    best_tip
 }
+
 fn canonical_branch_from_best_tip<'a>(
     tree_map: &mut BTreeMap<u32, Vec<&'a PathBuf>>,
-    parent_hash_map: &HashMap<String, String>,
+    parent_hash_map: &HashMap<&'a str, &'a str>,
     best_tip: &'a PathBuf,
 ) -> anyhow::Result<Vec<&'a PathBuf>> {
     let time = &std::time::Instant::now();
 
     let mut canonical_branch: Vec<&'a PathBuf> = vec![];
-    canonical_branch.push(best_tip); // Use reference to best_tip
+    canonical_branch.push(best_tip);
 
     // next iteration
     let (mut next_height, state_hash) = extract_height_and_hash(best_tip);
     let mut opt_parent_state_hash = parent_hash_map.get(state_hash);
     next_height -= 1;
-    while opt_parent_state_hash.is_some() {
-        let parent_state_hash = opt_parent_state_hash.unwrap();
+
+    while let Some(parent_state_hash) = opt_parent_state_hash {
         let paths = tree_map.get_mut(&next_height).unwrap();
         let mut i = None;
+
         for (j, path) in paths.iter().enumerate() {
-            let path_str = path.to_str().unwrap();
-            if path_str.contains(parent_state_hash.as_str()) {
+            if extract_state_hash(path) == *parent_state_hash {
                 next_height -= 1;
                 opt_parent_state_hash = parent_hash_map.get(extract_state_hash(path));
-                canonical_branch.push(path); // Push reference, not clone
+                canonical_branch.push(path);
                 i = Some(j);
                 break;
             }
         }
+
         if let Some(i) = i {
             paths.remove(i);
         }
@@ -198,7 +201,7 @@ fn split_off_recent_paths<'a>(
 fn log_progress(length_of_chain: u32, reporting_freq: u32, time: &std::time::Instant) {
     if length_of_chain % reporting_freq == 0 {
         info!(
-            "Found best tip canidate at height {} in {:?}",
+            "Found best tip candidate at height {} in {:?}",
             length_of_chain,
             pretty_print_duration(time.elapsed())
         );
@@ -230,18 +233,18 @@ mod discovery_algorithm_tests {
         tree_map.insert(105497, vec![&path_497_canon, &path_497_extra]);
 
         // Prepare the parent hash map
-        let mut parent_hash_map: HashMap<String, String> = HashMap::new();
+        let mut parent_hash_map: HashMap<&str, &str> = HashMap::new();
         parent_hash_map.insert(
-            "3NK73T6brdpBFgjbZKMpfYX596q68sfHx8NtMDYRLJ9ai88WzrKQ".into(),
-            "3NKEkf29fm6CARN6MAi6ZvmADxEXpu1wUwYfnjsiWCmR5LfCpwSg".into(),
+            "3NK73T6brdpBFgjbZKMpfYX596q68sfHx8NtMDYRLJ9ai88WzrKQ",
+            "3NKEkf29fm6CARN6MAi6ZvmADxEXpu1wUwYfnjsiWCmR5LfCpwSg",
         );
         parent_hash_map.insert(
-            "3NKEkf29fm6CARN6MAi6ZvmADxEXpu1wUwYfnjsiWCmR5LfCpwSg".into(),
-            "3NKbLiBHzQrAimK7AkP8qAfQpHnezkdsSm8mkt2TzsbjsLN8Axmt".into(),
+            "3NKEkf29fm6CARN6MAi6ZvmADxEXpu1wUwYfnjsiWCmR5LfCpwSg",
+            "3NKbLiBHzQrAimK7AkP8qAfQpHnezkdsSm8mkt2TzsbjsLN8Axmt",
         );
         parent_hash_map.insert(
-            "3NKbLiBHzQrAimK7AkP8qAfQpHnezkdsSm8mkt2TzsbjsLN8Axmt".into(),
-            "3NKjngJTXJzRUXF3uH2nK19iYUVtYBFjLhezSrMMFVQyEGwqEi3c".into(),
+            "3NKbLiBHzQrAimK7AkP8qAfQpHnezkdsSm8mkt2TzsbjsLN8Axmt",
+            "3NKjngJTXJzRUXF3uH2nK19iYUVtYBFjLhezSrMMFVQyEGwqEi3c",
         );
 
         // Expected canonical branch

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 19;
+    pub const PATCH: u32 = 20;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
⚠️ depends on https://github.com/Granola-Team/mina-indexer/pull/1439

## Describe your changes
Avoids heap allocations by using &str in the parent_hash_map

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
