### PR TITLE
`BlockHash::to_bytes -> [u8; BlockHash::LEN]` instead of `... -> Vec<u8>`

### DIFF
--- a/rust/src/block/mod.rs
+++ b/rust/src/block/mod.rs
@@ -475,7 +475,7 @@ mod block_tests {
         let bytes = input.0.as_bytes();
 
         assert_eq!(input.clone().to_bytes(), bytes, "to_bytes");
-        assert_eq!(input, BlockHash::from_bytes(&bytes)?, "from_bytes");
+        assert_eq!(input, BlockHash::from_bytes(bytes)?, "from_bytes");
         Ok(())
     }
 

--- a/rust/src/block/mod.rs
+++ b/rust/src/block/mod.rs
@@ -67,8 +67,10 @@ impl BlockHash {
             .map_err(|e| anyhow!("Error converting from hashv1: {e}"))
     }
 
-    pub fn to_bytes(self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
+    pub fn to_bytes(self) -> [u8; BlockHash::LEN] {
+        let mut res = [0u8; BlockHash::LEN]; // Pre-allocate the array with the correct size
+        res.copy_from_slice(self.0.as_bytes());
+        res
     }
 }
 
@@ -470,7 +472,7 @@ mod block_tests {
     #[test]
     fn block_hash_roundtrip() -> anyhow::Result<()> {
         let input = BlockHash("3NK4huLvUDiL4XuCUcyrWCKynmvhqfKsx5h2MfBXVVUq2Qwzi5uT".to_string());
-        let bytes = input.0.as_bytes().to_vec();
+        let bytes = input.0.as_bytes();
 
         assert_eq!(input.clone().to_bytes(), bytes, "to_bytes");
         assert_eq!(input, BlockHash::from_bytes(&bytes)?, "from_bytes");

--- a/rust/src/ledger/store/staged.rs
+++ b/rust/src/ledger/store/staged.rs
@@ -151,7 +151,7 @@ pub fn staged_account_balance_sort_key(
     balance: u64,
     pk: PublicKey,
 ) -> Vec<u8> {
-    let mut res = state_hash.to_bytes();
+    let mut res = state_hash.to_bytes().to_vec();
     res.append(&mut balance.to_be_bytes().to_vec());
     res.append(&mut pk.to_bytes());
     res

--- a/rust/src/store/block_store_impl.rs
+++ b/rust/src/store/block_store_impl.rs
@@ -991,14 +991,14 @@ impl BlockStore for IndexerStore {
 /// `{block height BE}{state hash}`
 fn block_height_key(block: &PrecomputedBlock) -> Vec<u8> {
     let mut key = to_be_bytes(block.blockchain_length());
-    key.append(&mut block.state_hash().to_bytes());
+    key.append(&mut block.state_hash().to_bytes().to_vec());
     key
 }
 
 /// `{global slot BE}{state hash}`
 fn block_global_slot_key(block: &PrecomputedBlock) -> Vec<u8> {
     let mut key = to_be_bytes(block.global_slot_since_genesis());
-    key.append(&mut block.state_hash().to_bytes());
+    key.append(&mut block.state_hash().to_bytes().to_vec());
     key
 }
 
@@ -1006,7 +1006,7 @@ fn block_global_slot_key(block: &PrecomputedBlock) -> Vec<u8> {
 fn pk_block_sort_key(pk: PublicKey, sort_value: u32, state_hash: BlockHash) -> Vec<u8> {
     let mut key = pk.to_bytes();
     key.append(&mut to_be_bytes(sort_value));
-    key.append(&mut state_hash.to_bytes());
+    key.append(&mut state_hash.to_bytes().to_vec());
     key
 }
 

--- a/rust/src/store/mod.rs
+++ b/rust/src/store/mod.rs
@@ -398,7 +398,7 @@ fn u64_prefix_key(prefix: u64, suffix: &str) -> Vec<u8> {
 pub fn txn_sort_key(prefix: u32, txn_hash: &str, state_hash: BlockHash) -> Vec<u8> {
     let mut bytes = to_be_bytes(prefix);
     bytes.append(&mut txn_hash.as_bytes().to_vec());
-    bytes.append(&mut state_hash.to_bytes());
+    bytes.append(&mut state_hash.to_bytes().to_vec());
     bytes
 }
 
@@ -421,7 +421,7 @@ pub fn pk_txn_sort_key(
     bytes.append(&mut to_be_bytes(sort));
     bytes.append(&mut to_be_bytes(nonce.0));
     bytes.append(&mut txn_hash.as_bytes().to_vec());
-    bytes.append(&mut state_hash.to_bytes());
+    bytes.append(&mut state_hash.to_bytes().to_vec());
     bytes
 }
 
@@ -462,14 +462,14 @@ pub fn state_hash_pk_txn_sort_key(key: &[u8]) -> BlockHash {
 }
 
 pub fn block_txn_index_key(state_hash: &BlockHash, index: u32) -> Vec<u8> {
-    let mut key = state_hash.clone().to_bytes();
+    let mut key = state_hash.clone().to_bytes().to_vec();
     key.append(&mut to_be_bytes(index));
     key
 }
 
 pub fn txn_block_key(txn_hash: &str, state_hash: BlockHash) -> Vec<u8> {
     let mut bytes = txn_hash.as_bytes().to_vec();
-    bytes.append(&mut state_hash.clone().to_bytes());
+    bytes.append(&mut state_hash.clone().to_bytes().to_vec());
     bytes
 }
 

--- a/rust/src/store/staged_ledger_store_impl.rs
+++ b/rust/src/store/staged_ledger_store_impl.rs
@@ -400,7 +400,7 @@ impl StagedLedgerStore for IndexerStore {
         state_hash: &BlockHash,
         direction: Direction,
     ) -> DBIterator<'_> {
-        let mut start = state_hash.clone().to_bytes();
+        let mut start = state_hash.clone().to_bytes().to_vec();
         let mode = IteratorMode::From(
             match direction {
                 Direction::Forward => start.as_slice(),

--- a/rust/src/store/staking_ledger_store_impl.rs
+++ b/rust/src/store/staking_ledger_store_impl.rs
@@ -601,7 +601,7 @@ fn staking_ledger_epoch_key(
 /// - genesis_hash: [BlockHash::LEN] bytes
 /// - epoch:        4 BE bytes
 fn staking_ledger_epoch_key_prefix(genesis_state_hash: BlockHash, epoch: u32) -> Vec<u8> {
-    let mut key = genesis_state_hash.to_bytes();
+    let mut key = genesis_state_hash.to_bytes().to_vec();
     key.append(&mut to_be_bytes(epoch));
     key
 }

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 20;
+    pub const PATCH: u32 = 21;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
* Makes a step towards better memory utilization. 
* Follow up issue has been created to convert other functions to &[u8] : https://github.com/Granola-Team/mina-indexer/issues/1442

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
