### PR TITLE
`PublicKey::to_bytes() -> [u8; PublicKey:LEN]` instead of `... -> Vec<u8>`

### DIFF
--- a/rust/src/ledger/public_key.rs
+++ b/rust/src/ledger/public_key.rs
@@ -21,8 +21,10 @@ impl PublicKey {
     }
 
     /// Convert to bytes (length [Self::LEN])
-    pub fn to_bytes(self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
+    pub fn to_bytes(self) -> [u8; Self::LEN] {
+        let mut res = [0u8; PublicKey::LEN];
+        res.copy_from_slice(self.0.as_bytes());
+        res
     }
 
     /// Convert from bytes (length [Self::LEN])
@@ -124,12 +126,12 @@ mod test {
             "B62qq66ZuaVGxVvNwR752jPoZfN4uyZWrKkLeBS8FxdG9S76dhscRLy",
         ];
         for pk in pks {
-            let bytes = pk.as_bytes().to_vec();
+            let bytes = pk.as_bytes();
 
             assert_eq!(PublicKey(pk.to_owned()).to_bytes(), bytes, "to_bytes");
             assert_eq!(
                 PublicKey(pk.to_owned()),
-                PublicKey::from_bytes(&bytes)?,
+                PublicKey::from_bytes(bytes)?,
                 "from_bytes"
             );
         }

--- a/rust/src/ledger/store/staged.rs
+++ b/rust/src/ledger/store/staged.rs
@@ -153,7 +153,7 @@ pub fn staged_account_balance_sort_key(
 ) -> Vec<u8> {
     let mut res = state_hash.to_bytes().to_vec();
     res.append(&mut balance.to_be_bytes().to_vec());
-    res.append(&mut pk.to_bytes());
+    res.append(&mut pk.to_bytes().to_vec());
     res
 }
 

--- a/rust/src/store/best_ledger_store_impl.rs
+++ b/rust/src/store/best_ledger_store_impl.rs
@@ -279,7 +279,7 @@ impl BestLedgerStore for IndexerStore {
         )?;
 
         // append new delegation
-        let mut key = pk.clone().to_bytes();
+        let mut key = pk.clone().to_bytes().to_vec();
         key.append(&mut to_be_bytes(num));
         self.database.put_cf(
             self.best_ledger_accounts_delegations_cf(),
@@ -300,7 +300,7 @@ impl BestLedgerStore for IndexerStore {
     }
 
     fn get_pk_delegation(&self, pk: &PublicKey, idx: u32) -> anyhow::Result<Option<PublicKey>> {
-        let mut key = pk.clone().to_bytes();
+        let mut key = pk.clone().to_bytes().to_vec();
         key.append(&mut to_be_bytes(idx));
         Ok(self
             .database
@@ -320,7 +320,7 @@ impl BestLedgerStore for IndexerStore {
             )?;
 
             // drop delegation
-            let mut key = pk.to_bytes();
+            let mut key = pk.to_bytes().to_vec();
             key.append(&mut to_be_bytes(idx - 1));
             self.database
                 .delete_cf(self.best_ledger_accounts_delegations_cf(), key)?;

--- a/rust/src/store/block_store_impl.rs
+++ b/rust/src/store/block_store_impl.rs
@@ -1004,7 +1004,7 @@ fn block_global_slot_key(block: &PrecomputedBlock) -> Vec<u8> {
 
 /// `{pk}{height/slot BE}{state hash}`
 fn pk_block_sort_key(pk: PublicKey, sort_value: u32, state_hash: BlockHash) -> Vec<u8> {
-    let mut key = pk.to_bytes();
+    let mut key = pk.to_bytes().to_vec();
     key.append(&mut to_be_bytes(sort_value));
     key.append(&mut state_hash.to_bytes().to_vec());
     key

--- a/rust/src/store/mod.rs
+++ b/rust/src/store/mod.rs
@@ -417,7 +417,7 @@ pub fn pk_txn_sort_key(
     txn_hash: &str,
     state_hash: BlockHash,
 ) -> Vec<u8> {
-    let mut bytes = pk.to_bytes();
+    let mut bytes = pk.to_bytes().to_vec();
     bytes.append(&mut to_be_bytes(sort));
     bytes.append(&mut to_be_bytes(nonce.0));
     bytes.append(&mut txn_hash.as_bytes().to_vec());
@@ -427,7 +427,7 @@ pub fn pk_txn_sort_key(
 
 /// Prefix `{pk}{u32_sort}`
 pub fn pk_txn_sort_key_prefix(public_key: PublicKey, sort: u32) -> Vec<u8> {
-    let mut bytes = public_key.to_bytes();
+    let mut bytes = public_key.to_bytes().to_vec();
     bytes.append(&mut to_be_bytes(sort));
     bytes
 }

--- a/rust/src/store/staking_ledger_store_impl.rs
+++ b/rust/src/store/staking_ledger_store_impl.rs
@@ -572,7 +572,7 @@ fn staking_ledger_account_key(
 ) -> Vec<u8> {
     let mut key = staking_ledger_epoch_key_prefix(genesis_state_hash, epoch);
     key.append(&mut ledger_hash.0.into_bytes());
-    key.append(&mut pk.to_bytes());
+    key.append(&mut pk.to_bytes().to_vec());
     key
 }
 

--- a/rust/src/store/username_store_impl.rs
+++ b/rust/src/store/username_store_impl.rs
@@ -77,7 +77,7 @@ impl UsernameStore for IndexerStore {
                             .delete_cf(self.username_pk_num_cf(), pk.0.as_bytes())?;
 
                         // remove pk index
-                        let mut key = pk.clone().to_bytes();
+                        let mut key = pk.clone().to_bytes().to_vec();
                         key.append(&mut to_be_bytes(0));
                         self.database.delete_cf(self.username_pk_index_cf(), key)?;
                     }
@@ -88,7 +88,7 @@ impl UsernameStore for IndexerStore {
                     )?;
 
                     // drop last update
-                    let mut key = pk.clone().to_bytes();
+                    let mut key = pk.clone().to_bytes().to_vec();
                     key.append(&mut to_be_bytes(num));
                     self.database.delete_cf(self.username_pk_index_cf(), key)?;
                 } else {
@@ -110,7 +110,7 @@ impl UsernameStore for IndexerStore {
                     )?;
 
                     // add update
-                    let mut key = pk.to_bytes();
+                    let mut key = pk.to_bytes().to_vec();
                     key.append(&mut to_be_bytes(num));
                     self.database.put_cf(
                         self.username_pk_index_cf(),
@@ -125,7 +125,7 @@ impl UsernameStore for IndexerStore {
                     )?;
 
                     // add update
-                    let mut key = pk.to_bytes();
+                    let mut key = pk.to_bytes().to_vec();
                     key.append(&mut to_be_bytes(0));
                     self.database.put_cf(
                         self.username_pk_index_cf(),
@@ -140,7 +140,7 @@ impl UsernameStore for IndexerStore {
 
     fn get_pk_username(&self, pk: &PublicKey, index: u32) -> anyhow::Result<Option<Username>> {
         trace!("Getting pk's {index}th username {pk}");
-        let mut key = pk.clone().to_bytes();
+        let mut key = pk.clone().to_bytes().to_vec();
         key.append(&mut to_be_bytes(index));
         Ok(self
             .database


### PR DESCRIPTION
⚠️ depends on https://github.com/Granola-Team/mina-indexer/pull/1443

## Describe your changes
* A step towards better memory utilization. 
* Other functions need to be updated and they are being tracked in https://github.com/Granola-Team/mina-indexer/issues/1442

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
