### PR TITLE
Refactor `snark_fee_prefix_key` to return `[u8, ...]` instead of `Vec<u8>`

### DIFF
--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 21;
+    pub const PATCH: u32 = 22;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes

## Link issue(s) fixed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have verified new and existing tests pass locally with my changes.
- [ ] I verified whether it was necessary to increment the database version.
