### PR TITLE
Manual compaction every 50000 blocks

### DIFF
--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -412,6 +412,17 @@ impl IndexerState {
                         None,
                     )?;
 
+                    if self.blocks_processed % 50000 == 0 {
+                        let compaction_time = std::time::Instant::now();
+                        indexer_store
+                            .database
+                            .compact_range::<&[u8], &[u8]>(None, None);
+                        info!(
+                            "Compaction time: {}",
+                            pretty_print_duration(compaction_time.elapsed())
+                        );
+                    }
+
                     // compute and store ledger at specified cadence
                     if self.blocks_processed % self.ledger_cadence == 0 {
                         for diff in ledger_diffs.iter() {

--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -47,6 +47,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+const COMPACTION_INTERVAL_IN_BLOCKS: u32 = 50000;
+
 /// Rooted forest of precomputed block summaries aka the witness tree
 /// `root_branch` - represents the tree of blocks connecting back to a known
 /// ledger state, e.g. genesis `dangling_branches` - trees of blocks stemming
@@ -412,7 +414,7 @@ impl IndexerState {
                         None,
                     )?;
 
-                    if self.blocks_processed % 50000 == 0 {
+                    if self.blocks_processed % COMPACTION_INTERVAL_IN_BLOCKS == 0 {
                         let compaction_time = std::time::Instant::now();
                         indexer_store
                             .database

--- a/rust/src/store/mod.rs
+++ b/rust/src/store/mod.rs
@@ -188,7 +188,10 @@ impl IndexerStore {
     /// Creates a new _primary_ indexer store
     pub fn new(path: &Path) -> anyhow::Result<Self> {
         let mut cf_opts = speedb::Options::default();
-        cf_opts.set_max_write_buffer_number(16);
+
+        // Compaction
+        cf_opts.set_disable_auto_compactions(true);
+
         cf_opts.set_compression_type(DBCompressionType::Zstd);
 
         let mut database_opts = speedb::Options::default();

--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 10;
-    pub const PATCH: u32 = 51;
+    pub const PATCH: u32 = 52;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
I have noticed the build pipeline starts by predicting a finishing time that gradually increases until about 80000 blocks, where it stabilizes and becomes more accurate. I wonder if compaction every 50000 blocks might help. 

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [ ] I verified whether it was necessary to increment the database version.
