### PR TITLE
Make canonical discovery algorithm near instantaneous

### DIFF
--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 11;
-    pub const PATCH: u32 = 5;
+    pub const PATCH: u32 = 6;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {


### PR DESCRIPTION
## Describe your changes
* Build a map of previous state hashes using threads to avoid blocking I/O on single thread.
* Benchmark on `40k` blocks yield `0s` discovery vs `19s` on main.
* Given that this is a 10 minute process in tier3, this should yield savings.

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
