### PR TITLE
fix(gql): use Unknown username for top snarkers

### DIFF
--- a/rust/src/web/graphql/top_snarkers.rs
+++ b/rust/src/web/graphql/top_snarkers.rs
@@ -28,7 +28,7 @@ pub struct TopSnarkersQueryRoot;
 
 #[derive(SimpleObject)]
 pub struct TopSnarker {
-    username: Option<String>,
+    username: String,
 
     #[graphql(name = "public_key")]
     public_key: String,
@@ -80,7 +80,11 @@ impl TopSnarkersQueryRoot {
             }
 
             let pk = PublicKey::from_bytes(&key[U32_LEN..][U64_LEN..])?;
-            let username = db.get_username(&pk).ok().flatten().map(|u| u.0);
+            let username = db
+                .get_username(&pk)
+                .ok()
+                .flatten()
+                .map_or("Unknown".to_string(), |u| u.0);
             let total_fees = db
                 .get_snark_prover_epoch_fees(&pk, Some(epoch))?
                 .expect("total fees");

--- a/tests/hurl/top_snarkers.hurl
+++ b/tests/hurl/top_snarkers.hurl
@@ -23,7 +23,7 @@ jsonpath "$.data.topSnarkers" count == 1
 
 # check data
 jsonpath "$.data.topSnarkers[0].public_key" == "B62qrCz3ehCqi8Pn8y3vWC9zYEB9RKsidauv15DeZxhzkxL3bKeba5h"
-jsonpath "$.data.topSnarkers[0].username" == null
+jsonpath "$.data.topSnarkers[0].username" == "Unknown"
 jsonpath "$.data.topSnarkers[0].total_fees" == 0
 jsonpath "$.data.topSnarkers[0].min_fee" == 0
 jsonpath "$.data.topSnarkers[0].max_fee" == 0


### PR DESCRIPTION
## Describe your changes

Returns username `"Unknown"` instead of `null`.

## Link issue(s) fixed

- #1558

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
