### PR TITLE
fix(gql): correct epoch SNARK fees

### DIFF
--- a/rust/src/store/version.rs
+++ b/rust/src/store/version.rs
@@ -25,7 +25,7 @@ pub struct IndexerStoreVersion {
 impl IndexerStoreVersion {
     pub const MAJOR: u32 = 0;
     pub const MINOR: u32 = 12;
-    pub const PATCH: u32 = 1;
+    pub const PATCH: u32 = 2;
 
     /// Output as `MAJOR`.`MINOR`.`PATCH`
     pub fn major_minor_patch(&self) -> String {

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -1534,9 +1534,9 @@ test_hurl() {
     # run in very verbose mode by setting HURL_VERBOSE to anything
     test_file="$SRC"/tests/hurl/"${HURL_TEST:-*}".hurl
     if [[ -z "${HURL_VERBOSE:-}" ]]; then
-        hurl --very-verbose --variable url=http://localhost:"$port"/graphql --test $parallel_flag $test_file
-    else
         hurl --variable url=http://localhost:"$port"/graphql --test $parallel_flag $test_file
+    else
+        hurl --very-verbose --variable url=http://localhost:"$port"/graphql --test $parallel_flag $test_file
     fi
 }
 


### PR DESCRIPTION
## Describe your changes

Corrects the epoch SNARK fee values stored in the db and used by GQL.

## Link issue(s) fixed

- #1565

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
