### PR TITLE
fix(state): dedupe witness tree root block

### DIFF
--- a/rust/src/state/mod.rs
+++ b/rust/src/state/mod.rs
@@ -1082,10 +1082,11 @@ impl IndexerState {
                         .flatten()
                         .for_each(|(key, _)| {
                             if let (Ok(height), Ok(state_hash)) = (block_u32_prefix_from_key(&key), state_hash_suffix(&key)) {
+                                if height <= 1 || state_hash == root_block.state_hash() {
+                                    return;
+                                }
                                 if let Ok(Some((block, _))) = indexer_store.get_block(&state_hash) {
-                                    if height > 1 {
-                                        witness_tree_blocks.push(block);
-                                    }
+                                    witness_tree_blocks.push(block);
                                 } else {
                                     panic!(
                                         "Fatal sync error: block missing from db (length {height}): {state_hash}"

--- a/rust/tests/event/sync.rs
+++ b/rust/tests/event/sync.rs
@@ -49,14 +49,20 @@ async fn test() -> anyhow::Result<()> {
     let best_tip_sync: BlockWithoutHeight = state_sync.best_tip_block().clone().into();
     let canonical_root_sync: BlockWithoutHeight = state_sync.canonical_root_block().clone().into();
 
+    // root & tip match
     assert_eq!(best_tip, best_tip_sync);
     assert_eq!(canonical_root, canonical_root_sync);
 
+    // sync diffs contained in original diffs
     for state_hash in state_sync.diffs_map.keys() {
         assert_eq!(
             state.diffs_map.get(state_hash),
             state_sync.diffs_map.get(state_hash)
         );
     }
+
+    // no dangling branches
+    assert!(state.dangling_branches.is_empty());
+    assert!(state_sync.dangling_branches.is_empty());
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes

Fixes a duplication of the witness tree's root block on sync.

## Link issue(s) fixed

- #1594

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
