### PR TITLE
feat(web)!: return full block in blocks REST endpoint

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use async_graphql::{self, Enum, Object, Result, SimpleObject};
 use log::error;
+use serde::Serialize;
 use speedb::{Direction, IteratorMode};
 use std::{collections::HashSet, sync::Arc};
 
@@ -461,7 +462,7 @@ pub enum BlockSortByInput {
     GlobalSlotDesc,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 pub struct Block {
     /// Value canonical
     pub canonical: bool,
@@ -515,7 +516,22 @@ pub struct Block {
     pub block: BlockWithoutCanonicity,
 }
 
-#[derive(Default, SimpleObject)]
+impl std::fmt::Debug for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl std::fmt::Display for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string_pretty(self) {
+            Ok(s) => write!(f, "{s}"),
+            Err(_) => Err(std::fmt::Error),
+        }
+    }
+}
+
+#[derive(Default, SimpleObject, Serialize)]
 pub struct BlockWithoutCanonicity {
     /// Value state_hash
     state_hash: String,
@@ -560,8 +576,7 @@ pub struct BlockWithoutCanonicity {
     snark_jobs: Vec<SnarkJob>,
 }
 
-#[derive(SimpleObject)]
-
+#[derive(SimpleObject, Serialize)]
 struct SnarkJob {
     /// Value block state hash
     block_state_hash: String,
@@ -579,7 +594,7 @@ struct SnarkJob {
     prover: String,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct Transactions {
     /// Value coinbase
     coinbase: String,
@@ -594,7 +609,7 @@ struct Transactions {
     user_commands: Vec<TransactionWithoutBlock>,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct BlockFeetransfer {
     pub fee: String,
     pub recipient: String,
@@ -603,7 +618,7 @@ struct BlockFeetransfer {
     pub feetransfer_kind: String,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct ConsensusState {
     /// Value total currency
     total_currency: u64,
@@ -642,7 +657,7 @@ struct ConsensusState {
     staking_epoch_data: StakingEpochData,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct StakingEpochData {
     /// Value seed
     seed: String,
@@ -660,7 +675,7 @@ struct StakingEpochData {
     ledger: StakingEpochDataLedger,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct NextEpochData {
     /// Value seed
     seed: String,
@@ -678,7 +693,7 @@ struct NextEpochData {
     ledger: NextEpochDataLedger,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct NextEpochDataLedger {
     /// Value hash
     hash: String,
@@ -687,7 +702,7 @@ struct NextEpochDataLedger {
     total_currency: u64,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct StakingEpochDataLedger {
     /// Value hash
     hash: String,
@@ -696,7 +711,7 @@ struct StakingEpochDataLedger {
     total_currency: u64,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct BlockchainState {
     /// Value utc_date as numeric string
     utc_date: String,
@@ -711,7 +726,7 @@ struct BlockchainState {
     staged_ledger_hash: String,
 }
 
-#[derive(Default, SimpleObject)]
+#[derive(Default, SimpleObject, Serialize)]
 struct ProtocolState {
     /// Value parent state hash
     previous_state_hash: String,

--- a/rust/src/web/graphql/mod.rs
+++ b/rust/src/web/graphql/mod.rs
@@ -22,6 +22,7 @@ use async_graphql::{
     http::GraphiQLSource, Context, EmptyMutation, EmptySubscription, InputValueError,
     InputValueResult, MergedObject, Scalar, ScalarType, Schema, SimpleObject, Value,
 };
+use serde::Serialize;
 use std::sync::Arc;
 
 #[derive(MergedObject, Default)]
@@ -136,7 +137,7 @@ pub(crate) fn get_block(db: &Arc<IndexerStore>, state_hash: &BlockHash) -> Preco
         .0
 }
 
-#[derive(Default, Clone, Debug, PartialEq, SimpleObject)]
+#[derive(Default, Clone, Debug, PartialEq, SimpleObject, Serialize)]
 #[graphql(name = "PublicKey")]
 pub(crate) struct PK {
     pub public_key: String,

--- a/rust/src/web/graphql/transactions/mod.rs
+++ b/rust/src/web/graphql/transactions/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     web::graphql::{gen::TransactionQueryInput, DateTime},
 };
 use async_graphql::{Context, Enum, Object, Result, SimpleObject};
+use serde::Serialize;
 use speedb::{Direction, IteratorMode};
 use std::sync::Arc;
 
@@ -40,7 +41,7 @@ pub enum TransactionSortByInput {
     GlobalSlotDesc,
 }
 
-#[derive(Clone, Debug, SimpleObject)]
+#[derive(Clone, Debug, SimpleObject, Serialize)]
 pub struct TransactionWithoutBlock {
     amount: u64,
     block_height: u32,

--- a/rust/src/web/mod.rs
+++ b/rust/src/web/mod.rs
@@ -37,7 +37,7 @@ pub async fn start_web_server<A: net::ToSocketAddrs>(
             .app_data(Data::new(state.clone()))
             .app_data(Data::new(locked.clone()))
             .service(blocks::get_blocks)
-            .service(blocks::get_block)
+            .service(blocks::get_block_by_state_hash)
             .service(accounts::get_account)
             .service(blockchain::get_blockchain_summary)
             .service(

--- a/rust/src/web/rest/blocks.rs
+++ b/rust/src/web/rest/blocks.rs
@@ -98,7 +98,7 @@ pub async fn get_blocks(
 }
 
 #[get("/blocks/{state_hash}")]
-pub async fn get_block(
+pub async fn get_block_by_state_hash(
     store: Data<Arc<IndexerStore>>,
     state_hash: web::Path<String>,
 ) -> HttpResponse {

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -1100,12 +1100,8 @@ test_rest_blocks() {
     curl --silent http://localhost:${port}/blocks/3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4 > output.json
     assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .state_hash)
 
-    # /blocks/height={height} endpoint
-    curl --silent http://localhost:${port}/blocks/height=100 > output.json
-    assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .[0].state_hash)
-
-    # /blocks/slot={globl_slot} endpoint
-    curl --silent http://localhost:${port}/blocks/slot=145 > output.json
+    # /blocks?height={height} endpoint
+    curl --silent http://localhost:${port}/blocks?height=100 > output.json
     assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .[0].state_hash)
 }
 

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -1094,15 +1094,15 @@ test_rest_blocks() {
 
     # /blocks endpoint
     curl --silent http://localhost:${port}/blocks > output.json
-    assert $(idxr summary --json | jq -r .witness_tree.best_tip_hash) $(cat output.json | jq -r .[0].state_hash)
+    assert $(idxr summary --json | jq -r .witness_tree.best_tip_hash) $(cat output.json | jq -r .[0].block.state_hash)
 
     # /blocks/{state_hash} endpoint
     curl --silent http://localhost:${port}/blocks/3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4 > output.json
-    assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .state_hash)
+    assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .block.state_hash)
 
     # /blocks?height={height} endpoint
     curl --silent http://localhost:${port}/blocks?height=100 > output.json
-    assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .[0].state_hash)
+    assert '3NKLtRnMaWAAfRvdizaeaucDPBePPKGbKw64RVcuRFtMMkE8aAD4' $(cat output.json | jq -r .[0].block.state_hash)
 }
 
 test_best_chain_many_blocks() {


### PR DESCRIPTION
If you step through at the commit level, it will be much easier to follow.

## Describe your changes

Return the full block (see example below)
Make height a query variable
Remove query by slot (unnecessary)

## Link issue(s) fixed

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.

## Example

```json
[
    {
      "canonical": true,
      "epoch_num_blocks": 166,
      "epoch_num_canonical_blocks": 100,
      "epoch_num_supercharged_blocks": 20,
      "total_num_blocks": 166,
      "total_num_canonical_blocks": 100,
      "total_num_supercharged_blocks": 20,
      "block_num_snarks": 0,
      "block_num_user_commands": 3,
      "block_num_internal_commands": 2,
      "epoch_num_slots_produced": 100,
      "num_unique_block_producers_last_n_blocks": null,
      "block": {
        "state_hash": "3NKGnZMYQiKAZDZfAnyHgVPhSrMWRHaR3aHMnAc28oatHJiifVFz",
        "block_height": 95,
        "global_slot_since_genesis": 136,
        "winner_account": {
          "public_key": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC"
        },
        "date_time": "2021-03-17T06:48:00.000Z",
        "received_time": "2021-03-17T06:48:34.898Z",
        "creator_account": {
          "public_key": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC"
        },
        "coinbase_receiver": {
          "public_key": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC"
        },
        "creator": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC",
        "protocol_state": {
          "previous_state_hash": "3NK7n6j2Bx9yCVjv2AKnfxwvwvCL9uww9mQaefkm3zyabdrcczjA",
          "blockchain_state": {
            "utc_date": "1615963680000",
            "date": "1615963680000",
            "snarked_ledger_hash": "jx7buQVWFLsXTtzRgSxbYcT8EYLS8KCZbLrfDcJxMtyy4thw2Ee",
            "staged_ledger_hash": "jx1mMFf433UeHdb6c4pPHcMvyRGsdmzEaYh7p66m49Cz7RJmPXR"
          },
          "consensus_state": {
            "total_currency": 805385692840039233,
            "blockchain_length": 95,
            "block_height": 95,
            "epoch_count": 0,
            "epoch": 0,
            "has_ancestor_in_same_checkpoint_window": true,
            "last_vrf_output": "lR1013dg7Yms68xJLBArsQcYdPbZdE6ldbJBmNd4DgA=",
            "min_window_density": 77,
            "slot": 136,
            "slot_since_genesis": 136,
            "next_epoch_data": {
              "seed": "2vb3d6UdrpXTrLxjxjbwHPZJLpJzQZNBYV2xrZYJRWJs3KaX7LGY",
              "epoch_length": 96,
              "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
              "lock_checkpoint": "3NK7n6j2Bx9yCVjv2AKnfxwvwvCL9uww9mQaefkm3zyabdrcczjA",
              "ledger": {
                "hash": "jx7buQVWFLsXTtzRgSxbYcT8EYLS8KCZbLrfDcJxMtyy4thw2Ee",
                "total_currency": 805385692840039233
              }
            },
            "staking_epoch_data": {
              "seed": "2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA",
              "epoch_length": 96,
              "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
              "lock_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
              "ledger": {
                "hash": "jx7buQVWFLsXTtzRgSxbYcT8EYLS8KCZbLrfDcJxMtyy4thw2Ee",
                "total_currency": 805385692840039233
              }
            }
          }
        },
        "tx_fees": "30000000",
        "snark_fees": "0",
        "transactions": {
          "coinbase": "720000000000",
          "coinbase_receiver_account": {
            "public_key": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC"
          },
          "fee_transfer": [
            {
              "fee": "30000000",
              "recipient": "B62qrafvvcSTkGMpFiprxzDN8JXqoiyHSUQwUsKbRqrvTK1khb1HJyC",
              "feetransfer_kind": "Fee_transfer"
            }
          ],
          "user_commands": [
            {
              "amount": 1000,
              "block_height": 95,
              "global_slot": 136,
              "canonical": true,
              "failure_reason": null,
              "is_applied": true,
              "fee": 10000000,
              "from": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
              "hash": "CkpZzZtaDCDsXCF23bUcytwKxEMM5i9xcKMRTVSUzqjjo2ZM3mqwq",
              "kind": "PAYMENT",
              "memo": "",
              "nonce": 138,
              "receiver": {
                "public_key": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM"
              },
              "to": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
              "token": 1,
              "epoch_num_user_commands": 247,
              "total_num_user_commands": 247
            },
            {
              "amount": 1000,
              "block_height": 95,
              "global_slot": 136,
              "canonical": true,
              "failure_reason": null,
              "is_applied": true,
              "fee": 10000000,
              "from": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
              "hash": "CkpZDke3de25Peph3L7WShQqXF9hfoZ4bwUq1n3SHiWSENF2f539v",
              "kind": "PAYMENT",
              "memo": "",
              "nonce": 139,
              "receiver": {
                "public_key": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM"
              },
              "to": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
              "token": 1,
              "epoch_num_user_commands": 247,
              "total_num_user_commands": 247
            },
            {
              "amount": 1000,
              "block_height": 95,
              "global_slot": 136,
              "canonical": true,
              "failure_reason": null,
              "is_applied": true,
              "fee": 10000000,
              "from": "B62qre3erTHfzQckNuibViWQGyyKwZseztqrjPZBv6SQF384Rg6ESAy",
              "hash": "CkpYTBgcbGKGfpKdVEu8L8xfr646VBtYbiYJLjkHwEvPJKKNWPdTe",
              "kind": "PAYMENT",
              "memo": "",
              "nonce": 140,
              "receiver": {
                "public_key": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM"
              },
              "to": "B62qjYanmV7y9njVeH5UHkz3GYBm7xKir1rAnoY4KsEYUGLMiU45FSM",
              "token": 1,
              "epoch_num_user_commands": 247,
              "total_num_user_commands": 247
            }
          ]
        },
        "snark_jobs": []
      }
    }
]
```