### PR TITLE
fix(signed): use the corrected mina daemon zkapp parser

### DIFF
--- a/rust/src/command/signed/mod.rs
+++ b/rust/src/command/signed/mod.rs
@@ -2,10 +2,7 @@ mod txn_hash;
 
 use crate::{
     command::*,
-    mina_blocks::v2::{
-        self,
-        staged_ledger_diff::{Authorization, ProofOrSignature, UserCommandData},
-    },
+    mina_blocks::v2::{self, staged_ledger_diff::UserCommandData},
     proof_systems::signer::signature::Signature,
     protocol::{
         bin_prot,
@@ -323,20 +320,6 @@ impl SignedCommand {
                 ))
             }
             Self::V2(data) => {
-                // TODO mina daemon has a JSON parsing bug
-                // https://github.com/Granola-Team/mina-indexer/issues/1699
-                if let UserCommandData::ZkappCommandData(zkapp) = data {
-                    if zkapp.account_updates.iter().any(|update| {
-                        matches!(
-                            update.elt.account_update.authorization,
-                            Authorization::Proof_((ProofOrSignature::Proof, _))
-                        )
-                    }) {
-                        return Ok(TxnHash::V2("5J".repeat(26)));
-                    }
-                }
-
-                // no bugs
                 let json: serde_json::Value = data.to_owned().to_mina_json();
 
                 match serde_json::to_string(&json) {


### PR DESCRIPTION
## Describe your changes

- uses the corrected mina daemon zkapp parsing code
- removes stubbed out zkapp command hashes

## Link issue(s) fixed

- #1699
- https://github.com/Granola-Team/mina/commit/f641e5bf06e77186db65292fa747842b4fa43f95

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have verified new and existing tests pass locally with my changes.
- [x] I verified whether it was necessary to increment the database version.
