### PR TITLE
feat(cli): add blocks compare subcommand

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -174,6 +174,21 @@ pub enum Blocks {
         #[arg(long, default_value_t = false)]
         verbose: bool,
     },
+
+    /// Compare two blocks and report the better state hash
+    Compare {
+        /// First state hash to compare
+        #[arg(long)]
+        state_hash: String,
+
+        /// Second state hash to compare
+        #[arg(long)]
+        other_state_hash: String,
+
+        /// Path to write the result [default: stdout]
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug, Encode, Decode)]

--- a/rust/src/unix_socket_server.rs
+++ b/rust/src/unix_socket_server.rs
@@ -470,6 +470,46 @@ pub async fn handle_connection(
                     }
                 }
             }
+            ClientCli::Blocks(Blocks::Compare {
+                state_hash,
+                other_state_hash,
+                path,
+            }) => {
+                debug!("Received block-compare command for {state_hash} and {other_state_hash}");
+                if !StateHash::is_valid(&state_hash) {
+                    invalid_state_hash(&state_hash)
+                } else if !StateHash::is_valid(&other_state_hash) {
+                    invalid_state_hash(&other_state_hash)
+                } else {
+                    let hash: StateHash = state_hash.clone().into();
+                    let other: StateHash = other_state_hash.clone().into();
+                    match db.block_cmp(&hash, &other) {
+                        // `block_cmp` orders blocks so that the better block is `Less`
+                        Ok(Some(ordering)) => {
+                            let better = if ordering == std::cmp::Ordering::Greater {
+                                &other_state_hash
+                            } else {
+                                &state_hash
+                            };
+                            if let Some(path) = path {
+                                debug!("Writing better block {better} to {path:?}");
+                                std::fs::write(&path, better)?;
+                                ServerCliResponse::Success(format!(
+                                    "Better block {better} written to {path:?}"
+                                ))
+                            } else {
+                                ServerCliResponse::Success(better.to_string())
+                            }
+                        }
+                        Ok(None) => ServerCliResponse::Success(format!(
+                            "Block missing from store: one of {state_hash} or {other_state_hash}"
+                        )),
+                        Err(e) => ServerCliResponse::Error(format!(
+                            "Failed to compare blocks '{state_hash}' and '{other_state_hash}': {e}"
+                        )),
+                    }
+                }
+            }
             ClientCli::Chain(Chain::Best {
                 num,
                 verbose,

--- a/tests/regression-test.rb
+++ b/tests/regression-test.rb
@@ -19,6 +19,7 @@ test_names = %w[
   best_tip_v1
   best_tip_v2
   blocks
+  blocks_compare
   block_copy
   missing_blocks
   missing_block_recovery

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -142,6 +142,9 @@ test_indexer_cli_reports() {
 	idxr blocks children --help 2>&1 |
 		grep -iq "Usage: mina-indexer blocks children"
 
+	idxr blocks compare --help 2>&1 |
+		grep -iq "Usage: mina-indexer blocks compare"
+
 	idxr ledgers --help 2>&1 |
 		grep -iq "Usage: mina-indexer ledgers"
 

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -143,7 +143,7 @@ test_indexer_cli_reports() {
 		grep -iq "Usage: mina-indexer blocks children"
 
 	idxr blocks compare --help 2>&1 |
-		grep -iq "Usage: mina-indexer blocks compare"
+		grep -iqF "Usage: mina-indexer blocks compare [OPTIONS] --state-hash <STATE_HASH> --other-state-hash <OTHER_STATE_HASH>"
 
 	idxr ledgers --help 2>&1 |
 		grep -iq "Usage: mina-indexer ledgers"

--- a/tests/regression.bash
+++ b/tests/regression.bash
@@ -461,6 +461,54 @@ test_blocks() {
 	assert 10 $height
 }
 
+# Indexer compares two blocks per consensus ordering
+test_blocks_compare() {
+	stage_blocks v1 10 "$BLOCKS_DIR"
+
+	start_v1
+
+	# Best tip at height 10 (canonical, longest chain in this fixture).
+	tip_hash=$(idxr summary --json | jq -r .witness_tree.best_tip_hash)
+	assert '3NKGgTk7en3347KH81yDra876GPAUSoSePrfVKPmwR1KHfMpvJC5' "$tip_hash"
+
+	# Two competing height-6 blocks: canonical vs orphaned sibling.
+	# (Same heights are exercised in test_block_children.)
+	h6_canonical='3NKqRR2BZFV7Ad5kxtGKNNL59neXohf4ZEC5EMKrrnijB1jy4R5v'
+	h6_orphan='3NKvdydTvLVDJ9PKAXrisjsXoZQvUy1V2sbComWyB2uyhARCJZ5M'
+
+	# Different heights: the longer chain wins, both argument orders.
+	winner=$(idxr blocks compare --state-hash $tip_hash --other-state-hash $h6_canonical)
+	assert "$tip_hash" "$winner"
+	winner=$(idxr blocks compare --state-hash $h6_canonical --other-state-hash $tip_hash)
+	assert "$tip_hash" "$winner"
+
+	# Same height, fork: canonical sibling wins, both argument orders.
+	winner=$(idxr blocks compare --state-hash $h6_canonical --other-state-hash $h6_orphan)
+	assert "$h6_canonical" "$winner"
+	winner=$(idxr blocks compare --state-hash $h6_orphan --other-state-hash $h6_canonical)
+	assert "$h6_canonical" "$winner"
+
+	# Comparing a block with itself returns that block.
+	winner=$(idxr blocks compare --state-hash $tip_hash --other-state-hash $tip_hash)
+	assert "$tip_hash" "$winner"
+
+	# Well-formed hash that is not in the store: reports missing.
+	missing_hash='3NMissingBlock00000000000000000000000000000000000000'
+	out=$(idxr blocks compare --state-hash $tip_hash --other-state-hash $missing_hash)
+	echo "$out" | grep -q "^Block missing from store: "
+
+	# Malformed hash: reports invalid.
+	out=$(idxr blocks compare --state-hash $tip_hash --other-state-hash not-a-state-hash)
+	echo "$out" | grep -q "^Invalid state hash: not-a-state-hash$"
+	out=$(idxr blocks compare --state-hash not-a-state-hash --other-state-hash $tip_hash)
+	echo "$out" | grep -q "^Invalid state hash: not-a-state-hash$"
+
+	# --path writes the winning state hash to the given file.
+	file=./compare_winner.txt
+	idxr blocks compare --state-hash $tip_hash --other-state-hash $h6_canonical --path $file
+	assert "$tip_hash" "$(cat $file)"
+}
+
 # Indexer handles copied blocks correctly
 test_block_copy() {
 	stage_blocks v1 10 "$BLOCKS_DIR"
@@ -1935,6 +1983,7 @@ for test_name in "$@"; do
 	"test_best_tip_v1") test_best_tip_v1 ;;
 	"test_best_tip_v2") test_best_tip_v2 ;;
 	"test_blocks") test_blocks ;;
+	"test_blocks_compare") test_blocks_compare ;;
 	"test_block_copy") test_block_copy ;;
 	"test_missing_blocks") test_missing_blocks ;;
 	"test_missing_block_recovery") test_missing_block_recovery ;;


### PR DESCRIPTION
## Summary

Implements `blocks compare` as requested in #1606.

```
mina-indexer blocks compare --state-hash <A> --other-state-hash <B> [--path <FILE>]
```

It reports the better of two blocks according to consensus ordering (longer chain, then VRF / state-hash tie-break). The handler reuses the existing `BlockStore::block_cmp`, so the consensus rule is not reimplemented here. `--path` writes the winning state hash to a file instead of stdout.

Behaviour:
- both hashes present: prints the better state hash (symmetric under argument order)
- one or both missing from the store: prints `Block missing from store: ...`
- malformed hash: prints `Invalid state hash: ...`

## Verification

Built and tested against a local indexer store built from the repo's own block fixtures (`canonical_chain_discovery`), with two competing height-10 blocks ingested:

- same-height fork: returns the better block, and the result is identical when the two arguments are swapped
- different heights: the longer-chain block wins, in both argument orders
- missing-from-store and invalid-hash paths produce the messages above
- `--path` writes the winning hash to the given file

A `blocks compare --help` assertion was added to `tests/regression.bash` alongside the other subcommand help checks. `cargo clippy` is clean.

Closes #1606