### PR TITLE
perf(store): cache block sort keys instead of re-reading per compare

### DIFF
--- a/rust/src/store/block_store_impl.rs
+++ b/rust/src/store/block_store_impl.rs
@@ -625,7 +625,7 @@ impl BlockStore for IndexerStore {
                 Some(bytes) => blocks.push(StateHash::from_bytes(&bytes)?),
             }
         }
-        blocks.sort_by(|a, b| block_cmp(self, a, b));
+        blocks.sort_by_cached_key(|sh| block_sort_key(self, sh));
         Ok(blocks)
     }
 
@@ -676,7 +676,7 @@ impl BlockStore for IndexerStore {
             }
         }
 
-        blocks.sort_by(|a, b| block_cmp(self, a, b));
+        blocks.sort_by_cached_key(|sh| block_sort_key(self, sh));
         Ok(blocks)
     }
 
@@ -727,7 +727,7 @@ impl BlockStore for IndexerStore {
             }
         }
 
-        blocks.sort_by(|a, b| block_cmp(self, a, b));
+        blocks.sort_by_cached_key(|sh| block_sort_key(self, sh));
         Ok(blocks)
     }
 
@@ -741,7 +741,7 @@ impl BlockStore for IndexerStore {
                     self.get_block_parent_hash(b).ok().flatten() == Some(state_hash.clone())
                 })
                 .collect();
-            children.sort_by(|a, b| block_cmp(self, a, b));
+            children.sort_by_cached_key(|sh| block_sort_key(self, sh));
             return Ok(children);
         }
         bail!("Block missing from store {state_hash}")
@@ -1925,19 +1925,17 @@ fn is_genesis_hash(hash: &StateHash) -> bool {
     hash.0 == MAINNET_GENESIS_HASH || hash.0 == HARDFORK_GENESIS_HASH
 }
 
-fn block_cmp(db: &IndexerStore, a: &StateHash, b: &StateHash) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
+// Canonical blocks sort before non-canonical ones; otherwise BlockComparison
+// orders by (length, vrf, state hash) per consensus.
+type BlockSortKey = (std::cmp::Reverse<bool>, BlockComparison);
 
-    let a_canonicity = db.get_block_canonicity(a).ok().flatten();
-    let b_canonicity = db.get_block_canonicity(b).ok().flatten();
-    let a_cmp = db.get_block_comparison(a).unwrap().unwrap();
-    let b_cmp = db.get_block_comparison(b).unwrap().unwrap();
-
-    match (a_canonicity, b_canonicity) {
-        (Some(Canonicity::Canonical), _) => Ordering::Less,
-        (_, Some(Canonicity::Canonical)) => Ordering::Greater,
-        _ => a_cmp.cmp(&b_cmp),
-    }
+fn block_sort_key(db: &IndexerStore, state_hash: &StateHash) -> BlockSortKey {
+    let is_canonical = matches!(
+        db.get_block_canonicity(state_hash).ok().flatten(),
+        Some(Canonicity::Canonical)
+    );
+    let comparison = db.get_block_comparison(state_hash).unwrap().unwrap();
+    (std::cmp::Reverse(is_canonical), comparison)
 }
 
 fn display_mode(mode: IteratorMode) -> String {


### PR DESCRIPTION
## Summary

The four `sort_by` sites in `BlockStore` ([`get_blocks_at_height`](https://github.com/Granola-Team/mina-indexer/blob/main/rust/src/store/block_store_impl.rs#L628), [`get_blocks_at_slot`](https://github.com/Granola-Team/mina-indexer/blob/main/rust/src/store/block_store_impl.rs#L679), [`get_blocks_at_public_key`](https://github.com/Granola-Team/mina-indexer/blob/main/rust/src/store/block_store_impl.rs#L730), [`get_block_children`](https://github.com/Granola-Team/mina-indexer/blob/main/rust/src/store/block_store_impl.rs#L744)) use a comparator that reads each block's canonicity and `BlockComparison` from RocksDB on every pairwise comparison: 6 column-family reads and 2 `serde_json::from_slice` calls per cmp, evaluated O(N log N) times.

Replace the free `block_cmp` function with `block_sort_key`, returning a `(Reverse<bool>, BlockComparison)` key, and switch the four call sites to `sort_by_cached_key`. DB reads and deserializations drop from O(N log N) to O(N) per sort; key comparisons are then in-memory.

## Result

Microbenchmark on a real mainnet 7-block fork (`tests/data/sequential_blocks`, height 105496), 10 000 iterations per run, three runs each:

| Build | Mean per call |
|---|---|
| Before (`sort_by` + `block_cmp`) | **29.15 µs** |
| After (`sort_by_cached_key` + `block_sort_key`) | **6.30 µs** |

**4.6x faster.** Variance under 5% across runs. The win scales: at fork width N, comparator-side DB work goes from `6 N log N` reads / `2 N log N` deserializes to `6 N` / `2 N`.

## Behavioural note

The previous comparator's `(Some(Canonical), Some(Canonical))` arm returned `Ordering::Less` regardless of argument order. That is an invariant-violating state (at most one canonical block per height) but technically not a total order. The new key gives a well-defined deterministic ordering in that case.

## Test plan

- [x] `cargo check --release` clean
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings` clean
- [x] 226 unit tests pass (`cargo test --release --lib`)
- [x] 107 integration tests pass (`cargo test --release --test mod`), including all 8 canonicity tests and all 7 block-store tests, which exercise the affected sort