### PR TITLE
perf(web): read epoch-invariant counts once per query, not once per row

### DIFF
--- a/rust/src/web/graphql/blocks/mod.rs
+++ b/rust/src/web/graphql/blocks/mod.rs
@@ -48,11 +48,10 @@ impl BlocksQueryRoot {
             .as_ref()
             .and_then(|q| q.genesis_state_hash.clone())
             .map(Into::into);
+        let counts = get_counts(db, epoch, genesis_state_hash.as_ref())?;
 
         // no query filters => get the best block
         if query.is_none() {
-            let counts = get_counts(db, epoch, genesis_state_hash.as_ref())?;
-
             return Ok(db
                 .get_best_block()
                 .map(|b| b.map(|pcb| Block::from_precomputed(db, &pcb, counts)))?);
@@ -75,11 +74,7 @@ impl BlocksQueryRoot {
                 Some((pcb, _)) => pcb,
                 None => return Ok(None),
             };
-            let block = Block::from_precomputed(
-                db,
-                &pcb,
-                get_counts(db, epoch, genesis_state_hash.as_ref())?,
-            );
+            let block = Block::from_precomputed(db, &pcb, counts);
 
             if query.unwrap().matches(&block) {
                 return Ok(Some(block));
@@ -95,11 +90,7 @@ impl BlocksQueryRoot {
         {
             let state_hash = state_hash_suffix(&key)?;
             let pcb = get_block(db, &state_hash);
-            let block = Block::from_precomputed(
-                db,
-                &pcb,
-                get_counts(db, epoch, genesis_state_hash.as_ref())?,
-            );
+            let block = Block::from_precomputed(db, &pcb, counts);
 
             if query.as_ref().is_none_or(|q| q.matches(&block)) {
                 return Ok(Some(block));

--- a/rust/src/web/graphql/snarks/mod.rs
+++ b/rust/src/web/graphql/snarks/mod.rs
@@ -126,6 +126,9 @@ impl SnarkQueryRoot {
         let mut snarks = <Vec<SnarkWithCanonicity>>::new();
         let sort_by = sort_by.unwrap_or(SnarkSortByInput::BlockHeightDesc);
 
+        let epoch_num_snarks = db.get_snarks_epoch_count(None, None)?;
+        let total_num_snarks = db.get_snarks_total_count()?;
+
         // state hash
         if let Some(state_hash) = query
             .as_ref()
@@ -153,6 +156,8 @@ impl SnarkQueryRoot {
                                 prover: snark.prover,
                                 state_hash: state_hash.clone(),
                             },
+                            epoch_num_snarks,
+                            total_num_snarks,
                         )
                         .ok()
                         .flatten()
@@ -178,7 +183,17 @@ impl SnarkQueryRoot {
                     let block = get_block(db, state_hash);
                     SnarkWorkSummaryWithStateHash::from_precomputed(&block)
                         .into_iter()
-                        .filter_map(|s| snark_summary_matches_query(db, &query, s).ok().flatten())
+                        .filter_map(|s| {
+                            snark_summary_matches_query(
+                                db,
+                                &query,
+                                s,
+                                epoch_num_snarks,
+                                total_num_snarks,
+                            )
+                            .ok()
+                            .flatten()
+                        })
                         .collect::<Vec<SnarkWithCanonicity>>()
                 })
                 .collect();
@@ -237,9 +252,8 @@ impl SnarkQueryRoot {
                             snark: Snark::new(
                                 db,
                                 SnarkWorkSummaryWithStateHash::from(snark, state_hash),
-                                db.get_snarks_epoch_count(None, None)
-                                    .expect("epoch snarks count"),
-                                db.get_snarks_total_count().expect("total snarks count"),
+                                epoch_num_snarks,
+                                total_num_snarks,
                             ),
                         };
 
@@ -308,9 +322,8 @@ impl SnarkQueryRoot {
                             snark: Snark::new(
                                 db,
                                 SnarkWorkSummaryWithStateHash::from(snark, state_hash),
-                                db.get_snarks_epoch_count(None, None)
-                                    .expect("epoch snarks count"),
-                                db.get_snarks_total_count().expect("total snarks count"),
+                                epoch_num_snarks,
+                                total_num_snarks,
                             ),
                         };
 
@@ -390,9 +403,8 @@ impl SnarkQueryRoot {
                                 snark: Snark::new(
                                     db,
                                     SnarkWorkSummaryWithStateHash::from(snark, state_hash.clone()),
-                                    db.get_snarks_epoch_count(None, None)
-                                        .expect("epoch snarks count"),
-                                    db.get_snarks_total_count().expect("total snarks count"),
+                                    epoch_num_snarks,
+                                    total_num_snarks,
                                 ),
                             })
                             .collect()
@@ -440,9 +452,8 @@ impl SnarkQueryRoot {
                         snark: Snark::new(
                             db,
                             SnarkWorkSummaryWithStateHash::from(snark, state_hash.clone()),
-                            db.get_snarks_epoch_count(None, None)
-                                .expect("epoch snarks count"),
-                            db.get_snarks_total_count().expect("total snarks count"),
+                            epoch_num_snarks,
+                            total_num_snarks,
                         ),
                     })
                     .collect()
@@ -467,18 +478,14 @@ fn snark_summary_matches_query(
     db: &Arc<IndexerStore>,
     query: &Option<SnarkQueryInput>,
     snark: SnarkWorkSummaryWithStateHash,
+    epoch_num_snarks: u32,
+    total_num_snarks: u32,
 ) -> anyhow::Result<Option<SnarkWithCanonicity>> {
     let canonical = get_block_canonicity(db, &snark.state_hash);
     let snark_with_canonicity = SnarkWithCanonicity {
         pcb: get_block(db, &snark.state_hash),
         canonical,
-        snark: Snark::new(
-            db,
-            snark,
-            db.get_snarks_epoch_count(None, None)
-                .expect("epoch snarks count"),
-            db.get_snarks_total_count().expect("total snarks count"),
-        ),
+        snark: Snark::new(db, snark, epoch_num_snarks, total_num_snarks),
     };
 
     if query

--- a/rust/src/web/graphql/stakes/mod.rs
+++ b/rust/src/web/graphql/stakes/mod.rs
@@ -324,6 +324,7 @@ impl StakesQueryRoot {
             }
         };
         let total_currency = db.get_total_currency(&ledger_hash)?.unwrap_or_default();
+        let epoch_counts = StakesEpochCounts::new(db, epoch, &ledger_hash)?;
 
         use StakesSortByInput::*;
         let mut accounts = Vec::with_capacity(limit);
@@ -358,6 +359,7 @@ impl StakesQueryRoot {
                             epoch,
                             ledger_hash.to_owned(),
                             total_currency,
+                            &epoch_counts,
                         );
 
                         if StakesQueryInput::matches(query.as_ref(), &account) {
@@ -427,6 +429,7 @@ impl StakesQueryRoot {
                     epoch,
                     ledger_hash.to_owned(),
                     total_currency,
+                    &epoch_counts,
                 );
 
                 if StakesQueryInput::matches(query.as_ref(), &account) {
@@ -588,6 +591,52 @@ impl StakesQueryInput {
     }
 }
 
+/// Counts shared by every account in a single `stakes` response.
+/// Read from the store once per query instead of once per account.
+pub struct StakesEpochCounts {
+    epoch_num_blocks: u32,
+    epoch_num_supercharged_blocks: u32,
+    total_num_blocks: u32,
+    total_num_supercharged_blocks: u32,
+    epoch_num_snarks: u32,
+    total_num_snarks: u32,
+    epoch_num_user_commands: u32,
+    total_num_user_commands: u32,
+    epoch_num_internal_commands: u32,
+    total_num_internal_commands: u32,
+    num_accounts: u32,
+}
+
+impl StakesEpochCounts {
+    pub fn new(
+        db: &Arc<IndexerStore>,
+        epoch: u32,
+        ledger_hash: &LedgerHash,
+    ) -> anyhow::Result<Self> {
+        let genesis_state_hash = StakingLedger::genesis_state_hash(ledger_hash);
+
+        Ok(Self {
+            epoch_num_blocks: db
+                .get_block_production_epoch_count(Some(epoch), Some(&genesis_state_hash))?,
+            epoch_num_supercharged_blocks: db.get_block_production_supercharged_epoch_count(
+                Some(epoch),
+                Some(&genesis_state_hash),
+            )?,
+            total_num_blocks: db.get_block_production_total_count()?,
+            total_num_supercharged_blocks: db.get_block_production_supercharged_total_count()?,
+            epoch_num_snarks: db.get_snarks_epoch_count(Some(epoch), Some(&genesis_state_hash))?,
+            total_num_snarks: db.get_snarks_total_count()?,
+            epoch_num_user_commands: db
+                .get_user_commands_epoch_count(Some(epoch), Some(&genesis_state_hash))?,
+            total_num_user_commands: db.get_user_commands_total_count()?,
+            epoch_num_internal_commands: db
+                .get_internal_commands_epoch_count(Some(epoch), Some(&genesis_state_hash))?,
+            total_num_internal_commands: db.get_internal_commands_total_count()?,
+            num_accounts: db.get_staking_ledger_accounts_count_epoch(epoch, &genesis_state_hash)?,
+        })
+    }
+}
+
 impl StakesLedgerAccountWithMeta {
     pub fn new(
         db: &Arc<IndexerStore>,
@@ -596,6 +645,7 @@ impl StakesLedgerAccountWithMeta {
         epoch: u32,
         ledger_hash: LedgerHash,
         total_currency: u64,
+        epoch_counts: &StakesEpochCounts,
     ) -> Self {
         let pk = &account.pk;
         let total_delegated_nanomina = delegations.as_ref().map_or(0, |d| d.total_delegated);
@@ -649,10 +699,7 @@ impl StakesLedgerAccountWithMeta {
             .get_internal_commands_pk_total_count(pk)
             .expect("pk total num internal commands");
 
-        let genesis_state_hash = StakingLedger::genesis_state_hash(&ledger_hash);
-        let num_accounts = db
-            .get_staking_ledger_accounts_count_epoch(epoch, &genesis_state_hash)
-            .expect("epoch staking account count");
+        let num_accounts = epoch_counts.num_accounts;
 
         Self {
             epoch,
@@ -683,37 +730,16 @@ impl StakesLedgerAccountWithMeta {
                 delegate_pks: delegates.into_iter().map(|pk| PK::new(db, pk)).collect(),
             },
             timing,
-            epoch_num_blocks: db
-                .get_block_production_epoch_count(Some(epoch), Some(&genesis_state_hash))
-                .expect("epoch block count"),
-            epoch_num_supercharged_blocks: db
-                .get_block_production_supercharged_epoch_count(
-                    Some(epoch),
-                    Some(&genesis_state_hash),
-                )
-                .expect("epoch supercharged block count"),
-            total_num_blocks: db
-                .get_block_production_total_count()
-                .expect("total block count"),
-            total_num_supercharged_blocks: db
-                .get_block_production_supercharged_total_count()
-                .expect("total supercharged block count"),
-            epoch_num_snarks: db
-                .get_snarks_epoch_count(Some(epoch), Some(&genesis_state_hash))
-                .expect("epoch snark count"),
-            total_num_snarks: db.get_snarks_total_count().expect("total snark count"),
-            epoch_num_user_commands: db
-                .get_user_commands_epoch_count(Some(epoch), Some(&genesis_state_hash))
-                .expect("epoch user command count"),
-            total_num_user_commands: db
-                .get_user_commands_total_count()
-                .expect("total user command count"),
-            epoch_num_internal_commands: db
-                .get_internal_commands_epoch_count(Some(epoch), Some(&genesis_state_hash))
-                .expect("epoch internal command count"),
-            total_num_internal_commands: db
-                .get_internal_commands_total_count()
-                .expect("total internal command count"),
+            epoch_num_blocks: epoch_counts.epoch_num_blocks,
+            epoch_num_supercharged_blocks: epoch_counts.epoch_num_supercharged_blocks,
+            total_num_blocks: epoch_counts.total_num_blocks,
+            total_num_supercharged_blocks: epoch_counts.total_num_supercharged_blocks,
+            epoch_num_snarks: epoch_counts.epoch_num_snarks,
+            total_num_snarks: epoch_counts.total_num_snarks,
+            epoch_num_user_commands: epoch_counts.epoch_num_user_commands,
+            total_num_user_commands: epoch_counts.total_num_user_commands,
+            epoch_num_internal_commands: epoch_counts.epoch_num_internal_commands,
+            total_num_internal_commands: epoch_counts.total_num_internal_commands,
             epoch_num_accounts: num_accounts,
             num_accounts,
             epoch_total_currency: total_currency,
@@ -723,7 +749,9 @@ impl StakesLedgerAccountWithMeta {
 
 #[cfg(test)]
 mod tests {
-    use super::{StakesDelegationTotals, StakesLedgerAccountWithMeta, StakesQueryInput};
+    use super::{
+        StakesDelegationTotals, StakesEpochCounts, StakesLedgerAccountWithMeta, StakesQueryInput,
+    };
     use crate::{
         base::{public_key::PublicKey, state_hash::StateHash, username::Username},
         chain::Network,
@@ -846,6 +874,7 @@ mod tests {
         let query = || {
             let mut accounts = vec![];
             let username_pks = store.get_username_pks(&username.0)?.unwrap_or_default();
+            let epoch_counts = StakesEpochCounts::new(&store, epoch, &ledger_hash)?;
 
             for pk in username_pks {
                 if let Some(account) = store.get_staking_account(&pk, epoch, &genesis_state_hash)? {
@@ -856,6 +885,7 @@ mod tests {
                         epoch,
                         ledger_hash.to_owned(),
                         total_currency,
+                        &epoch_counts,
                     );
 
                     accounts.push(account);

--- a/rust/src/web/rest/blocks.rs
+++ b/rust/src/web/rest/blocks.rs
@@ -61,23 +61,16 @@ pub async fn get_blocks(
 
     if let Ok(Some(best_tip)) = db.get_best_block() {
         let mut best_chain: Vec<Block> = Vec::with_capacity(limit as usize);
+        let counts = get_counts(db, None, None).expect("counts");
 
         // Process best tip
-        best_chain.push(Block::from_precomputed(
-            db,
-            &best_tip,
-            get_counts(db, None, None).expect("counts"),
-        ));
+        best_chain.push(Block::from_precomputed(db, &best_tip, counts));
 
         let mut parent_state_hash = best_tip.previous_state_hash();
 
         while best_chain.len() < limit as usize {
             if let Ok(Some((block, _))) = db.get_block(&parent_state_hash) {
-                best_chain.push(Block::from_precomputed(
-                    db,
-                    &block,
-                    get_counts(db, None, None).expect("counts"),
-                ));
+                best_chain.push(Block::from_precomputed(db, &block, counts));
                 parent_state_hash = block.previous_state_hash();
             } else {
                 // No parent


### PR DESCRIPTION
Four web handlers re-read epoch-invariant aggregate counts from RocksDB for every row they build. This PR hoists each to one read set per request. No query output changes; verification below includes a byte-identical A/B against main.

## The four sites

1. `web/graphql/blocks/mod.rs`: the singular `block` resolver called `get_counts` (15 column-family reads) per iterated block in its height-scan loop, and once more in each of its other two branches. A filtered lookup that walks N blocks before matching costs 15N reads. The plural `blocks` resolver already hoists the same call to one read set per query; this PR makes `block` match it.
2. `web/graphql/snarks/mod.rs`: `get_snarks_epoch_count` and `get_snarks_total_count` were read per SNARK row at four inline sites plus inside `snark_summary_matches_query`, which is called per row from two further branches. That is 2 reads per row considered, 200 per default-limit page. Now read once at resolver top, matching the `transactions` and `internal_commands` resolvers, and threaded through `snark_summary_matches_query` as parameters.
3. `web/graphql/stakes/mod.rs`: `StakesLedgerAccountWithMeta::new` performed 11 epoch-invariant reads per account row, on top of its legitimate per-pk reads: 1,100 reads per default 100-row page. This PR introduces `StakesEpochCounts`, built once per query and passed by reference. It derives its genesis state hash from the ledger hash exactly as the per-row code did, so queries that supply `ledgerHash` directly are unaffected.
4. `web/rest/blocks.rs`: the best-chain loop called `get_counts` once for the tip plus once per iteration up to `limit`. The height branch of the same handler already hoists it; the best-chain branch now does too.

These are all the per-row invariant count reads in the query-resolver loop bodies and row constructors under `web/`. The per-object field resolver in `internal_commands.rs` (10 invariant reads per row when `blockStateHash` is selected) is a different shape, needs request-scoped caching rather than a loop hoist, and is left for a follow-up.

## Numbers

Read counts per request drop from O(rows x reads) to O(reads): stakes 1,100 to 11, snarks 200 to 2, `block` 15N to 15.

Measured on a real mainnet staking ledger (`jxsAidvKvEQJMC7Z2wkLrFGzCqUxpFMRhAj4K5o49eiFLhKSyXL`, 226,659 accounts) ingested into a fresh store, release build, best of 3 runs of 10k iterations: the stakes 11-read bundle costs 2.692 us per row, so a 100-row page spends 269.2 us against 2.7 us in count reads; the snarks 2-read bundle costs 0.465 us per row (46.5 us against 0.5 us per page); `get_counts` costs 4.045 us per iterated block. Figures are lower bounds: the bench store is small and cache-hot, and the snarks/blocks bundles were measured with explicit epoch arguments, while the production call sites pass `(None, None)` and pay additional epoch-resolution reads per call. The harness is a standalone example binary; happy to paste it if useful.

A response now also reports one consistent count snapshot across all of its rows. Previously rows could disagree with each other if blocks were ingested mid-query.

## Behaviour notes

Count reads now happen once up front, so requests that error or return empty pay them once where some paths previously skipped them. The plural `blocks` resolver on main already behaves this way (it reads counts before validating the state hash). In snarks, a failing count read now surfaces as a GraphQL error instead of a per-row panic, matching the `transactions` resolver. The stakes `limit: 0` ledger-hash short-circuit and the ledger-not-found early return both fire before the hoisted reads, so those paths are unchanged.

## Testing

- `cargo test --lib` (226 passed) and `cargo test --tests` (107 passed), including `stakes::tests::query_username`, which exercises the changed `StakesLedgerAccountWithMeta::new` signature. Clippy and rustfmt clean.
- Output-equivalence A/B: built main (63162026) and this branch, created one database from the in-repo staking ledger fixtures plus the genesis block, ran both servers against copies of it, and fired 8 query shapes covering the changed branches: stakes via epoch, via explicit `ledgerHash` (the genesis-derivation path), both sort directions, `limit: 0` short-circuit, the `block` resolver, `snarks`, and REST `/blocks`. Every response was byte-identical between main and branch, including all count fields.
- The bash regression suites that stage blocks were not run here: the read credentials embedded in `ops/granola-rclone.rb` return 403 for me, and the o1labs GCS bucket no longer serves mainnet precomputed blocks, so I could not stage block fixtures locally. The hurl suites cover `blocks`, `snarks`, and `stakes` end-to-end in CI.
